### PR TITLE
release v0.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: cargo publish yffi
-        run: sleep 10 && cd ./yffi && cargo publish --token ${CRATES_TOKEN}
+        run: sleep 20 && cd ./yffi && cargo publish --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       - name: cargo publish ywasm
-        run: sleep 10 && cd ./ywasm && cargo publish --token ${CRATES_TOKEN}
+        run: sleep 20 && cd ./ywasm && cargo publish --token ${CRATES_TOKEN}
         env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib0"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -985,7 +985,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yffi"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "lib0",
  "yrs",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "lib0",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/lib0/Cargo.toml
+++ b/lib0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib0"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,8 +12,8 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.8.1"}
-yrs = { path = "../yrs", version = "0.8.1"}
+lib0 = { path = "../lib0", version = "0.9"}
+yrs = { path = "../yrs", version = "0.9"}
 
 [lib]
 crate-type = ["staticlib"]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.8.1"
+version = "0.9.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
@@ -13,7 +13,7 @@ readme = "./README.md"
 [dependencies]
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
 wasm-bindgen = "0.2"
-lib0 = { path = "../lib0", version = "0.8.1"}
+lib0 = { path = "../lib0", version = "0.9"}
 smallstr = { version = "0.2", features = ["union"]}
 
 [dev-dependencies]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.8.1"}
-yrs = { path = "../yrs", version = "0.8.1"}
+lib0 = { path = "../lib0", version = "0.9"}
+yrs = { path = "../yrs", version = "0.9"}
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
- Fixed issues with update event not firing when transaction made changes other than apply_updates. This change required altering API: modified `Doc::on_update` &rarr; `Doc::on_update_v1`/`Doc::on_update_v2`.