### PR TITLE
Update yrb link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Project organization:
 Other projects using *yrs*:
 
 - [ypy](https://github.com/y-crdt/ypy) - Python bindings.
-- [y-rb](https://gitlab.com/gitlab-org/incubation-engineering/real-time-editing/y-rb) - Ruby bindings.
+- [yrb](https://github.com/y-crdt/yrb) - Ruby bindings.
 
 ## Feature parity with Yjs project
 


### PR DESCRIPTION
The y-rb bindings were moved into the `y-crdt` org last week. I'll keep the GitLab mirror for CI and deployment right now, but the source of truth should be the repo here.