### PR TITLE
Replaced Box<str> with Rc<str> for XML node names and content format

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -1141,7 +1141,7 @@ pub enum ItemContent {
 
     /// Formatting attribute entry. Format attributes are not considered countable and don't
     /// contribute to an overall length of a collection they are applied to.
-    Format(Box<str>, Box<Any>),
+    Format(Rc<str>, Box<Any>),
 
     /// A chunk of text, usually applied by collaborative text insertion.
     String(SplittableString),
@@ -1273,7 +1273,7 @@ impl ItemContent {
                 let type_ref = inner.type_ref();
                 if type_ref == types::TYPE_REFS_XML_ELEMENT || type_ref == types::TYPE_REFS_XML_HOOK
                 {
-                    encoder.write_key(inner.name.as_ref().unwrap().as_str())
+                    encoder.write_key(inner.name.as_ref().unwrap().as_ref())
                 }
             }
             ItemContent::Any(any) => {
@@ -1302,7 +1302,7 @@ impl ItemContent {
                 }
             }
             ItemContent::Format(k, v) => {
-                encoder.write_string(k.as_ref());
+                encoder.write_key(k.as_ref());
                 encoder.write_json(v.as_ref());
             }
             ItemContent::Type(inner) => {
@@ -1310,7 +1310,7 @@ impl ItemContent {
                 encoder.write_type_ref(type_ref);
                 if type_ref == types::TYPE_REFS_XML_ELEMENT || type_ref == types::TYPE_REFS_XML_HOOK
                 {
-                    encoder.write_key(inner.name.as_ref().unwrap().as_str())
+                    encoder.write_key(inner.name.as_ref().unwrap().as_ref())
                 }
             }
             ItemContent::Any(any) => {
@@ -1342,7 +1342,7 @@ impl ItemContent {
             BLOCK_ITEM_STRING_REF_NUMBER => ItemContent::String(decoder.read_string().into()),
             BLOCK_ITEM_EMBED_REF_NUMBER => ItemContent::Embed(decoder.read_json().into()),
             BLOCK_ITEM_FORMAT_REF_NUMBER => {
-                ItemContent::Format(decoder.read_string().into(), decoder.read_json().into())
+                ItemContent::Format(decoder.read_key(), decoder.read_json().into())
             }
             BLOCK_ITEM_TYPE_REF_NUMBER => {
                 let type_ref = decoder.read_type_ref();

--- a/yrs/src/compatibility_tests.rs
+++ b/yrs/src/compatibility_tests.rs
@@ -245,10 +245,7 @@ fn xml_fragment_insert() {
             None,
             TypePtr::Unknown,
             None,
-            ItemContent::Type(Branch::new(
-                TYPE_REFS_XML_ELEMENT,
-                Some("node-name".to_string()),
-            )),
+            ItemContent::Type(Branch::new(TYPE_REFS_XML_ELEMENT, Some("node-name".into()))),
         )
         .into(),
     ];

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -74,7 +74,7 @@ impl Store {
     pub fn get_or_create_type<K: Into<Rc<str>>>(
         &mut self,
         key: K,
-        node_name: Option<String>,
+        node_name: Option<Rc<str>>,
         type_ref: TypeRefs,
     ) -> BranchPtr {
         let key = key.into();

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -150,7 +150,7 @@ impl Transaction {
     pub fn get_xml_element(&mut self, name: &str) -> XmlElement {
         let c = self.store_mut().get_or_create_type(
             name,
-            Some("UNDEFINED".to_string()),
+            Some("UNDEFINED".into()),
             TYPE_REFS_XML_ELEMENT,
         );
         XmlElement::from(c)

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -168,7 +168,7 @@ pub struct Branch {
     pub(crate) item: Option<BlockPtr>,
 
     /// A tag name identifier, used only by [XmlElement].
-    pub name: Option<String>,
+    pub name: Option<Rc<str>>,
 
     /// A length of an indexed sequence component of a current branch node. Map component elements
     /// are computed on demand.
@@ -209,7 +209,7 @@ impl PartialEq for Branch {
 }
 
 impl Branch {
-    pub fn new(type_ref: TypeRefs, name: Option<String>) -> Box<Self> {
+    pub fn new(type_ref: TypeRefs, name: Option<Rc<str>>) -> Box<Self> {
         Box::new(Self {
             start: None,
             map: HashMap::default(),
@@ -830,7 +830,7 @@ pub enum Delta {
 }
 
 /// An alias for map of attributes used as formatting parameters by [Text] and [XmlText] types.
-pub type Attrs = HashMap<Box<str>, Any>;
+pub type Attrs = HashMap<Rc<str>, Any>;
 
 pub(crate) fn event_keys(
     txn: &Transaction,

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -63,7 +63,7 @@ impl XmlElement {
         let tag = inner
             .name
             .as_ref()
-            .map(|s| s.as_str())
+            .map(|s| s.as_ref())
             .unwrap_or(&"UNDEFINED");
         write!(&mut s, "<{}", tag).unwrap();
         let attributes = Attributes(inner.entries());
@@ -207,7 +207,7 @@ impl XmlElement {
     /// If `index` is equal to length of current XML element, new element will be inserted as a last
     /// child.
     /// This method will panic if `index` is greater than the length of current XML element.
-    pub fn insert_elem<S: ToString>(
+    pub fn insert_elem<S: Into<Rc<str>>>(
         &self,
         txn: &mut Transaction,
         index: u32,
@@ -234,13 +234,13 @@ impl XmlElement {
 
     /// Pushes a new [XmlElement] with a given tag `name` as the last child of a current one and
     /// returns it.
-    pub fn push_elem_back<S: ToString>(&self, txn: &mut Transaction, name: S) -> XmlElement {
+    pub fn push_elem_back<S: Into<Rc<str>>>(&self, txn: &mut Transaction, name: S) -> XmlElement {
         self.0.push_elem_back(txn, name)
     }
 
     /// Pushes a new [XmlElement] with a given tag `name` as the first child of a current one and
     /// returns it.
-    pub fn push_elem_front<S: ToString>(&self, txn: &mut Transaction, name: S) -> XmlElement {
+    pub fn push_elem_front<S: Into<Rc<str>>>(&self, txn: &mut Transaction, name: S) -> XmlElement {
         self.0.push_elem_front(txn, name)
     }
 
@@ -365,15 +365,13 @@ impl XmlFragment {
         s
     }
 
-    pub fn insert_elem<S: ToString>(
+    pub fn insert_elem<S: Into<Rc<str>>>(
         &self,
         txn: &mut Transaction,
         index: u32,
         name: S,
     ) -> XmlElement {
-        let ptr = self
-            .0
-            .insert_at(txn, index, PrelimXml::Elem(name.to_string()));
+        let ptr = self.0.insert_at(txn, index, PrelimXml::Elem(name.into()));
         let item = ptr.as_item().unwrap();
         if let ItemContent::Type(inner) = &item.content {
             XmlElement::from(BranchPtr::from(inner))
@@ -399,12 +397,12 @@ impl XmlFragment {
         }
     }
 
-    pub fn push_elem_back<S: ToString>(&self, txn: &mut Transaction, name: S) -> XmlElement {
+    pub fn push_elem_back<S: Into<Rc<str>>>(&self, txn: &mut Transaction, name: S) -> XmlElement {
         let len = self.len();
         self.insert_elem(txn, len, name)
     }
 
-    pub fn push_elem_front<S: ToString>(&self, txn: &mut Transaction, name: S) -> XmlElement {
+    pub fn push_elem_front<S: Into<Rc<str>>>(&self, txn: &mut Transaction, name: S) -> XmlElement {
         self.insert_elem(txn, 0, name)
     }
 
@@ -877,7 +875,7 @@ impl XmlTextEvent {
 }
 
 enum PrelimXml {
-    Elem(String),
+    Elem(Rc<str>),
     Text,
 }
 

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -1353,7 +1353,7 @@ impl YText {
                 let tuple = js_sys::Array::from(&tuple);
                 let key: String = tuple.get(0).as_string()?;
                 let value = js_into_any(&tuple.get(1))?;
-                map.insert(key.into_boxed_str(), value);
+                map.insert(key.into(), value);
             }
             Some(map)
         } else {


### PR DESCRIPTION
Fixes #94

Allows to pass reusable strings in places like XML node names and formatting attribute start/end blocks.