### PR TITLE
Fixed encode with offset

### DIFF
--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -152,7 +152,8 @@ impl Store {
             encoder.write_uvar(clock);
             let first_block = blocks.get(start);
             // write first struct with an offset
-            first_block.encode(Some(self), encoder);
+            let offset = clock - first_block.id().clock;
+            first_block.encode_with_offset(Some(self), encoder, offset);
             for i in (start + 1)..blocks.len() {
                 blocks.get(i).encode(Some(self), encoder);
             }


### PR DESCRIPTION
This PR introduces several fixes that were discovered while working on `observe_udpdate_vX` observers. It turned out that transaction changed block that was merged, generated update payload would serialize entire block instead of just new part.