### PR TITLE
Export `AfterTransactionEvent`

### DIFF
--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -52,7 +52,7 @@ pub use crate::block_store::StateVector;
 pub use crate::doc::Doc;
 pub use crate::doc::OffsetKind;
 pub use crate::doc::Options;
-pub use crate::event::{Subscription, SubscriptionId, UpdateEvent};
+pub use crate::event::{AfterTransactionEvent, Subscription, SubscriptionId, UpdateEvent};
 pub use crate::id_set::DeleteSet;
 pub use crate::transaction::Transaction;
 pub use crate::types::array::Array;


### PR DESCRIPTION
While I made the `AfterTransactionEvent` struct public, I forgot to export it in lib.rs. Ypy needs access to this to address the [YDoc events issue](https://github.com/y-crdt/ypy/issues/41)