### PR TITLE
Implement Into<Any> for i64

### DIFF
--- a/lib0/src/any.rs
+++ b/lib0/src/any.rs
@@ -327,6 +327,12 @@ impl Into<Any> for i32 {
     }
 }
 
+impl Into<Any> for i64 {
+    fn into(self) -> Any {
+        Any::BigInt(self)
+    }
+}
+
 impl Into<Any> for String {
     fn into(self) -> Any {
         Any::String(self.into_boxed_str())


### PR DESCRIPTION
There is a BigInt type that holds an i64 but there was no `impl Into<Any>` for that.