### PR TITLE
added explicitly signed varint for lib0 v2 encoding compatibility

### DIFF
--- a/lib0/src/decoding.rs
+++ b/lib0/src/decoding.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::number::VarInt;
+use crate::number::{Signed, SignedVarInt, VarInt};
 
 #[derive(Default)]
 pub struct Cursor<'a> {
@@ -89,6 +89,14 @@ pub trait Read: Sized {
     #[inline]
     fn read_var<T: VarInt>(&mut self) -> Result<T, Error> {
         T::read(self)
+    }
+
+    /// Read unsigned integer with variable length.
+    /// * numbers < 2^7 are stored in one byte
+    /// * numbers < 2^14 are stored in two bytes
+    #[inline]
+    fn read_var_signed<T: SignedVarInt>(&mut self) -> Result<Signed<T>, Error> {
+        T::read_signed(self)
     }
 
     /// Read string of variable length.

--- a/lib0/src/encoding.rs
+++ b/lib0/src/encoding.rs
@@ -1,4 +1,4 @@
-use crate::number::VarInt;
+use crate::number::{Signed, SignedVarInt, VarInt};
 
 impl Write for Vec<u8> {
     fn write_all(&mut self, buf: &[u8]) {
@@ -51,6 +51,17 @@ pub trait Write: Sized {
     #[inline]
     fn write_var<T: VarInt>(&mut self, num: T) {
         num.write(self)
+    }
+
+    /// Write a variable length integer or unsigned integer.
+    ///
+    /// We don't use zig-zag encoding because we want to keep the option open
+    /// to use the same function for BigInt and 53bit integers.
+    ///
+    /// We use the 7th bit instead for signaling that this is a negative number.
+    #[inline]
+    fn write_var_signed<T: SignedVarInt>(&mut self, num: &Signed<T>) {
+        T::write_signed(num, self)
     }
 
     /// Write variable length buffer (binary content).

--- a/yrs/src/updates/decoder.rs
+++ b/yrs/src/updates/decoder.rs
@@ -421,15 +421,15 @@ impl<'a> UIntOptRleDecoder<'a> {
 
     fn read_u64(&mut self) -> Result<u64, Error> {
         if self.count == 0 {
-            let s = self.cursor.read_var::<i64>()?;
+            let s = self.cursor.read_var_signed::<i64>()?;
             // if the sign is negative, we read the count too, otherwise count is 1
             let is_negative = s.is_negative();
             if is_negative {
                 self.count = self.cursor.read_var::<u32>()? + 2;
-                self.last = (-s) as u64;
+                self.last = (-s.value()) as u64;
             } else {
                 self.count = 1;
-                self.last = s as u64;
+                self.last = s.value() as u64;
             }
         }
         self.count -= 1;

--- a/yrs/src/updates/encoder.rs
+++ b/yrs/src/updates/encoder.rs
@@ -2,6 +2,7 @@ use crate::block::ClientID;
 use crate::*;
 use lib0::any::Any;
 use lib0::encoding::Write;
+use lib0::number::Signed;
 use std::collections::HashMap;
 
 /// A trait that can be implemented by any other type in order to support lib0 encoding capability.
@@ -446,7 +447,8 @@ impl UIntOptRleEncoder {
             if self.count == 1 {
                 self.buf.write_var(self.last as i64);
             } else {
-                self.buf.write_var(-(self.last as i64));
+                let value = Signed::new(-(self.last as i64), true);
+                self.buf.write_var_signed(&value);
                 self.buf.write_var(self.count - 2);
             }
         }


### PR DESCRIPTION
Fixes #188
Fixes #189

This PR solves a problem of `-0`/`0` differentiation in lib0 v2 encoding which is necessary and present in Yjs, but due to Rust nature (which doesn't recognize signed 0) was implicitly erased in Yrs, causing problems with compatibility.

Kudos to @namse for tracking down this issue. This PR also fixes it on both encoding/decoding sides.