### PR TITLE
Store - use Arc & AtomicRefCells to multithreaded access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1025,7 @@ dependencies = [
 name = "yrs"
 version = "0.12.2"
 dependencies = [
+ "atomic_refcell",
  "criterion",
  "lib0",
  "rand 0.7.3",

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -15,6 +15,7 @@ thiserror = "1"
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
 lib0 = { path = "../lib0", version = "0.12.2" }
 smallstr = { version = "0.2", features = ["union"]}
+atomic_refcell = "0.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,4 +1,4 @@
-use crate::block::{Block, BlockPtr, BlockSlice, ClientID, Item, ID};
+use crate::block::{Block, BlockPtr, BlockSlice, ClientID, ID};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::client_hasher::ClientHasher;

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -1247,10 +1247,10 @@ mod test {
     #[test]
     fn multi_threading() {
         use rand::thread_rng;
-        use std::sync::{Arc, Mutex};
+        use std::sync::{Arc, RwLock};
         use std::thread::{sleep, spawn};
 
-        let doc = Arc::new(Mutex::new(Doc::with_client_id(1)));
+        let doc = Arc::new(RwLock::new(Doc::with_client_id(1)));
 
         let d2 = doc.clone();
         let h2 = spawn(move || {
@@ -1258,7 +1258,7 @@ mod test {
                 let millis = thread_rng().gen_range(1, 20);
                 sleep(Duration::from_millis(millis));
 
-                let doc = d2.lock().unwrap();
+                let doc = d2.write().unwrap();
                 let array = doc.get_array("test");
                 let mut txn = doc.transact_mut();
                 array.push_back(&mut txn, "a");
@@ -1271,7 +1271,7 @@ mod test {
                 let millis = thread_rng().gen_range(1, 20);
                 sleep(Duration::from_millis(millis));
 
-                let doc = d3.lock().unwrap();
+                let doc = d3.write().unwrap();
                 let array = doc.get_array("test");
                 let mut txn = doc.transact_mut();
                 array.push_back(&mut txn, "b");
@@ -1281,7 +1281,7 @@ mod test {
         h3.join().unwrap();
         h2.join().unwrap();
 
-        let doc = doc.lock().unwrap();
+        let doc = doc.read().unwrap();
         let array = doc.get_array("test");
         let len = array.len(&doc.transact());
         assert_eq!(len, 20);

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -918,10 +918,10 @@ mod test {
     #[test]
     fn multi_threading() {
         use rand::thread_rng;
-        use std::sync::{Arc, Mutex};
+        use std::sync::{Arc, RwLock};
         use std::thread::{sleep, spawn};
 
-        let doc = Arc::new(Mutex::new(Doc::with_client_id(1)));
+        let doc = Arc::new(RwLock::new(Doc::with_client_id(1)));
 
         let d2 = doc.clone();
         let h2 = spawn(move || {
@@ -929,7 +929,7 @@ mod test {
                 let millis = thread_rng().gen_range(1, 20);
                 sleep(Duration::from_millis(millis));
 
-                let doc = d2.lock().unwrap();
+                let doc = d2.write().unwrap();
                 let map = doc.get_map("test");
                 let mut txn = doc.transact_mut();
                 map.insert(&mut txn, "key", 1);
@@ -942,7 +942,7 @@ mod test {
                 let millis = thread_rng().gen_range(1, 20);
                 sleep(Duration::from_millis(millis));
 
-                let doc = d3.lock().unwrap();
+                let doc = d3.write().unwrap();
                 let map = doc.get_map("test");
                 let mut txn = doc.transact_mut();
                 map.insert(&mut txn, "key", 2);
@@ -952,7 +952,7 @@ mod test {
         h3.join().unwrap();
         h2.join().unwrap();
 
-        let doc = doc.lock().unwrap();
+        let doc = doc.read().unwrap();
         let map = doc.get_map("test");
         let txn = doc.transact();
         let value = map.get(&txn, "key").unwrap().to_json(&txn);

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -17,6 +17,7 @@ use crate::types::array::{ArrayEvent, ArrayRef};
 use crate::types::map::MapEvent;
 use crate::types::text::TextEvent;
 use crate::types::xml::{XmlElementRef, XmlEvent, XmlTextEvent, XmlTextRef};
+use atomic_refcell::AtomicRefCell;
 use lib0::any::Any;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryInto;
@@ -24,8 +25,8 @@ use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::ptr::NonNull;
-use std::rc::{Rc, Weak};
-use std::sync::Arc;
+use std::rc::Rc;
+use std::sync::{Arc, Weak};
 
 pub type TypeRefs = u8;
 
@@ -250,7 +251,7 @@ pub struct Branch {
     /// another complex type.
     pub(crate) item: Option<BlockPtr>,
 
-    pub(crate) store: Option<Weak<RefCell<Store>>>,
+    pub(crate) store: Option<Weak<AtomicRefCell<Store>>>,
 
     /// A tag name identifier, used only by [XmlElement].
     pub name: Option<Rc<str>>,


### PR DESCRIPTION
Merge after #210

Perf benchmarks against `bart/xml-fragment` branch - in general we expected some performance degradation, since we've moved to use atomic hardware intrinsic ops to avoid risks of caching ref counters in L-caches. These ops are slower, but they are used only for establishing transactions and creating shared types.

```
[B1.1] Append N characters/6000
                        time:   [13.903 ms 16.477 ms 19.038 ms]
                        change: [-6.2946% +7.2149% +23.976%] (p = 0.37 > 0.05)
                        No change in performance detected.

[B1.2] Insert string of length N/1
                        time:   [7.6692 us 7.6861 us 7.7223 us]
                        change: [+24.088% +42.258% +54.557%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B1.3] Prepend N characters/6000
                        time:   [4.5485 ms 4.5655 ms 4.5955 ms]
                        change: [-1.3148% -0.2449% +1.1504%] (p = 0.73 > 0.05)
                        No change in performance detected.

[B1.4] Insert N characters at random positions/6000
                        time:   [66.641 ms 67.480 ms 67.899 ms]
                        change: [-0.7671% -0.1725% +0.5718%] (p = 0.63 > 0.05)
                        No change in performance detected.

[B1.5] Insert N words at random positions/6000
                        time:   [22.016 ms 22.058 ms 22.133 ms]
                        change: [-1.0951% -0.6727% -0.2789%] (p = 0.01 < 0.05)
                        Change within noise threshold.

Benchmarking [B1.7] Insert/Delete strings at random positions/6000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.7s or enable flat sampling.
[B1.7] Insert/Delete strings at random positions/6000
                        time:   [300.27 ms 369.18 ms 410.69 ms]
                        change: [-21.546% -4.3086% +17.081%] (p = 0.69 > 0.05)
                        No change in performance detected.

[B1.8] Append N numbers/6000
                        time:   [5.8137 ms 5.8453 ms 5.8728 ms]
                        change: [+7.0376% +7.7521% +8.4152%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B1.9] Insert Array of N numbers/1
                        time:   [102.37 us 168.91 us 240.24 us]
                        change: [+11.776% +53.726% +114.71%] (p = 0.04 < 0.05)
                        Performance has regressed.

[B1.10] Prepend N numbers/6000
                        time:   [5.7707 ms 5.8511 ms 5.9772 ms]
                        change: [+8.2468% +10.859% +13.628%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking [B1.11] Insert N numbers at random positions/6000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.2s or enable flat sampling.
[B1.11] Insert N numbers at random positions/6000
                        time:   [111.77 ms 111.81 ms 111.86 ms]
                        change: [+12.272% +12.504% +12.789%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B2.1] Concurrently insert string of length N at index 0/6000
                        time:   [31.994 us 37.544 us 40.066 us]
                        change: [-21.133% -14.541% -7.0264%] (p = 0.00 < 0.05)
                        Performance has improved.

[B2.2] Concurrently insert N characters at random positions/6000
                        time:   [196.67 ms 196.83 ms 197.02 ms]
                        change: [-1.1118% -0.3045% +0.5325%] (p = 0.51 > 0.05)
                        No change in performance detected.

[B2.3] Concurrently insert N words at random positions/6000
                        time:   [359.21 ms 360.70 ms 362.43 ms]
                        change: [-4.4714% -2.7808% -1.2782%] (p = 0.00 < 0.05)
                        Performance has improved.

[B2.4] Concurrently insert & delete/6000
                        time:   [528.74 ms 600.56 ms 672.47 ms]
                        change: [-14.648% +0.8707% +19.290%] (p = 0.92 > 0.05)
                        No change in performance detected.

[B3.1] 20√N clients concurrently set number in Map/1540
                        time:   [80.799 ms 80.829 ms 80.877 ms]
                        change: [-4.8364% -4.6076% -4.3486%] (p = 0.00 < 0.05)
                        Performance has improved.

[B3.2] 20√N clients concurrently set Object in Map/1540
                        time:   [87.500 ms 88.479 ms 89.792 ms]
                        change: [+9.8779% +10.442% +11.458%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking [B3.3] 20√N clients concurrently set String in Map/1540: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.1s or enable flat sampling.
[B3.3] 20√N clients concurrently set String in Map/1540
                        time:   [91.595 ms 91.724 ms 91.866 ms]
                        change: [+1.4150% +3.4972% +5.3906%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking [B3.4] 20√N clients concurrently insert text in Array/1540: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s or enable flat sampling.
[B3.4] 20√N clients concurrently insert text in Array/1540
                        time:   [95.761 ms 96.182 ms 96.686 ms]
                        change: [+8.2623% +8.5761% +8.9655%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B4.2] Apply real-world document snapshot of size/400972
                        time:   [2.8747 ms 2.8766 ms 2.8781 ms]
                        change: [+6.9131% +7.1990% +7.4280%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking [B4.1] Apply real-world editing dataset/259778: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 56.7s.
[B4.1] Apply real-world editing dataset/259778
                        time:   [5.5556 s 5.5829 s 5.6113 s]
                        change: [-5.3838% -1.9712% +1.1074%] (p = 0.31 > 0.05)
                        No change in performance detected.
``` 