### PR TITLE
Serde Integration for lib0::Any

### DIFF
--- a/lib0/Cargo.toml
+++ b/lib0/Cargo.toml
@@ -9,11 +9,13 @@ description = "Efficient binary encoding library for Yrs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
 criterion = "^0.3"
 proptest = "^1.0.0"
 proptest-derive = "0.3.0"
+serde_json = "1.0"
 
 [[bench]]
 name = "lib0_benchmarks"

--- a/lib0/benches/lib0_benchmarks.rs
+++ b/lib0/benches/lib0_benchmarks.rs
@@ -1,14 +1,14 @@
-use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingMode};
 use lib0::decoding::{Cursor, Read};
 use lib0::encoding::Write;
 
 const BENCHMARK_SIZE: u32 = 100000;
 
-fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("encoding");
-    group.sampling_mode(SamplingMode::Flat);
+fn bench_encoding(c: &mut Criterion) {
+    let mut encoding_group = c.benchmark_group("encoding");
+    encoding_group.sampling_mode(SamplingMode::Flat);
 
-    group.bench_function("var_int (64 bit)", |b| {
+    encoding_group.bench_function("var_int (64 bit)", |b| {
         b.iter(|| {
             let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..(BENCHMARK_SIZE as i64) {
@@ -22,7 +22,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("var_uint (32 bit)", |b| {
+    encoding_group.bench_function("var_uint (32 bit)", |b| {
         b.iter(|| {
             let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..BENCHMARK_SIZE {
@@ -36,7 +36,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("uint32", |b| {
+    encoding_group.bench_function("uint32", |b| {
         b.iter(|| {
             let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..BENCHMARK_SIZE {
@@ -50,7 +50,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("var_uint (64 bit)", |b| {
+    encoding_group.bench_function("var_uint (64 bit)", |b| {
         b.iter(|| {
             let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..(BENCHMARK_SIZE as u64) {
@@ -64,7 +64,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         })
     });
 
-    group.bench_function("uint64", |b| {
+    encoding_group.bench_function("uint64", |b| {
         b.iter(|| {
             let mut encoder = Vec::with_capacity(BENCHMARK_SIZE as usize * 8);
             for i in 0..(BENCHMARK_SIZE as u64) {
@@ -77,9 +77,108 @@ fn criterion_benchmark(c: &mut Criterion) {
             }
         })
     });
-
-    group.finish();
 }
 
-criterion_group!(benches, criterion_benchmark);
+#[cfg(feature = "serde")]
+fn bench_serialization(c: &mut Criterion) {
+    use lib0::any::Any;
+    use std::collections::HashMap;
+
+    let any = Any::Map(Box::new(HashMap::from([
+        ("bool".into(), Any::Bool(true)),
+        ("int".into(), Any::BigInt(1)),
+        ("negativeInt".into(), Any::BigInt(-1)),
+        ("maxInt".into(), Any::BigInt(i64::MAX)),
+        ("minInt".into(), Any::BigInt(i64::MIN)),
+        ("realNumber".into(), Any::Number(-123.2387f64)),
+        ("maxNumber".into(), Any::Number(f64::MIN)),
+        ("minNumber".into(), Any::Number(f64::MAX)),
+        ("null".into(), Any::Null),
+        (
+            "map".into(),
+            Any::Map(Box::new(HashMap::from([
+                ("bool".into(), Any::Bool(true)),
+                ("int".into(), Any::BigInt(1)),
+                ("negativeInt".into(), Any::BigInt(-1)),
+                ("maxInt".into(), Any::BigInt(i64::MAX)),
+                ("minInt".into(), Any::BigInt(i64::MIN)),
+                ("realNumber".into(), Any::Number(-123.2387f64)),
+                ("maxNumber".into(), Any::Number(f64::MIN)),
+                ("minNumber".into(), Any::Number(f64::MAX)),
+                ("null".into(), Any::Null),
+            ]))),
+        ),
+        (
+            "key6".into(),
+            Any::Array(
+                vec![
+                    Any::Bool(true),
+                    Any::BigInt(1),
+                    Any::BigInt(-1),
+                    Any::BigInt(i64::MAX),
+                    Any::BigInt(i64::MIN),
+                    Any::Number(-123.2387f64),
+                    Any::Number(f64::MIN),
+                    Any::Number(f64::MAX),
+                    Any::Null,
+                ]
+                .into_boxed_slice(),
+            ),
+        ),
+    ])));
+
+    let any_json = serde_json::to_string(&any).unwrap();
+
+    let mut serde_group = c.benchmark_group("serde");
+    serde_group.bench_function("Any-JSON roundtrip", |b| {
+        b.iter(|| {
+            black_box(serde_json::from_str::<Any>(&serde_json::to_string(&any).unwrap()).unwrap());
+        })
+    });
+
+    serde_group.bench_function("Any serialize", |b| {
+        b.iter(|| {
+            black_box(serde_json::to_string(&any).unwrap());
+        })
+    });
+
+    serde_group.bench_function("Any deserialize", |b| {
+        b.iter(|| {
+            black_box(serde_json::to_string(&any).unwrap());
+        })
+    });
+
+    serde_group.finish();
+
+    let mut custom_group = c.benchmark_group("custom json serialization");
+
+    custom_group.bench_function("Any-JSON roundtrip", |b| {
+        b.iter(|| {
+            let mut roundtrip = String::new();
+            any.to_json(&mut roundtrip);
+
+            black_box(Any::from_json(&roundtrip));
+        })
+    });
+
+    custom_group.bench_function("Any serialize", |b| {
+        b.iter(|| {
+            let mut roundtrip = String::new();
+            black_box(any.to_json(&mut roundtrip));
+        })
+    });
+
+    custom_group.bench_function("Any deserialize", |b| {
+        b.iter(|| {
+            black_box(Any::from_json(&any_json));
+        })
+    });
+
+    custom_group.finish();
+}
+
+#[cfg(feature = "serde")]
+criterion_group!(benches, bench_encoding, bench_serialization);
+#[cfg(not(feature = "serde"))]
+criterion_group!(benches, bench_encoding);
 criterion_main!(benches);

--- a/lib0/src/lib.rs
+++ b/lib0/src/lib.rs
@@ -4,3 +4,6 @@ pub mod decoding;
 pub mod encoding;
 mod json_parser;
 pub mod number;
+
+#[cfg(feature = "serde")]
+pub mod serde;

--- a/lib0/src/serde.rs
+++ b/lib0/src/serde.rs
@@ -1,0 +1,359 @@
+use std::collections::HashMap;
+use std::fmt::{Formatter};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::ser::{SerializeMap, SerializeSeq};
+use crate::any::Any;
+
+impl Serialize for Any {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        match self {
+            Any::Null => serializer.serialize_none(),
+            Any::Undefined => serializer.serialize_none(),
+            Any::Bool(value) => serializer.serialize_bool(*value),
+            Any::Number(value) => serializer.serialize_f64(*value),
+            Any::BigInt(value) => serializer.serialize_i64(*value),
+            Any::String(value) => serializer.serialize_str(value.as_ref()),
+            Any::Array(values) => {
+                let mut seq = serializer.serialize_seq(Some(values.len()))?;
+                for value in values.iter() {
+                    seq.serialize_element(value)?;
+                }
+                seq.end()
+            }
+            Any::Map(entries) => {
+                let mut map = serializer.serialize_map(Some(entries.len()))?;
+                for (key, value) in entries.iter() {
+                    map.serialize_entry(key, value)?;
+                }
+                map.end()
+            }
+            Any::Buffer(buf) => serializer.serialize_bytes(buf),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Any {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        struct AnyVisitor;
+        impl<'de> Visitor<'de> for AnyVisitor {
+            type Value = Any;
+
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                formatter.write_str("enum Any")
+            }
+
+            fn visit_bool<E>(self, v: bool)  -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::Bool(v))
+            }
+
+            fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(i64::from(v)))
+            }
+
+            fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(i64::from(v)))
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(i64::from(v)))
+            }
+
+            fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(v))
+            }
+
+            fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(i64::from(v)))
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(i64::from(v)))
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::BigInt(i64::from(v)))
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E> where E:  de::Error {
+                if v > i64::MAX as u64 {
+                    Err(de::Error::custom(format!("Value {} out of range for i64", v)))
+                } else {
+                    Ok(Any::BigInt(v as i64))
+                }
+            }
+
+            fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::Number(f64::from(v)))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::Number(v))
+            }
+
+            fn visit_char<E>(self, v: char) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::String(v.to_string().into_boxed_str()))
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::String(v.to_string().into_boxed_str()))
+            }
+
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::String(v.to_string().into_boxed_str()))
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::String(v.into_boxed_str()))
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::Buffer(v.to_owned().into_boxed_slice()))
+            }
+
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::Buffer(v.to_owned().into_boxed_slice()))
+            }
+
+            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::Buffer(v.into_boxed_slice()))
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E> where E:  de::Error {
+                Ok(Any::Null)
+            }
+
+            fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error> where D: Deserializer<'de> {
+                Any::deserialize(deserializer)
+            }
+
+            fn visit_unit<E>(self) -> Result<Self::Value, E> where E: de::Error {
+                Ok(Any::Null)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error> where A: SeqAccess<'de> {
+                let mut vec = Vec::new();
+
+                while let Some(value) = seq.next_element()? {
+                    vec.push(value);
+                }
+
+                Ok(Any::Array(vec.into_boxed_slice()))
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error> where A: MapAccess<'de> {
+                let mut any_map = HashMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    any_map.insert(key, value);
+                }
+
+                Ok(Any::Map(Box::new(any_map)))
+            }
+        }
+
+        deserializer.deserialize_any(AnyVisitor)
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+    use serde_json::json;
+    use crate::any::Any;
+
+    #[test]
+    fn test_deserialize_bool() {
+        assert_eq!(serde_json::from_str::<Any>("true").unwrap(), Any::Bool(true));
+    }
+
+    #[test]
+    fn test_serialize_bool() {
+        assert_eq!(serde_json::to_string(&Any::Bool(false)).unwrap(), "false");
+    }
+
+    #[test]
+    fn test_deserialize_float() {
+        assert_eq!(serde_json::from_str::<Any>("18.812036").unwrap(), Any::Number(18.812036f64));
+    }
+
+    #[test]
+    fn test_serialize_float() {
+        assert_eq!(serde_json::to_string(&Any::Number(-1298.283f64)).unwrap(), "-1298.283");
+    }
+
+    #[test]
+    fn test_deserialize_int() {
+        assert_eq!(serde_json::from_str::<Any>("18").unwrap(), Any::BigInt(18));
+    }
+
+    #[test]
+    fn test_deserialize_int_unrepresentable() {
+        assert!(serde_json::from_str::<Any>(&u64::MAX.to_string()).is_err());
+    }
+
+    #[test]
+    fn test_serialize_int() {
+        assert_eq!(serde_json::to_string(&Any::BigInt(-1298)).unwrap(), "-1298");
+    }
+
+    #[test]
+    fn test_deserialize_string() {
+        assert_eq!(serde_json::from_str::<Any>("\"string\"").unwrap(), Any::String("string".into()));
+    }
+
+    #[test]
+    fn test_serialize_string() {
+        assert_eq!(serde_json::to_string(&Any::String("string".into())).unwrap(), "\"string\"");
+    }
+
+    #[test]
+    fn test_deserialize_null() {
+        assert_eq!(serde_json::from_str::<Any>("null").unwrap(), Any::Null);
+    }
+
+    #[test]
+    fn test_serialize_null() {
+        assert_eq!(serde_json::to_string(&Any::Null).unwrap(), "null");
+    }
+
+    #[test]
+    fn test_serialize_undefined() {
+        assert_eq!(serde_json::to_string(&Any::Undefined).unwrap(), "null");
+    }
+
+    #[test]
+    fn test_serialize_buffer() {
+        assert_eq!(serde_json::to_string(&Any::Buffer("buffer".as_bytes().into())).unwrap(), "[98,117,102,102,101,114]");
+    }
+
+    #[test]
+    fn test_serialize_array() {
+        assert_eq!(
+            serde_json::to_string(&Any::Array(vec![Any::Bool(true), Any::BigInt(1)].into_boxed_slice())).unwrap(),
+            "[true,1]"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_array() {
+        assert_eq!(
+            serde_json::from_str::<Any>("[true, -101]").unwrap(),
+            Any::Array(vec![Any::Bool(true), Any::BigInt(-101)].into_boxed_slice())
+        );
+    }
+
+    #[test]
+    fn test_serialize_map() {
+        assert_eq!(
+            serde_json::to_value(&Any::Map(Box::new(
+                HashMap::from([
+                    ("key1".into(), Any::Bool(true)),
+                    ("key2".into(), Any::BigInt(1))
+                ])
+            ))).unwrap(),
+            json!({"key1":true, "key2":1})
+        );
+    }
+
+    #[test]
+    fn test_deserialize_map() {
+        assert_eq!(
+            serde_json::from_str::<Any>("{\"key1\":true,\"key2\":-12307.2138}").unwrap(),
+            Any::Map(Box::new(
+                HashMap::from([
+                    ("key1".into(), Any::Bool(true)),
+                    ("key2".into(), Any::Number(-12307.2138f64))
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_serialize_complex_map() {
+        assert_eq!(
+            serde_json::to_value(&Any::Map(Box::new(
+                HashMap::from([
+                    ("key1".into(), Any::Bool(true)),
+                    ("key2".into(), Any::BigInt(1)),
+                    ("key3".into(), Any::Map(Box::new(
+                        HashMap::from([
+                            ("key4".into(), Any::Bool(true)),
+                            ("key5".into(), Any::BigInt(1))
+                        ])
+                    ))),
+                    ("key6".into(), Any::Array(vec![Any::Bool(true), Any::BigInt(1)].into_boxed_slice()))
+                ])
+            ))).unwrap(),
+            json!({"key1": true, "key2":1, "key3":{"key4":true, "key5":1}, "key6": [true,1]})
+        );
+    }
+
+    #[test]
+    fn test_deserialize_complex_map() {
+        assert_eq!(
+            serde_json::from_str::<Any>("{\"key1\":true,\"key2\":1.1,\"key3\":{\"key4\":true,\"key5\":1},\"key6\":[true,1,null]}").unwrap(),
+            Any::Map(Box::new(
+                HashMap::from([
+                    ("key1".into(), Any::Bool(true)),
+                    ("key2".into(), Any::Number(1.1f64)),
+                    ("key3".into(), Any::Map(Box::new(
+                        HashMap::from([
+                            ("key4".into(), Any::Bool(true)),
+                            ("key5".into(), Any::BigInt(1))
+                        ])
+                    ))),
+                    ("key6".into(), Any::Array(vec![Any::Bool(true), Any::BigInt(1), Any::Null].into_boxed_slice()))
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let any = Any::Map(Box::new(
+            HashMap::from([
+                ("bool".into(), Any::Bool(true)),
+                ("int".into(), Any::BigInt(1)),
+                ("negativeInt".into(), Any::BigInt(-1)),
+                ("maxInt".into(), Any::BigInt(i64::MAX)),
+                ("minInt".into(), Any::BigInt(i64::MIN)),
+                ("realNumber".into(), Any::Number(-123.2387f64)),
+                ("maxNumber".into(), Any::Number(f64::MIN)),
+                ("minNumber".into(), Any::Number(f64::MAX)),
+                ("null".into(), Any::Null),
+                ("map".into(), Any::Map(Box::new(
+                    HashMap::from([
+                        ("bool".into(), Any::Bool(true)),
+                        ("int".into(), Any::BigInt(1)),
+                        ("negativeInt".into(), Any::BigInt(-1)),
+                        ("maxInt".into(), Any::BigInt(i64::MAX)),
+                        ("minInt".into(), Any::BigInt(i64::MIN)),
+                        ("realNumber".into(), Any::Number(-123.2387f64)),
+                        ("maxNumber".into(), Any::Number(f64::MIN)),
+                        ("minNumber".into(), Any::Number(f64::MAX)),
+                        ("null".into(), Any::Null),
+                    ])
+                ))),
+                ("key6".into(), Any::Array(vec![Any::Bool(true),
+                                                Any::BigInt(1),
+                                                Any::BigInt(-1),
+                                                Any::BigInt(i64::MAX),
+                                                Any::BigInt(i64::MIN),
+                                                Any::Number(-123.2387f64),
+                                                Any::Number(f64::MIN),
+                                                Any::Number(f64::MAX),
+                                                Any::Null].into_boxed_slice()))
+            ])
+        ));
+
+        assert_eq!(any, serde_json::from_str::<Any>(serde_json::to_string(&any).unwrap().as_str()).unwrap());
+    }
+
+}


### PR DESCRIPTION
Hi, I've been testing out Yrs as a CRDT solution for a primarily Rust project that I'm working on. One point of frustration which I had was the lack of integration into the greater Rust ecosystem. Since I understand that probably isn't your priority at the moment, I thought I'd contribute a first step by integrating the `lib0::Any` type with [the Serde ecosystem](https://serde.rs/#data-formats) to solve some of my own problems.

My serde implementation outperforms the hand-rolled `to_json` and `from_json` functions by a significant margin in benchmarks and is also capable of performing roundtrips in some cases where the handrolled functions switch types between `BigInt` and `Number`.

Benchmark results:
```
serde/Any-JSON roundtrip                                                                             
                        time:   [5.6044 us 5.6162 us 5.6362 us]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
serde/Any serialize
                        time:   [889.08 ns 890.32 ns 892.19 ns]                                 
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe
serde/Any deserialize   
                        time:   [891.03 ns 895.33 ns 901.11 ns]                                   
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  9 (9.00%) high severe

custom json serialization/Any-JSON roundtrip                                                                             
                        time:   [21.291 us 21.438 us 21.675 us]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
custom json serialization/Any serialize                                                                             
                        time:   [2.5150 us 2.5344 us 2.5716 us]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
custom json serialization/Any deserialize                                                                             
                        time:   [10.502 us 10.522 us 10.550 us]
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe
```