### PR TITLE
v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib0"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "criterion",
  "lib0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "yffi"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "lib0",
  "yrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "lib0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,7 +1143,7 @@ dependencies = [
 
 [[package]]
 name = "yffi"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "lib0",
  "yrs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib0"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "proptest",

--- a/lib0/Cargo.toml
+++ b/lib0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib0"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/lib0/Cargo.toml
+++ b/lib0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib0"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -11,7 +11,7 @@ name = "y_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.3.0"}
+yrs = { path = "../yrs", version = "0.4.0"}
 lib0 = { path = "../lib0", version = "0.4.0"}
 
 [dependencies.pyo3]

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 yrs = { path = "../yrs", version = "0.3.0"}
-lib0 = { path = "../lib0", version = "0.3.0"}
+lib0 = { path = "../lib0", version = "0.4.0"}
 
 [dependencies.pyo3]
 version = "0.14.5"

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 yrs = { path = "../yrs", version = "0.2.1" }
-lib0 = { path = "../lib0", version = "0.2.1" }
+lib0 = { path = "../lib0", version = "0.3.0"}
 
 [dependencies.pyo3]
 version = "0.14.5"

--- a/y-py/Cargo.toml
+++ b/y-py/Cargo.toml
@@ -11,7 +11,7 @@ name = "y_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.2.1" }
+yrs = { path = "../yrs", version = "0.3.0"}
 lib0 = { path = "../lib0", version = "0.3.0"}
 
 [dependencies.pyo3]

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -13,7 +13,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 
 [dependencies]
 lib0 = { path = "../lib0", version = "0.3.0"}
-yrs = { path = "../yrs", version = "0.2.1" }
+yrs = { path = "../yrs", version = "0.3.0"}
 
 [lib]
 crate-type = ["staticlib"]

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.2.1" }
+lib0 = { path = "../lib0", version = "0.3.0"}
 yrs = { path = "../yrs", version = "0.2.1" }
 
 [lib]

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -13,7 +13,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 
 [dependencies]
 lib0 = { path = "../lib0", version = "0.4.0"}
-yrs = { path = "../yrs", version = "0.3.0"}
+yrs = { path = "../yrs", version = "0.4.0"}
 
 [lib]
 crate-type = ["staticlib"]

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.3.0"}
+lib0 = { path = "../lib0", version = "0.4.0"}
 yrs = { path = "../yrs", version = "0.3.0"}
 
 [lib]

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -13,7 +13,7 @@ readme = "./README.md"
 [dependencies]
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
 wasm-bindgen = "0.2"
-lib0 = { path = "../lib0", version = "0.3.0"}
+lib0 = { path = "../lib0", version = "0.4.0"}
 smallstr = { version = "0.2", features = ["union"]}
 
 [dev-dependencies]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -13,7 +13,7 @@ readme = "./README.md"
 [dependencies]
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
 wasm-bindgen = "0.2"
-lib0 = { path = "../lib0", version = "0.2.1" }
+lib0 = { path = "../lib0", version = "0.3.0"}
 smallstr = { version = "0.2", features = ["union"]}
 
 [dev-dependencies]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.3.0"
+version = "0.4.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.2.1"
+version = "0.3.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -18,7 +18,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 lib0 = { path = "../lib0", version = "0.3.0"}
-yrs = { path = "../yrs", version = "0.2.1" }
+yrs = { path = "../yrs", version = "0.3.0"}
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.3.0"}
+lib0 = { path = "../lib0", version = "0.4.0"}
 yrs = { path = "../yrs", version = "0.3.0"}
 wasm-bindgen = { version = "0.2" }
 

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.2.1" }
+lib0 = { path = "../lib0", version = "0.3.0"}
 yrs = { path = "../yrs", version = "0.2.1" }
 wasm-bindgen = { version = "0.2" }
 

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -18,7 +18,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 lib0 = { path = "../lib0", version = "0.4.0"}
-yrs = { path = "../yrs", version = "0.3.0"}
+yrs = { path = "../yrs", version = "0.4.0"}
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
Finally I managed to get `cargo release` to work and released yrs packages (except y-py which still doesn't compile locally for me) - they are visible on crates.io. That's a good news. 
Bad one is: when running `cargo release minor` it handles automatically minor version upgrade and does a dry-run, which is fine. However when executing `cargo release minor --execute` in order to do actual (not dry-run) release, it bumped up the version again. Therefore I published v0.4 and skipped over v0.3.