### PR TITLE
Impl Send for Doc

### DIFF
--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -45,6 +45,8 @@ pub struct Doc {
     store: Rc<UnsafeCell<Store>>,
 }
 
+unsafe impl Send for Doc { }
+
 impl Doc {
     /// Creates a new document with a randomized client identifier.
     pub fn new() -> Self {


### PR DESCRIPTION
Related #68 

AFAIK, this shouldn't bring any issues. `Send` is mostly about referencing structures between the threads. It won't automagically work without locks anyway, so the only thread capable of changing the document state is the one that acquired lock.