### PR TITLE
Remove wasm-bindgen from yrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -999,7 +999,6 @@ dependencies = [
  "lib0",
  "rand 0.7.3",
  "smallstr",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -12,7 +12,6 @@ readme = "./README.md"
 
 [dependencies]
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
-wasm-bindgen = "0.2"
 lib0 = { path = "../lib0", version = "0.9.1"}
 smallstr = { version = "0.2", features = ["union"]}
 


### PR DESCRIPTION
Rand's wasm-bindgen feature will enable wasm-bindgen feature on
getrandom crate which will compile wasm-bindgen package only for wasm
target: https://github.com/rust-random/getrandom/blob/v0.1.1/Cargo.toml#L35:L36

This means that on non-wasm targets wasm-bindgen is no longer included
and reduces the amount compiled crates from 37 to 15.