### PR TITLE
Y-Py Test Workflow

### DIFF
--- a/.github/workflows/y-py.yml
+++ b/.github/workflows/y-py.yml
@@ -1,8 +1,6 @@
 name: Y-Py
 
 on:
-  workflow_dispatch:
-  
   push:
     branches: [ main ]
     paths:
@@ -34,11 +32,9 @@ jobs:
             profile: minimal
             default: true
       - name: Build Package
-        uses: messense/maturin-action@v1
-        with:
-          maturin-version: latest
-          command: build
-          args: --release --out dist -m y-py/Cargo.toml
+        run: |
+          pip install maturin
+          maturin build --release --out dist
       - name: Install Dependencies
         run: |
           pip install pytest

--- a/.github/workflows/y-py.yml
+++ b/.github/workflows/y-py.yml
@@ -1,36 +1,47 @@
-name: Rust
+name: Y-Py
 
 on:
+  workflow_dispatch:
+  
   push:
     branches: [ main ]
+    paths:
+      - 'y-py/**'
   pull_request:
     branches: [ main ]
-
+    paths:
+      - 'y-py/**'
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   test:
-
+    defaults:
+      run:
+        working-directory: y-py
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Install Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
       - name: Install Rust Nightly
         uses: actions-rs/toolchain@v1
         with:
             toolchain: nightly
-            override: true
-            components: rustfmt, clippy
-      
-      - name: Install Python Dependencies
-        run: pip install maturin pytest
-      - name: Build Y-Py
-        run: maturin develop
-        working-directory: y-py
+            profile: minimal
+            default: true
+      - name: Build Package
+        uses: messense/maturin-action@v1
+        with:
+          maturin-version: latest
+          command: build
+          args: --release --out dist -m y-py/Cargo.toml
+      - name: Install Dependencies
+        run: |
+          pip install pytest
+          pip install y-py --no-index --find-links dist --force-reinstall
       - name: Run Tests
         run: pytest
-        working-directory: y-py

--- a/.github/workflows/y-py.yml
+++ b/.github/workflows/y-py.yml
@@ -1,0 +1,36 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Install Python
+        uses: actions/setup-python@v1
+      - name: Install Rust Nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+            components: rustfmt, clippy
+      
+      - name: Install Python Dependencies
+        run: pip install maturin pytest
+      - name: Build Y-Py
+        run: maturin develop
+        working-directory: y-py
+      - name: Run Tests
+        run: pytest
+        working-directory: y-py


### PR DESCRIPTION
Y-Py GitHub Action for testing library code on PR and merge. Only runs on edits to in the `y-py` directory. The action installs Rust, Python along with the `maturin` and `pytest` dependencies. Then It builds a Python wheel for Y-Py, installs the wheel into the active Python instance and runs tests via `pytest`.

I tested all of the steps locally using [`act`](https://github.com/nektos/act) except for the Maturin build system, since the extension is using my local file path instead of the Docker-relative file path. If anyone knows how to test the action without merging, I would appreciate the assistance.