### PR TITLE
Y-Py XML

### DIFF
--- a/y-py/README.md
+++ b/y-py/README.md
@@ -1,43 +1,61 @@
-# y-py
+# Y-Py
 
-y-py is a Pythong binding to Yrs using Maturin, using pyo3.
+Y-Py is a Python binding for Y-CRDT. It provides distributed data types that enable real-time collaboration between devices. Y-Py can sync data with any other platform that has a Y-CRDT binding, allowing for seamless cross-domain communication. The library is a thin wrapper around Yrs, taking advantage of the safety and performance of Rust.
 
-Reference :
-https://docs.rs/crate/maturin/0.10.3
+## Installation
+```
+pip install y-py
+```
 
+## Getting Started
+Y-Py provides many of the same shared data types as [Yjs](https://docs.yjs.dev/). All objects are shared within a `YDoc` and get modified within a transaction block. 
 
-### install maturin
+```python
+import y_py as Y
 
-maturin is necessary to build y-py
+d1 = Y.YDoc()
+# Create a new YText object in the YDoc
+text = d1.get_text('test')
+# Start a transaction in order to update the text
+with d1.begin_transaction() as txn:
+    # Add text contents
+    text.push(txn, "hello world!")
+
+# Create another document
+d2 = Y.YDoc()
+# Share state with the original document
+state_vector = Y.encode_state_vector(d2)
+diff = Y.encode_state_as_update(d1, state_vector)
+Y.apply_update(d2, diff)
+
+with d2.begin_transaction() as txn: 
+    value = d2.get_text('test').to_string(txn)
+
+assert value == "hello world!"
+```
+
+## Development Setup
+0. Install Rust Nightly and Python
+1. Install `maturin` in order to build Y-Py 
 ```
 pip install maturin
 ```
+2. Create a development build of the library
+``` maturin develop ```
 
-### install rust
-
-You need to install nightly Rust
+## Tests
+All tests are located in `/tests`. You can run them with `pytest`.
 ```
-rustup install nightly
-rustup override set nightly
+pytest
 ```
 
-### Build y-py :
-- Build and install locally as a python module : ``` maturin develop ```
-- Build the wheels and stores them in `target/wheels` : ```maturin build```
-
-
-
-### use y-py :
-
+## Build Y-Py :
+Build the library as a wheel and store them in `target/wheels` : 
 ```
-import y_py
-
-# shows all the functions available in module y_py
-print(dir(y_py))
-
-# To be completed with working examples
-
+maturin build
 ```
+
+
 
 
 

--- a/y-py/src/lib.rs
+++ b/y-py/src/lib.rs
@@ -284,7 +284,6 @@ pub fn apply_update(doc: &mut YDoc, diff: Vec<u8>) {
 ///     text.insert(txn, 0, 'hello world')
 /// ```
 #[pyclass(unsendable)]
-#[pyo3(text_signature = "this is a test docstring")]
 pub struct YTransaction(Transaction);
 
 impl Deref for YTransaction {
@@ -1982,8 +1981,6 @@ pub fn y_py(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<YMapIterator>()?;
     m.add_class::<YXmlText>()?;
     m.add_class::<YXmlElement>()?;
-    m.add_class::<YXmlEvent>()?;
-    m.add_class::<YXmlAttributes>()?;
     m.add_wrapped(wrap_pyfunction!(encode_state_vector))?;
     m.add_wrapped(wrap_pyfunction!(encode_state_as_update))?;
     m.add_wrapped(wrap_pyfunction!(apply_update))?;

--- a/y-py/tests/test_y_text.py
+++ b/y-py/tests/test_y_text.py
@@ -7,19 +7,20 @@ import y_py as Y
 def test_inserts():
     d1 = Y.YDoc()
     x = d1.get_text('test')
-
-    d1.transact(lambda txn : x.push(txn, "hello "))
-    d1.transact(lambda txn : x.push(txn, "world!"))
+    with d1.begin_transaction() as txn:
+        x.push(txn, "hello ")
+        x.push(txn, "world!")
+        value = x.to_string(txn)
     expected = "hello world!"
-    value = d1.transact(lambda txn : x.to_string(txn))
     assert value == expected
 
     d2 = Y.YDoc(2)
     x = d2.get_text('test')
 
     exchange_updates([d1, d2])
+    with d2.begin_transaction() as txn:
+        value = x.to_string(txn)
 
-    value = d2.transact(lambda txn : x.to_string(txn))
     assert value == expected
 
 def test_deletes():

--- a/y-py/tests/test_y_xml.py
+++ b/y-py/tests/test_y_xml.py
@@ -159,7 +159,7 @@ def test_xml_text_observer():
     with d1.begin_transaction() as txn:
         x.insert(txn, 0, 'abcd')
     assert get_value(target), get_value(x)
-    assert delta, [{"insert": ['a','b','c','d']}]
+    assert delta == [{"insert": "abcd"}] 
     assert attributes == {}
     target = None
     attributes = None

--- a/y-py/tests/test_y_xml.py
+++ b/y-py/tests/test_y_xml.py
@@ -1,0 +1,287 @@
+from test_helper import exchange_updates
+import unittest
+import y_py as Y
+
+
+def test_insert():
+    d1 = Y.YDoc()
+    root = d1.get_xml_element('test')
+    with d1.begin_transaction() as txn:
+        b = root.push_xml_text(txn)
+        a = root.insert_xml_element(txn, 0, 'p')
+        aa = a.push_xml_text(txn)
+
+        aa.push(txn, 'hello')
+        b.push(txn, 'world')
+
+        s = root.to_string(txn)
+    assert s == '<UNDEFINED><p>hello</p>world</UNDEFINED>'
+
+def test_attributes():
+    d1 = Y.YDoc()
+    root = d1.get_xml_element('test')
+    with d1.begin_transaction() as txn:
+        root.set_attribute(txn, 'key1', 'value1')
+        root.set_attribute(txn, 'key2', 'value2')
+
+        actual = {}
+        for key,value in root.attributes(txn):
+            actual[key] = value
+    assert actual == {
+        "key1": 'value1',
+        "key2": 'value2'
+    }
+
+    with d1.begin_transaction() as txn:
+        root.remove_attribute(txn, 'key1')
+        actual = {
+            "key1": root.get_attribute(txn, 'key1'),
+            "key2": root.get_attribute(txn, 'key2')
+        }
+
+    assert actual == {
+        "key1": None,
+        "key2": 'value2'
+    }
+
+
+def test_siblings():
+    d1 = Y.YDoc()
+    root = d1.get_xml_element('test')
+    with d1.begin_transaction() as txn:
+        b = root.push_xml_text(txn)
+        a = root.insert_xml_element(txn, 0, 'p')
+        aa = a.push_xml_text(txn)
+
+        aa.push(txn, 'hello')
+        b.push(txn, 'world')
+        first = a
+        assert first.prev_sibling(txn) == None
+
+    with d1.begin_transaction() as txn:
+        second = first.next_sibling(txn)
+        s = second.to_string(txn)
+        assert s == "world"
+        assert second.nextSibling(txn) == None
+
+    with d1.begin_transaction() as txn:
+        actual = second.prev_sibling(txn).to_string(txn)
+        expected = first.to_string(txn)
+        assert actual == expected
+
+
+def test_tree_walker():
+    d1 = Y.YDoc()
+    root = d1.get_xml_element('test')
+    with d1.begin_transaction() as txn:
+        b = root.push_xml_text(txn)
+        a = root.insert_xml_element(txn, 0, 'p')
+        aa = a.push_xml_text(txn)
+        aa.push(txn, 'hello')
+        b.push(txn, 'world')
+
+    with d1.begin_transaction() as txn:
+        actual = []
+        for child in root.tree_walker(txn):
+            actual.push(child.to_string(txn))
+
+        expected = [
+            '<p>hello</p>',
+            'hello',
+            'world'
+        ]
+        assert actual == expected
+
+    with d1.begin_transaction() as txn:
+        actual = []
+        for child in root.tree_walker(txn):
+            actual.push(child.to_string(txn))
+
+        expected = [
+            '<p>hello</p>',
+            'hello',
+            'world'
+        ]
+        assert actual == expected
+
+
+def test_xml_text_observer():
+    d1 = Y.YDoc()
+    def get_value(x: Y.YXmlText) -> str:
+        with d1.begin_transaction() as txn:
+            return x.to_string(txn)
+    x = d1.get_xml_text('test')
+    target = None
+    attributes = None
+    delta = None
+
+    def callback(e):
+        nonlocal target
+        nonlocal attributes
+        nonlocal delta
+        target = e.target
+        attributes = e.keys
+        delta = e.delta
+
+    observer = x.observe(callback)
+
+    # set initial attributes
+    with d1.begin_transaction() as txn:
+        x.set_attribute(txn, 'attr1', 'value1')
+        x.set_attribute(txn, 'attr2', 'value2')
+
+    assert get_value(target) == get_value(x)
+    assert delta == []
+    assert attributes == {
+        "attr1": { "action": 'add', "newValue": 'value1' },
+        "attr2": { "action": 'add', "newValue": 'value2' }
+    }
+    target = None
+    attributes = None
+    delta = None
+
+    # update attributes
+    with d1.begin_transaction() as txn:
+        x.set_attribute(txn, 'attr1', 'value11')
+        x.remove_attribute(txn, 'attr2')
+
+    assert get_value(target) == get_value(x)
+    assert delta == []
+    assert attributes == {
+        "attr1": { "action": 'update', "oldValue": 'value1', "newValue": 'value11' },
+        "attr2": { "action": 'delete', "oldValue": 'value2' }
+    }
+    target = None
+    attributes = None
+    delta = None
+
+    # insert initial data to an empty YText
+    with d1.begin_transaction() as txn:
+        x.insert(txn, 0, 'abcd')
+    assert get_value(target), get_value(x)
+    assert delta, [{"insert": ['a','b','c','d']}]
+    assert attributes == {}
+    target = None
+    attributes = None
+    delta = None
+    # remove 2 chars from the middle
+    with d1.begin_transaction() as txn:
+        x.delete(txn, 1, 2)
+    assert get_value(target) == get_value(x)
+    assert delta == [{"retain":1}, {"delete": 2}]
+    assert attributes == {}
+    target = None
+    attributes = None
+    delta = None
+
+    # insert item in the middle
+    with d1.begin_transaction() as txn:
+        x.insert(txn, 1, 'e')
+    assert get_value(target) == get_value(x)
+    assert delta == [{"retain":1}, {"insert": 'e'}]
+    assert attributes == {}
+    target = None
+    attributes = None
+    delta = None
+
+    # free the observer and make sure that callback is no longer called
+    del observer
+    with d1.begin_transaction() as txn: 
+        x.insert(txn, 1, 'fgh')
+    assert target == None
+    assert attributes == None
+    assert delta == None
+
+def test_xml_element_observer():
+    d1 = Y.YDoc()
+    def get_value(x: Y.YXmlElement) -> str:
+        with d1.begin_transaction() as txn:
+            return x.to_string(txn)
+
+    x = d1.get_xml_element('test')
+    target = None
+    attributes = None
+    nodes = None
+
+    def callback(e):
+        nonlocal target
+        nonlocal attributes 
+        nonlocal nodes
+        target = e.target
+        attributes = e.keys
+        nodes = e.delta
+    
+    observer = x.observe(callback)
+
+    # insert initial attributes
+    with d1.begin_transaction() as txn:
+        x.set_attribute(txn, 'attr1', 'value1')
+        x.set_attribute(txn, 'attr2', 'value2')
+
+    assert get_value(target) == get_value(x)
+    assert nodes == []
+    assert attributes == {
+        "attr1": { "action": 'add', "newValue": 'value1' },
+        "attr2": { "action": 'add', "newValue": 'value2' }
+    }
+    target = None
+    attributes = None
+    nodes = None
+
+    # update attributes
+    with d1.begin_transaction() as txn:
+        x.set_attribute(txn, 'attr1', 'value11')
+        x.remove_attribute(txn, 'attr2')
+
+    assert get_value(target), get_value(x)
+    assert nodes == []
+    assert attributes == {
+        "attr1": { "action": 'update', "oldValue": 'value1', "newValue": 'value11' },
+        "attr2": { "action": 'delete', "oldValue": 'value2' }
+    }
+
+    target = None
+    attributes = None
+    nodes = None
+
+    # add children
+    with d1.begin_transaction() as txn:
+        x.insert_xml_element(txn, 0, 'div')
+        x.insert_xml_element(txn, 1, 'p')
+
+    assert get_value(target) == get_value(x)
+    assert len(nodes[0]["insert"]) == 2 # [{ insert: [div, p] }
+    assert attributes ==  {}
+    target = None
+    attributes = None
+    nodes = None
+
+    # remove a child
+    with d1.begin_transaction() as txn:
+        x.delete(txn, 0, 1)
+    assert get_value(target) == get_value(x)
+    assert nodes == [{ "delete": 1 }]
+    assert attributes == {}
+    target = None
+    attributes = None
+    nodes = None
+
+    # insert child again
+    with d1.begin_transaction() as txn:
+        txt = x.insert_xml_text(txn, x.length(txn))
+
+    assert get_value(target) == get_value(x)
+    assert nodes[0] == { "retain": 1 }
+    assert nodes[1]["insert"] != None
+    assert attributes ==  {}
+    target = None
+    attributes = None
+    nodes = None
+
+    # free the observer and make sure that callback is no longer called
+    del observer
+    with d1.begin_transaction() as txn:
+        x.insert_xml_element(txn, 0, 'head')
+    assert target == None
+    assert nodes == None
+    assert attributes == None


### PR DESCRIPTION
Added the XML portion of the API to Y-Py.
- Added `YXmlElement` and `YXmlText` types.
- Added XML related types including:
   - `YXmlTreeWalker`
   - `YXmlAttributes`
   - `YXml[Text]Observer`
   - `YXml[Text]Event`
- Ported XML tests into `test_y_xml.py`
- Updated README to include installation, development, build info and a simple Hello World example