### PR TITLE
Fix: block ptr added to Transaction::merge_blocks is deallocated while pointer remains

### DIFF
--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -348,13 +348,14 @@ impl Transaction {
             }
         }
 
-        for ptr in recurse.iter() {
-            if !self.delete(*ptr) {
+        for &ptr in recurse.iter() {
+            if !self.delete(ptr) {
                 // Whis will be gc'd later and we want to merge it if possible
                 // We try to merge all deleted items after each transaction,
                 // but we have no knowledge about that this needs to be merged
                 // since it is not in transaction.ds. Hence we add it to transaction._mergeStructs
-                self.merge_blocks.push(*ptr);
+                //println!("merge block 3: {}", ptr);
+                //self.merge_blocks.push(ptr);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/y-crdt/ypy/issues/63

The issue repeat steps:

1. We delete some blocks.
2. We apply update which contains delete set. 
3. We delete blocks marked in delete set - they are partially overlapping with blocks from pt.1.
4. These blocks are added to transaction `merge_blocks` list.
5. We squash these blocks as part of another process. 
6. In result of squashing the block is incorporated into its left neighbour and deallocated. However we still have a hanging reference to it in `merge_blocks` list which now points to a garbage data.

I still need to verify scenarios, where commented out code would make a difference, but for a validity sake this is a right thing to do.