### PR TITLE
fixed invalid encoding param for block splitting in text cursor positioning

### DIFF
--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -355,7 +355,6 @@ impl Transaction {
                 // We try to merge all deleted items after each transaction,
                 // but we have no knowledge about that this needs to be merged
                 // since it is not in transaction.ds. Hence we add it to transaction._mergeStructs
-                //println!("merge block 3: {}", ptr);
                 self.merge_blocks.push(id);
             }
         }


### PR DESCRIPTION
Related to #156

The reason why the issue reappeared this time was due to fact, that I've assigned `OffsetKind::UTF16` correctly in text remove method but not in text find_position.