### PR TITLE
Fix: call update events callbacks on any changes in committed transactions

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -851,13 +851,15 @@ unsigned long ydoc_id(YDoc *doc);
 
 unsigned int ydoc_observe_updates_v1(YDoc *doc,
                                      void *state,
-                                     void (*cb)(void*, int, unsigned char*));
+                                     void (*cb)(void*, int, const unsigned char*));
 
 unsigned int ydoc_observe_updates_v2(YDoc *doc,
                                      void *state,
-                                     void (*cb)(void*, int, unsigned char*));
+                                     void (*cb)(void*, int, const unsigned char*));
 
-void ydoc_unobserve_updates(YDoc *doc, unsigned int subscription_id);
+void ydoc_unobserve_updates_v1(YDoc *doc, unsigned int subscription_id);
+
+void ydoc_unobserve_updates_v2(YDoc *doc, unsigned int subscription_id);
 
 unsigned int ydoc_observe_after_transaction(YDoc *doc,
                                             void *state,

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1128,7 +1128,7 @@ void reset_observe_updates(ObserveUpdatesTest* t) {
     t->incoming_len = 0;
 }
 
-void observe_updates(void* state, int len, unsigned char* bytes) {
+void observe_updates(void* state, int len, const unsigned char* bytes) {
     ObserveUpdatesTest* t = (ObserveUpdatesTest*)state;
     t->incoming_len = len;
     void* buf = malloc(sizeof(unsigned char*) * len);
@@ -1159,7 +1159,7 @@ TEST_CASE("YDoc observe updates V1") {
     reset_observe_updates(&t);
 
     // check unsubscribe
-    ydoc_unobserve_updates(doc2, subscription_id);
+    ydoc_unobserve_updates_v1(doc2, subscription_id);
 
     txn = ytransaction_new(doc1);
     ytext_insert(txt1, txn, 5, " world", NULL);
@@ -1200,7 +1200,7 @@ TEST_CASE("YDoc observe updates V2") {
     reset_observe_updates(&t);
 
     // check unsubscribe
-    ydoc_unobserve_updates(doc2, subscription_id);
+    ydoc_unobserve_updates_v2(doc2, subscription_id);
 
     txn = ytransaction_new(doc1);
     ytext_insert(txt1, txn, 5, " world", NULL);

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.7.1",
+      "version": "0.8.1",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -285,13 +285,13 @@ pub unsafe extern "C" fn ydoc_id(doc: *mut Doc) -> c_ulong {
 pub unsafe extern "C" fn ydoc_observe_updates_v1(
     doc: *mut Doc,
     state: *mut c_void,
-    cb: extern "C" fn(*mut c_void, c_int, *mut c_uchar),
+    cb: extern "C" fn(*mut c_void, c_int, *const c_uchar),
 ) -> c_uint {
     let doc = doc.as_mut().unwrap();
-    let observer = doc.observe_update(move |_, e| {
-        let mut bytes = e.update.encode_v1();
+    let observer = doc.observe_update_v1(move |_, e| {
+        let mut bytes = &e.update;
         let len = bytes.len();
-        cb(state, len as c_int, bytes.as_mut_ptr() as *mut c_uchar)
+        cb(state, len as c_int, bytes.as_ptr() as *const c_uchar)
     });
     let subscription_id: u32 = observer.into();
     subscription_id as c_uint
@@ -301,22 +301,28 @@ pub unsafe extern "C" fn ydoc_observe_updates_v1(
 pub unsafe extern "C" fn ydoc_observe_updates_v2(
     doc: *mut Doc,
     state: *mut c_void,
-    cb: extern "C" fn(*mut c_void, c_int, *mut c_uchar),
+    cb: extern "C" fn(*mut c_void, c_int, *const c_uchar),
 ) -> c_uint {
     let doc = doc.as_mut().unwrap();
-    let observer = doc.observe_update(move |_, e| {
-        let mut bytes = e.update.encode_v2();
+    let observer = doc.observe_update_v2(move |_, e| {
+        let mut bytes = &e.update;
         let len = bytes.len();
-        cb(state, len as c_int, bytes.as_mut_ptr() as *mut c_uchar)
+        cb(state, len as c_int, bytes.as_ptr() as *const c_uchar)
     });
     let subscription_id: u32 = observer.into();
     subscription_id as c_uint
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_updates(doc: *mut Doc, subscription_id: c_uint) {
+pub unsafe extern "C" fn ydoc_unobserve_updates_v1(doc: *mut Doc, subscription_id: c_uint) {
     let doc = doc.as_mut().unwrap();
-    doc.unobserve_update(subscription_id as SubscriptionId);
+    doc.unobserve_update_v1(subscription_id as SubscriptionId);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ydoc_unobserve_updates_v2(doc: *mut Doc, subscription_id: c_uint) {
+    let doc = doc.as_mut().unwrap();
+    doc.unobserve_update_v2(subscription_id as SubscriptionId);
 }
 
 #[no_mangle]

--- a/yrs/src/event.rs
+++ b/yrs/src/event.rs
@@ -1,9 +1,9 @@
-use crate::update::Update;
 use crate::{DeleteSet, StateVector, Transaction};
 use rand::RngCore;
 use std::collections::HashMap;
 use std::ptr::NonNull;
 
+#[repr(transparent)]
 pub(crate) struct EventHandler<T>(Box<Subscriptions<T>>);
 
 pub type SubscriptionId = u32;
@@ -78,11 +78,11 @@ impl<T> Drop for Subscription<T> {
 pub struct UpdateEvent {
     /// An update that's about to be applied. Update contains information about all inserted blocks,
     /// which have been send from a remote peer.
-    pub update: Update,
+    pub update: Vec<u8>,
 }
 
 impl UpdateEvent {
-    pub(crate) fn new(update: Update) -> Self {
+    pub(crate) fn new(update: Vec<u8>) -> Self {
         UpdateEvent { update }
     }
 }

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -3,7 +3,6 @@ use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::{Encode, Encoder, EncoderV1};
 use crate::{Doc, StateVector, Update};
 use lib0::decoding::{Cursor, Read};
-use lib0::encoding::Write;
 use rand::distributions::Alphanumeric;
 use rand::prelude::{SliceRandom, StdRng};
 use rand::{random, Rng, RngCore, SeedableRng};
@@ -121,15 +120,9 @@ impl TestConnector {
             let rc = self.0.clone();
             let inner = unsafe { self.0.as_ptr().as_mut().unwrap() };
             let mut instance = TestPeer::new(client_id);
-            instance.doc.observe_update(move |_, e| {
-                let payload = {
-                    let mut encoder = EncoderV1::new();
-                    encoder.write_uvar(MSG_SYNC_UPDATE);
-                    e.update.encode(&mut encoder);
-                    encoder.to_vec()
-                };
+            instance.doc.observe_update_v1(move |_, e| {
                 let mut inner = rc.borrow_mut();
-                Self::broadcast(&mut inner, client_id, &payload);
+                Self::broadcast(&mut inner, client_id, &e.update);
             });
             let idx = inner.peers.len();
             inner.peers.push(instance);

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -195,9 +195,8 @@ impl YDoc {
     #[wasm_bindgen(js_name = onUpdate)]
     pub fn on_update(&mut self, f: js_sys::Function) -> YUpdateObserver {
         self.0
-            .observe_update(move |_, e| {
-                let u = e.update.encode_v1();
-                let arg = Uint8Array::from(u.as_slice());
+            .observe_update_v1(move |_, e| {
+                let arg = Uint8Array::from(e.update.as_slice());
                 f.call1(&JsValue::UNDEFINED, &arg).unwrap();
             })
             .into()
@@ -211,9 +210,8 @@ impl YDoc {
     #[wasm_bindgen(js_name = onUpdateV2)]
     pub fn on_update_v2(&mut self, f: js_sys::Function) -> YUpdateObserver {
         self.0
-            .observe_update(move |_, e| {
-                let u = e.update.encode_v2();
-                let arg = Uint8Array::from(u.as_slice());
+            .observe_update_v2(move |_, e| {
+                let arg = Uint8Array::from(e.update.as_slice());
                 f.call1(&JsValue::UNDEFINED, &arg).unwrap();
             })
             .into()


### PR DESCRIPTION
Previous implementation on `on_update` callback was basically unchanged for over a year - it didn't do full job, as it was only called when `transaction.apply_update` was called. This PR fixes that behavior and triggers the callbacks on any changes found in the transaction during a commit. 

Changes:

- `Do::on_update` is now split into `Doc::on_update_v1` and `Doc::on_update_v2` because the nature of how these callbacks are triggered, has changes. We no longer have `Update` struct at the moment of calling them, so it's better to make it aligned with Yjs behavior.