### PR TITLE
Fixed Text::remove_range for even/odd-byte length chars

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -1112,13 +1112,14 @@ impl SplittableString {
             OffsetKind::Bytes => {
                 let mut remaining = offset;
                 let mut i = 0;
-                for c in self.content.encode_utf16() {
+                // since this offset is used to splitting later on - and we can only split entire
+                // characters - we're computing by characters
+                for c in self.content.chars() {
                     if remaining == 0 {
                         break;
                     }
-                    let utf8_len = if c < 0x80 { 1 } else { 2 };
-                    remaining -= utf8_len;
-                    i += 1;
+                    remaining -= c.len_utf8() as u32;
+                    i += c.len_utf16() as u32;
                 }
                 i
             }
@@ -1137,12 +1138,12 @@ impl SplittableString {
     fn map_utf16_offset(&self, offset: u32) -> u32 {
         let mut off = 0;
         let mut i = 0;
-        for c in self.content.encode_utf16() {
+        for c in self.content.chars() {
             if i >= offset {
                 break;
             }
-            off += if c < 0x80 { 1 } else { 2 };
-            i += 1;
+            off += c.len_utf8() as u32;
+            i += c.len_utf16() as u32;
         }
         off
     }

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1784,14 +1784,38 @@ mod test {
     }
 
     #[test]
-    fn text_remove_multibyte_range() {
-        let doc = Doc::new();
-        let mut txn = doc.transact();
-        let txt = txn.get_text("test");
+    fn text_remove_4_byte_range() {
+        let d1 = Doc::new();
+        let txt = d1.transact().get_text("test");
 
-        txt.insert(&mut txn, 0, "😭😊");
-        txt.remove_range(&mut txn, 0, "😭".len() as u32);
+        txt.insert(&mut d1.transact(), 0, "😭😊");
 
+        let d2 = Doc::new();
+        exchange_updates(&[&d1, &d2]);
+
+        txt.remove_range(&mut d1.transact(), 0, "😭".len() as u32);
         assert_eq!(txt.to_string().as_str(), "😊");
+
+        exchange_updates(&[&d1, &d2]);
+        let txt = d2.transact().get_text("test");
+        assert_eq!(txt.to_string().as_str(), "😊");
+    }
+
+    #[test]
+    fn text_remove_3_byte_range() {
+        let d1 = Doc::new();
+        let txt = d1.transact().get_text("test");
+
+        txt.insert(&mut d1.transact(), 0, "⏰⏳");
+
+        let d2 = Doc::new();
+        exchange_updates(&[&d1, &d2]);
+
+        txt.remove_range(&mut d1.transact(), 0, "⏰".len() as u32);
+        assert_eq!(txt.to_string().as_str(), "⏳");
+
+        exchange_updates(&[&d1, &d2]);
+        let txt = d2.transact().get_text("test");
+        assert_eq!(txt.to_string().as_str(), "⏳");
     }
 }


### PR DESCRIPTION
Fixes #156 (hopefully permanently this time).