### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -350,11 +350,11 @@ impl BlockPtr {
                 item.content.gc();
                 let len = item.len();
                 if parent_gced {
-                    unsafe {
+                    
                         let gc = Block::GC(BlockRange::new(item.id, len));
-                        let self_mut = self.0.as_mut();
+                        let self_mut = unsafe { self.0.as_mut() };
                         *self_mut = gc;
-                    }
+                    
                 } else {
                     item.content = ItemContent::Deleted(len);
                     item.info.clear_countable();

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -129,19 +129,19 @@ impl IdRange {
             if !ranges.is_empty() {
                 ranges.sort_by(|a, b| a.start.cmp(&b.start));
                 let mut new_len = 1;
-                unsafe {
+               
                     let len = ranges.len() as isize;
                     let head = ranges.as_mut_ptr();
-                    let mut current = head.as_mut().unwrap();
+                    let mut current = unsafe { head.as_mut().unwrap() };
                     let mut i = 1;
                     while i < len {
-                        let next = head.offset(i).as_ref().unwrap();
+                        let next = unsafe { head.offset(i).as_ref().unwrap() };
                         if !Self::try_join(current, next) {
                             // current and next are disjoined eg. [0,5) & [6,9)
 
                             // move current pointer one index to the left: by using new_len we
                             // squash ranges possibly already merged to current
-                            current = head.offset(new_len).as_mut().unwrap();
+                            current = unsafe { head.offset(new_len).as_mut().unwrap() };
 
                             // make next a new current
                             current.start = next.start;
@@ -151,7 +151,7 @@ impl IdRange {
 
                         i += 1;
                     }
-                }
+                
 
                 if new_len == 1 {
                     *self = IdRange::Continuous(ranges[0].clone())

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -110,19 +110,19 @@ impl<'a> From<&'a mut Box<Branch>> for BranchPtr {
 impl<'a> From<&'a Box<Branch>> for BranchPtr {
     fn from(branch: &'a Box<Branch>) -> Self {
         let b: &Branch = &*branch;
-        unsafe {
-            let ptr = NonNull::new_unchecked(b as *const Branch as *mut Branch);
+        
+            let ptr = unsafe { NonNull::new_unchecked(b as *const Branch as *mut Branch) };
             BranchPtr(ptr)
-        }
+        
     }
 }
 
 impl<'a> From<&'a Branch> for BranchPtr {
     fn from(branch: &'a Branch) -> Self {
-        unsafe {
-            let ptr = NonNull::new_unchecked(branch as *const Branch as *mut Branch);
+        
+            let ptr = unsafe { NonNull::new_unchecked(branch as *const Branch as *mut Branch) };
             BranchPtr(ptr)
-        }
+        
     }
 }
 

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -2577,12 +2577,12 @@ impl YXmlText {
     /// unspecified order.
     #[wasm_bindgen(js_name = attributes)]
     pub fn attributes(&self) -> YXmlAttributes {
-        unsafe {
+        
             let this: *const XmlText = &self.0;
             let static_iter: ManuallyDrop<Attributes<'static>> =
-                ManuallyDrop::new((*this).attributes());
+                unsafe { ManuallyDrop::new((*this).attributes()) };
             YXmlAttributes(static_iter)
-        }
+        
     }
 
     /// Subscribes to all operations happening over this instance of `YXmlText`. All changes are


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html