### PR TITLE
Fix stack overflow in update.rs

### DIFF
--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -745,7 +745,8 @@ impl BlockCarrier {
     pub(crate) fn same_type(&self, other: &BlockCarrier) -> bool {
         match (self, other) {
             (BlockCarrier::Skip(_), BlockCarrier::Skip(_)) => true,
-            (a, b) => a.same_type(b),
+            (BlockCarrier::Block(a), BlockCarrier::Block(b)) => a.same_type(b),
+            (_, _) => false,
         }
     }
     pub(crate) fn id(&self) -> &ID {


### PR DESCRIPTION
The current implementation of the function is incorrect, it just calls itself. I believe the original idea was to delegate the call to the `Block::same_type` function. 

Feel free to close this if the fix is not correct.