### PR TITLE
Renamed root-level accessors Doc::get_* -> Doc::get_or_insert_*

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -930,13 +930,17 @@ void ytransaction_commit(YTransaction *txn);
 uint8_t ytransaction_writeable(YTransaction *txn);
 
 /**
+ * Gets a reference to shared data type instance at the document root-level,
+ * identified by its `name`, which must be a null-terminated UTF-8 compatible string.
+ *
+ * Returns `NULL` if no such structure was defined in the document before.
+ */
+Branch *ytype_get(YTransaction *txn, const char *name);
+
+/**
  * Gets or creates a new shared `YText` data type instance as a root-level type of a given document.
  * This structure can later be accessed using its `name`, which must be a null-terminated UTF-8
  * compatible string.
- *
- * Use [ytext_destroy] in order to release pointer returned that way - keep in mind that this will
- * not remove `YText` instance from the document itself (once created it'll last for the entire
- * lifecycle of a document).
  */
 Branch *ytext(YDoc *doc, const char *name);
 

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -502,20 +502,35 @@ pub unsafe extern "C" fn ytransaction_writeable(txn: *mut Transaction) -> u8 {
     }
 }
 
+/// Gets a reference to shared data type instance at the document root-level,
+/// identified by its `name`, which must be a null-terminated UTF-8 compatible string.
+///
+/// Returns `NULL` if no such structure was defined in the document before.
+#[no_mangle]
+pub unsafe extern "C" fn ytype_get(txn: *mut Transaction, name: *const c_char) -> *mut Branch {
+    assert!(!txn.is_null());
+    assert!(!name.is_null());
+
+    let name = CStr::from_ptr(name).to_str().unwrap();
+    //NOTE: we're retrieving this as a text, but ultimatelly it doesn't matter as we don't define
+    // nor redefine the underlying branch type
+    if let Some(txt) = txn.as_mut().unwrap().get_text(name) {
+        txt.into_raw_branch()
+    } else {
+        null_mut()
+    }
+}
+
 /// Gets or creates a new shared `YText` data type instance as a root-level type of a given document.
 /// This structure can later be accessed using its `name`, which must be a null-terminated UTF-8
 /// compatible string.
-///
-/// Use [ytext_destroy] in order to release pointer returned that way - keep in mind that this will
-/// not remove `YText` instance from the document itself (once created it'll last for the entire
-/// lifecycle of a document).
 #[no_mangle]
 pub unsafe extern "C" fn ytext(doc: *mut Doc, name: *const c_char) -> *mut Branch {
     assert!(!doc.is_null());
     assert!(!name.is_null());
 
     let name = CStr::from_ptr(name).to_str().unwrap();
-    let txt = doc.as_mut().unwrap().get_text(name);
+    let txt = doc.as_mut().unwrap().get_or_insert_text(name);
     txt.into_raw_branch()
 }
 
@@ -532,7 +547,10 @@ pub unsafe extern "C" fn yarray(doc: *mut Doc, name: *const c_char) -> *mut Bran
     assert!(!name.is_null());
 
     let name = CStr::from_ptr(name).to_str().unwrap();
-    doc.as_mut().unwrap().get_array(name).into_raw_branch()
+    doc.as_mut()
+        .unwrap()
+        .get_or_insert_array(name)
+        .into_raw_branch()
 }
 
 /// Gets or creates a new shared `YMap` data type instance as a root-level type of a given document.
@@ -548,7 +566,10 @@ pub unsafe extern "C" fn ymap(doc: *mut Doc, name: *const c_char) -> *mut Branch
     assert!(!name.is_null());
 
     let name = CStr::from_ptr(name).to_str().unwrap();
-    doc.as_mut().unwrap().get_map(name).into_raw_branch()
+    doc.as_mut()
+        .unwrap()
+        .get_or_insert_map(name)
+        .into_raw_branch()
 }
 
 /// Gets or creates a new shared `YXmlElement` data type instance as a root-level type of a given
@@ -562,7 +583,7 @@ pub unsafe extern "C" fn yxmlelem(doc: *mut Doc, name: *const c_char) -> *mut Br
     let name = CStr::from_ptr(name).to_str().unwrap();
     doc.as_mut()
         .unwrap()
-        .get_xml_element(name)
+        .get_or_insert_xml_element(name)
         .into_raw_branch()
 }
 
@@ -577,7 +598,7 @@ pub unsafe extern "C" fn yxmlfragment(doc: *mut Doc, name: *const c_char) -> *mu
     let name = CStr::from_ptr(name).to_str().unwrap();
     doc.as_mut()
         .unwrap()
-        .get_xml_fragment(name)
+        .get_or_insert_xml_fragment(name)
         .into_raw_branch()
 }
 
@@ -590,7 +611,10 @@ pub unsafe extern "C" fn yxmltext(doc: *mut Doc, name: *const c_char) -> *mut Br
     assert!(!name.is_null());
 
     let name = CStr::from_ptr(name).to_str().unwrap();
-    doc.as_mut().unwrap().get_xml_text(name).into_raw_branch()
+    doc.as_mut()
+        .unwrap()
+        .get_or_insert_xml_text(name)
+        .into_raw_branch()
 }
 
 /// Returns a state vector of a current transaction's document, serialized using lib0 version 1

--- a/yrs/benches/benches.rs
+++ b/yrs/benches/benches.rs
@@ -156,7 +156,7 @@ where
 {
     let input = {
         let doc = Doc::new();
-        let txt = doc.get_text("text");
+        let txt = doc.get_or_insert_text("text");
         let mut rng = StdRng::seed_from_u64(SEED);
         let ops = gen(&mut rng, N);
         (doc, txt, ops)
@@ -185,7 +185,7 @@ where
 {
     let input = {
         let doc = Doc::new();
-        let array = doc.get_array("text");
+        let array = doc.get_or_insert_array("text");
         let mut rng = StdRng::seed_from_u64(SEED);
         let ops = gen(&mut rng, N);
         (doc, array, ops)
@@ -216,10 +216,10 @@ where
 {
     let input = {
         let d1 = Doc::new();
-        let t1 = d1.get_text("text");
+        let t1 = d1.get_or_insert_text("text");
 
         let d2 = Doc::new();
-        let t2 = d2.get_text("text");
+        let t2 = d2.get_or_insert_text("text");
 
         let mut rng = StdRng::seed_from_u64(SEED);
         let ops = gen(&mut rng, N);
@@ -340,7 +340,7 @@ where
         .into_iter()
         .map(|i| {
             let doc = Doc::new();
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
             let update = {
                 let mut txn = doc.transact_mut();
                 f(&map, &mut txn, i);
@@ -387,7 +387,7 @@ fn b3_4(c: &mut Criterion, name: &str) {
         .into_iter()
         .map(|i| {
             let doc = Doc::new();
-            let array = doc.get_array("array");
+            let array = doc.get_or_insert_array("array");
             let update = {
                 let mut txn = doc.transact_mut();
                 array.insert(&mut txn, 0, i.to_string());
@@ -411,7 +411,7 @@ fn b3_4(c: &mut Criterion, name: &str) {
 
 fn b4_1(c: &mut Criterion, name: &str) {
     let doc = Doc::new();
-    let txt = doc.get_text("text");
+    let txt = doc.get_or_insert_text("text");
     let input = read_input("./yrs/benches/input/b4-editing-trace.bin");
 
     c.bench_with_input(
@@ -433,7 +433,7 @@ fn b4_1(c: &mut Criterion, name: &str) {
 
 fn b4_2(c: &mut Criterion, name: &str) {
     let doc = Doc::new();
-    let txt = doc.get_text("text");
+    let txt = doc.get_or_insert_text("text");
     let mut buf = Vec::with_capacity(400 * 1024);
     let mut f = std::fs::File::open("./yrs/benches/input/b4-update.bin").unwrap();
     std::io::Read::read_to_end(&mut f, &mut buf).unwrap();

--- a/yrs/src/compatibility_tests.rs
+++ b/yrs/src/compatibility_tests.rs
@@ -107,7 +107,7 @@ fn text_insert_delete() {
     let setter = visited.clone();
 
     let mut doc = Doc::new();
-    let txt = doc.get_text("type");
+    let txt = doc.get_or_insert_text("type");
     let _sub = doc.observe_update_v1(move |_, e| {
         let u = Update::decode_v1(&e.update).unwrap();
         for (actual, expected) in u.blocks.blocks().zip(expected_blocks.as_slice()) {
@@ -333,7 +333,7 @@ fn utf32_lib0_v2_decoding() {
         0, 19, 8, 1, 5, 1, 1, 1, 1, 9, 2, 4, 4, 4, 4, 4,
     ];
     let doc = Doc::new();
-    let xml = doc.get_xml_fragment("prosemirror");
+    let xml = doc.get_or_insert_xml_fragment("prosemirror");
     let mut txn = doc.transact_mut();
     let update = Update::decode_v2(data).unwrap();
     txn.apply_update(update);
@@ -382,7 +382,7 @@ fn roundtrip_v2(payload: &[u8], expected: &Vec<BlockCarrier>) {
 #[test]
 fn negative_zero_decoding_v2() {
     let doc = Doc::new();
-    let root = doc.get_map("root");
+    let root = doc.get_or_insert_map("root");
     let mut txn = doc.transact_mut();
 
     root.insert(&mut txn, "sequence", MapPrelim::<bool>::new()); //NOTE: This is how I put nested map.
@@ -405,7 +405,7 @@ fn negative_zero_decoding_v2() {
     let u = Update::decode_v2(&buffer).unwrap();
 
     let doc2 = Doc::new();
-    let root = doc2.get_map("root");
+    let root = doc2.get_or_insert_map("root");
     let mut txn = doc2.transact_mut();
     txn.apply_update(u);
     let actual = root.to_json(&txn);
@@ -440,9 +440,9 @@ fn test_data_set<P: AsRef<std::path::Path>>(path: P) {
     for test_num in 0..test_count {
         let updates_len: u32 = decoder.read_var().unwrap();
         let doc = Doc::new();
-        let txt = doc.get_text("text");
-        let map = doc.get_map("map");
-        let arr = doc.get_array("array");
+        let txt = doc.get_or_insert_text("text");
+        let map = doc.get_or_insert_map("map");
+        let arr = doc.get_or_insert_array("array");
         for _ in 0..updates_len {
             let update = Update::decode_v1(decoder.read_buf().unwrap()).unwrap();
             doc.transact_mut().apply_update(update);

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 /// use yrs::updates::encoder::Encode;
 ///
 /// let doc = Doc::new();
-/// let root = doc.get_text("root-type-name");
+/// let root = doc.get_or_insert_text("root-type-name");
 /// let mut txn = doc.transact_mut(); // all Yrs operations happen in scope of a transaction
 /// root.push(&mut txn, "hello world"); // append text to our collaborative document
 ///
@@ -78,13 +78,13 @@ impl Doc {
     /// collaborative text editing: they expose operations to append and remove chunks of text,
     /// which are free to execute concurrently by multiple peers over remote boundaries.
     ///
-    /// If not structure under defined `name` existed before, it will be created and returned
+    /// If no structure under defined `name` existed before, it will be created and returned
     /// instead.
     ///
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a text (in such case a sequence component of complex data type will be
     /// interpreted as a list of text chunks).
-    pub fn get_text(&self, name: &str) -> TextRef {
+    pub fn get_or_insert_text(&self, name: &str) -> TextRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
@@ -98,13 +98,13 @@ impl Doc {
     /// a JavaScript Object Notation) as well as other shared types (Yrs maps, arrays, text
     /// structures etc.), enabling to construct a complex recursive tree structures.
     ///
-    /// If not structure under defined `name` existed before, it will be created and returned
+    /// If no structure under defined `name` existed before, it will be created and returned
     /// instead.
     ///
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a map (in such case a map component of complex data type will be
     /// interpreted as native map).
-    pub fn get_map(&self, name: &str) -> MapRef {
+    pub fn get_or_insert_map(&self, name: &str) -> MapRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
@@ -117,13 +117,13 @@ impl Doc {
     /// storing a sequences of elements in ordered manner, positioning given element accordingly
     /// to its index.
     ///
-    /// If not structure under defined `name` existed before, it will be created and returned
+    /// If no structure under defined `name` existed before, it will be created and returned
     /// instead.
     ///
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as an array (in such case a sequence component of complex data type will be
     /// interpreted as a list of inserted values).
-    pub fn get_array(&self, name: &str) -> ArrayRef {
+    pub fn get_or_insert_array(&self, name: &str) -> ArrayRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
@@ -137,14 +137,14 @@ impl Doc {
     /// as well as other nested XML elements or text values, which are stored in their insertion
     /// order.
     ///
-    /// If not structure under defined `name` existed before, it will be created and returned
+    /// If no structure under defined `name` existed before, it will be created and returned
     /// instead.
     ///
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a XML element (in such case a map component of complex data type will be
     /// interpreted as map of its attributes, while a sequence component - as a list of its child
     /// XML nodes).
-    pub fn get_xml_fragment(&self, name: &str) -> XmlFragmentRef {
+    pub fn get_or_insert_xml_fragment(&self, name: &str) -> XmlFragmentRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
@@ -158,14 +158,14 @@ impl Doc {
     /// as well as other nested XML elements or text values, which are stored in their insertion
     /// order.
     ///
-    /// If not structure under defined `name` existed before, it will be created and returned
+    /// If no structure under defined `name` existed before, it will be created and returned
     /// instead.
     ///
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a XML element (in such case a map component of complex data type will be
     /// interpreted as map of its attributes, while a sequence component - as a list of its child
     /// XML nodes).
-    pub fn get_xml_element(&self, name: &str) -> XmlElementRef {
+    pub fn get_or_insert_xml_element(&self, name: &str) -> XmlElementRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
@@ -178,13 +178,13 @@ impl Doc {
     /// for collaborative text editing: they expose operations to append and remove chunks of text,
     /// which are free to execute concurrently by multiple peers over remote boundaries.
     ///
-    /// If not structure under defined `name` existed before, it will be created and returned
+    /// If no structure under defined `name` existed before, it will be created and returned
     /// instead.
     ///
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a text (in such case a sequence component of complex data type will be
     /// interpreted as a list of text chunks).
-    pub fn get_xml_text(&self, name: &str) -> XmlTextRef {
+    pub fn get_or_insert_xml_text(&self, name: &str) -> XmlTextRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
@@ -446,7 +446,7 @@ mod test {
             198, 5, 0, 1, 49, 68, 227, 214, 245, 198, 5, 1, 1, 50, 0,
         ];
         let doc = Doc::new();
-        let txt = doc.get_text("type");
+        let txt = doc.get_or_insert_text("type");
         let mut txn = doc.transact_mut();
         txn.apply_update(Update::decode_v1(update).unwrap());
 
@@ -473,7 +473,7 @@ mod test {
             48, 49, 50, 4, 65, 1, 1, 1, 0, 0, 1, 3, 0, 0,
         ];
         let doc = Doc::new();
-        let txt = doc.get_text("type");
+        let txt = doc.get_or_insert_text("type");
         let mut txn = doc.transact_mut();
         txn.apply_update(Update::decode_v2(update).unwrap());
 
@@ -484,7 +484,7 @@ mod test {
     #[test]
     fn encode_basic() {
         let doc = Doc::with_client_id(1490905955);
-        let txt = doc.get_text("type");
+        let txt = doc.get_or_insert_text("type");
         let mut t = doc.transact_mut();
         txt.insert(&mut t, 0, "0");
         txt.insert(&mut t, 0, "1");
@@ -502,7 +502,7 @@ mod test {
     fn integrate() {
         // create new document at A and add some initial text to it
         let d1 = Doc::new();
-        let txt = d1.get_text("test");
+        let txt = d1.get_or_insert_text("test");
         let mut t1 = d1.transact_mut();
         // Question: why YText.insert uses positions of blocks instead of actual cursor positions
         // in text as seen by user?
@@ -514,7 +514,7 @@ mod test {
 
         // create document at B
         let d2 = Doc::new();
-        let txt = d2.get_text("test");
+        let txt = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
         let sv = t2.state_vector().encode_v1();
 
@@ -549,7 +549,7 @@ mod test {
                 c.set(c.get() + block.len());
             }
         });
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
         {
             txt.insert(&mut txn, 0, "abc");
@@ -575,7 +575,7 @@ mod test {
     #[test]
     fn pending_update_integration() {
         let doc = Doc::new();
-        let txt = doc.get_text("source");
+        let txt = doc.get_or_insert_text("source");
 
         let updates = [
             vec![
@@ -628,7 +628,7 @@ mod test {
     #[test]
     fn ypy_issue_32() {
         let d1 = Doc::with_client_id(1971027812);
-        let source_1 = d1.get_text("source");
+        let source_1 = d1.get_or_insert_text("source");
         source_1.push(&mut d1.transact_mut(), "a");
 
         let updates = [
@@ -660,7 +660,7 @@ mod test {
         assert_eq!("a", source_1.get_string(&source_1.transact()));
 
         let d2 = Doc::new();
-        let source_2 = d2.get_text("source");
+        let source_2 = d2.get_or_insert_text("source");
         let state_2 = d2.transact().state_vector().encode_v1();
         let update = d1
             .transact()
@@ -679,7 +679,7 @@ mod test {
         assert_eq!("ab", source_1.get_string(&source_1.transact()));
 
         let d3 = Doc::new();
-        let source_3 = d3.get_text("source");
+        let source_3 = d3.get_or_insert_text("source");
         let state_3 = d3.transact().state_vector().encode_v1();
         let state_3 = StateVector::decode_v1(&state_3).unwrap();
         let update = d1.transact().encode_state_as_update_v1(&state_3);
@@ -693,7 +693,7 @@ mod test {
     fn observe_transaction_cleanup() {
         // Setup
         let mut doc = Doc::new();
-        let text = doc.get_text("test");
+        let text = doc.get_or_insert_text("test");
         let before_state = Rc::new(Cell::new(StateVector::default()));
         let after_state = Rc::new(Cell::new(StateVector::default()));
         let delete_set = Rc::new(Cell::new(DeleteSet::default()));
@@ -737,14 +737,14 @@ mod test {
     #[test]
     fn partially_duplicated_update() {
         let d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("text");
+        let txt1 = d1.get_or_insert_text("text");
         txt1.insert(&mut d1.transact_mut(), 0, "hello");
         let u = d1
             .transact()
             .encode_state_as_update_v1(&StateVector::default());
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("text");
+        let txt2 = d2.get_or_insert_text("text");
         d2.transact_mut()
             .apply_update(Update::decode_v1(&u).unwrap());
 
@@ -766,7 +766,7 @@ mod test {
         const INPUT: &'static str = "hello";
 
         let mut d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("text");
+        let txt1 = d1.get_or_insert_text("text");
         let acc = Rc::new(RefCell::new(String::new()));
 
         let a = acc.clone();
@@ -839,7 +839,7 @@ mod test {
         let update = Update::decode_v2(bin).unwrap();
         doc.transact_mut().apply_update(update);
 
-        let root = doc.get_map("root");
+        let root = doc.get_or_insert_map("root");
         let actual = root.to_json(&doc.transact());
         let expected = Any::from_json(
             r#"{
@@ -865,7 +865,7 @@ mod test {
         options.skip_gc = true;
 
         let d1 = Doc::with_options(options);
-        let txt1 = d1.get_text("text");
+        let txt1 = d1.get_or_insert_text("text");
         txt1.insert(&mut d1.transact_mut(), 0, "hello");
         let snapshot = d1.transact_mut().snapshot();
         txt1.insert(&mut d1.transact_mut(), 5, " world");
@@ -877,7 +877,7 @@ mod test {
         let update = encoder.to_vec();
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("text");
+        let txt2 = d2.get_or_insert_text("text");
         d2.transact_mut()
             .apply_update(Update::decode_v1(&update).unwrap());
 
@@ -1091,10 +1091,10 @@ mod test {
     fn root_refs() {
         let doc = Doc::new();
         {
-            let _txt = doc.get_text("text");
-            let _array = doc.get_array("array");
-            let _map = doc.get_map("map");
-            let _xml_elem = doc.get_xml_fragment("xml_elem");
+            let _txt = doc.get_or_insert_text("text");
+            let _array = doc.get_or_insert_array("array");
+            let _map = doc.get_or_insert_map("map");
+            let _xml_elem = doc.get_or_insert_xml_fragment("xml_elem");
         }
 
         let txn = doc.transact();
@@ -1117,7 +1117,7 @@ mod test {
         let d3 = Doc::with_client_id(3);
 
         {
-            let root = d1.get_array("array");
+            let root = d1.get_or_insert_array("array");
             let mut txn = d1.transact_mut();
             root.push_back(&mut txn, ArrayPrelim::from(["A"]));
         }
@@ -1125,7 +1125,7 @@ mod test {
         exchange_updates(&[&d1, &d2, &d3]);
 
         {
-            let root = d2.get_array("array");
+            let root = d2.get_or_insert_array("array");
             let mut t2 = d2.transact_mut();
             root.remove(&mut t2, 0);
             d1.transact_mut()
@@ -1133,7 +1133,7 @@ mod test {
         }
 
         {
-            let root = d3.get_array("array");
+            let root = d3.get_or_insert_array("array");
             let mut t3 = d3.transact_mut();
             let a3 = root.get(&t3, 0).unwrap().to_yarray().unwrap();
             a3.push_back(&mut t3, "B");
@@ -1144,9 +1144,9 @@ mod test {
 
         exchange_updates(&[&d1, &d2, &d3]);
 
-        let r1 = d1.get_array("array").to_json(&d1.transact());
-        let r2 = d2.get_array("array").to_json(&d2.transact());
-        let r3 = d3.get_array("array").to_json(&d3.transact());
+        let r1 = d1.get_or_insert_array("array").to_json(&d1.transact());
+        let r2 = d2.get_or_insert_array("array").to_json(&d2.transact());
+        let r3 = d3.get_or_insert_array("array").to_json(&d3.transact());
 
         assert_eq!(r1, r2);
         assert_eq!(r2, r3);

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -98,8 +98,8 @@ impl TestConnector {
         let mut tc = Self::with_rng(rng);
         for client_id in 0..peer_num {
             let peer = tc.create_peer(client_id as ClientID);
-            peer.doc.get_text("text");
-            peer.doc.get_map("map");
+            peer.doc.get_or_insert_text("text");
+            peer.doc.get_or_insert_map("map");
         }
         tc.sync_all();
         tc

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -78,6 +78,101 @@ pub trait ReadTxn: Sized {
         let store = self.store();
         RootRefs(store.types.iter())
     }
+
+    /// Returns a [TextRef] data structure stored under a given `name`. Text structures are used for
+    /// collaborative text editing: they expose operations to append and remove chunks of text,
+    /// which are free to execute concurrently by multiple peers over remote boundaries.
+    ///
+    /// If not structure under defined `name` existed before, [None] will be returned.
+    ///
+    /// If a structure under defined `name` already existed, but its type was different it will be
+    /// reinterpreted as a text (in such case a sequence component of complex data type will be
+    /// interpreted as a list of text chunks).
+    fn get_text(&self, name: &str) -> Option<TextRef> {
+        let store = self.store();
+        let branch = store.get_type(name)?;
+        Some(TextRef::from(branch))
+    }
+
+    /// Returns an [ArrayRef] data structure stored under a given `name`. Array structures are used for
+    /// storing a sequences of elements in ordered manner, positioning given element accordingly
+    /// to its index.
+    ///
+    /// If not structure under defined `name` existed before, [None] will be returned.
+    ///
+    /// If a structure under defined `name` already existed, but its type was different it will be
+    /// reinterpreted as an array (in such case a sequence component of complex data type will be
+    /// interpreted as a list of inserted values).
+    fn get_array(&self, name: &str) -> Option<ArrayRef> {
+        let store = self.store();
+        let branch = store.get_type(name)?;
+        Some(ArrayRef::from(branch))
+    }
+
+    /// Returns a [MapRef] data structure stored under a given `name`. Maps are used to store key-value
+    /// pairs associated together. These values can be primitive data (similar but not limited to
+    /// a JavaScript Object Notation) as well as other shared types (Yrs maps, arrays, text
+    /// structures etc.), enabling to construct a complex recursive tree structures.
+    ///
+    /// If not structure under defined `name` existed before, [None] will be returned.
+    ///
+    /// If a structure under defined `name` already existed, but its type was different it will be
+    /// reinterpreted as a map (in such case a map component of complex data type will be
+    /// interpreted as native map).
+    fn get_map(&self, name: &str) -> Option<MapRef> {
+        let store = self.store();
+        let branch = store.get_type(name)?;
+        Some(MapRef::from(branch))
+    }
+
+    /// Returns a [XmlFragmentRef] data structure stored under a given `name`. XML elements represent
+    /// nodes of XML document. They can contain attributes (key-value pairs, both of string type)
+    /// as well as other nested XML elements or text values, which are stored in their insertion
+    /// order.
+    ///
+    /// If not structure under defined `name` existed before, [None] will be returned.
+    ///
+    /// If a structure under defined `name` already existed, but its type was different it will be
+    /// reinterpreted as a XML element (in such case a map component of complex data type will be
+    /// interpreted as map of its attributes, while a sequence component - as a list of its child
+    /// XML nodes).
+    fn get_xml_fragment(&self, name: &str) -> Option<XmlFragmentRef> {
+        let store = self.store();
+        let branch = store.get_type(name)?;
+        Some(XmlFragmentRef::from(branch))
+    }
+
+    /// Returns a [XmlElementRef] data structure stored under a given `name`. XML elements represent
+    /// nodes of XML document. They can contain attributes (key-value pairs, both of string type)
+    /// as well as other nested XML elements or text values, which are stored in their insertion
+    /// order.
+    ///
+    /// If not structure under defined `name` existed before, [None] will be returned.
+    ///
+    /// If a structure under defined `name` already existed, but its type was different it will be
+    /// reinterpreted as a XML element (in such case a map component of complex data type will be
+    /// interpreted as map of its attributes, while a sequence component - as a list of its child
+    /// XML nodes).
+    fn get_xml_element(&self, name: &str) -> Option<XmlElementRef> {
+        let store = self.store();
+        let branch = store.get_type(name)?;
+        Some(XmlElementRef::from(branch))
+    }
+
+    /// Returns a [XmlTextRef] data structure stored under a given `name`. Text structures are used
+    /// for collaborative text editing: they expose operations to append and remove chunks of text,
+    /// which are free to execute concurrently by multiple peers over remote boundaries.
+    ///
+    /// If not structure under defined `name` existed before, [None] will be returned.
+    ///
+    /// If a structure under defined `name` already existed, but its type was different it will be
+    /// reinterpreted as a text (in such case a sequence component of complex data type will be
+    /// interpreted as a list of text chunks).
+    fn get_xml_text(&self, name: &str) -> Option<XmlTextRef> {
+        let store = self.store();
+        let branch = store.get_type(name)?;
+        Some(XmlTextRef::from(branch))
+    }
 }
 
 pub trait WriteTxn: Sized {

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -367,11 +367,11 @@ mod test {
     #[test]
     fn map_basic() {
         let d1 = Doc::with_client_id(1);
-        let m1 = d1.get_map("map");
+        let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
         let d2 = Doc::with_client_id(2);
-        let m2 = d2.get_map("map");
+        let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
         m1.insert(&mut t1, "number".to_owned(), 1);
@@ -426,7 +426,7 @@ mod test {
     #[test]
     fn map_get_set() {
         let d1 = Doc::with_client_id(1);
-        let m1 = d1.get_map("map");
+        let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
         m1.insert(&mut t1, "stuff".to_owned(), "stuffy");
@@ -435,7 +435,7 @@ mod test {
         let update = t1.encode_state_as_update_v1(&StateVector::default());
 
         let d2 = Doc::with_client_id(2);
-        let m2 = d2.get_map("map");
+        let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
         t2.apply_update(Update::decode_v1(update.as_slice()).unwrap());
@@ -450,11 +450,11 @@ mod test {
     #[test]
     fn map_get_set_sync_with_conflicts() {
         let d1 = Doc::with_client_id(1);
-        let m1 = d1.get_map("map");
+        let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
         let d2 = Doc::with_client_id(2);
-        let m2 = d2.get_map("map");
+        let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
         m1.insert(&mut t1, "stuff".to_owned(), "c0");
@@ -473,7 +473,7 @@ mod test {
     #[test]
     fn map_len_remove() {
         let d1 = Doc::with_client_id(1);
-        let m1 = d1.get_map("map");
+        let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
         let key1 = "stuff".to_owned();
@@ -499,7 +499,7 @@ mod test {
     #[test]
     fn map_clear() {
         let d1 = Doc::with_client_id(1);
-        let m1 = d1.get_map("map");
+        let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
         m1.insert(&mut t1, "key1".to_owned(), "c0");
@@ -511,7 +511,7 @@ mod test {
         assert_eq!(m1.get(&t1, &"key2".to_owned()), None);
 
         let d2 = Doc::with_client_id(2);
-        let m2 = d2.get_map("map");
+        let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
         let u1 = t1.encode_state_as_update_v1(&StateVector::default());
@@ -530,9 +530,9 @@ mod test {
         let d4 = Doc::with_client_id(4);
 
         {
-            let m1 = d1.get_map("map");
-            let m2 = d2.get_map("map");
-            let m3 = d3.get_map("map");
+            let m1 = d1.get_or_insert_map("map");
+            let m2 = d2.get_or_insert_map("map");
+            let m3 = d3.get_or_insert_map("map");
 
             let mut t1 = d1.transact_mut();
             let mut t2 = d2.transact_mut();
@@ -547,9 +547,9 @@ mod test {
         exchange_updates(&[&d1, &d2, &d3, &d4]);
 
         {
-            let m1 = d1.get_map("map");
-            let m2 = d2.get_map("map");
-            let m3 = d3.get_map("map");
+            let m1 = d1.get_or_insert_map("map");
+            let m2 = d2.get_or_insert_map("map");
+            let m3 = d3.get_or_insert_map("map");
 
             let mut t1 = d1.transact_mut();
             let mut t2 = d2.transact_mut();
@@ -565,7 +565,7 @@ mod test {
         exchange_updates(&[&d1, &d2, &d3, &d4]);
 
         for doc in [d1, d2, d3, d4] {
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
 
             assert_eq!(
                 map.get(&map.transact(), &"key1".to_owned()),
@@ -595,9 +595,9 @@ mod test {
         let d3 = Doc::with_client_id(3);
 
         {
-            let m1 = d1.get_map("map");
-            let m2 = d2.get_map("map");
-            let m3 = d3.get_map("map");
+            let m1 = d1.get_or_insert_map("map");
+            let m2 = d2.get_or_insert_map("map");
+            let m3 = d3.get_or_insert_map("map");
 
             let mut t1 = d1.transact_mut();
             let mut t2 = d2.transact_mut();
@@ -612,7 +612,7 @@ mod test {
         exchange_updates(&[&d1, &d2, &d3]);
 
         for doc in [d1, d2, d3] {
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
 
             assert_eq!(
                 map.get(&map.transact(), &"stuff".to_owned()),
@@ -631,9 +631,9 @@ mod test {
         let d4 = Doc::with_client_id(4);
 
         {
-            let m1 = d1.get_map("map");
-            let m2 = d2.get_map("map");
-            let m3 = d3.get_map("map");
+            let m1 = d1.get_or_insert_map("map");
+            let m2 = d2.get_or_insert_map("map");
+            let m3 = d3.get_or_insert_map("map");
 
             let mut t1 = d1.transact_mut();
             let mut t2 = d2.transact_mut();
@@ -648,10 +648,10 @@ mod test {
         exchange_updates(&[&d1, &d2, &d3, &d4]);
 
         {
-            let m1 = d1.get_map("map");
-            let m2 = d2.get_map("map");
-            let m3 = d3.get_map("map");
-            let m4 = d4.get_map("map");
+            let m1 = d1.get_or_insert_map("map");
+            let m2 = d2.get_or_insert_map("map");
+            let m3 = d3.get_or_insert_map("map");
+            let m4 = d4.get_or_insert_map("map");
 
             let mut t1 = d1.transact_mut();
             let mut t2 = d2.transact_mut();
@@ -668,7 +668,7 @@ mod test {
         exchange_updates(&[&d1, &d2, &d3, &d4]);
 
         for doc in [d1, d2, d3, d4] {
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
 
             assert_eq!(
                 map.get(&map.transact(), &"key1".to_owned()),
@@ -682,7 +682,7 @@ mod test {
     #[test]
     fn insert_and_remove_events() {
         let d1 = Doc::with_client_id(1);
-        let mut m1 = d1.get_map("map");
+        let mut m1 = d1.get_or_insert_map("map");
 
         let entries = Rc::new(RefCell::new(None));
         let entries_c = entries.clone();
@@ -769,7 +769,7 @@ mod test {
 
         // copy updates over
         let d2 = Doc::with_client_id(2);
-        let mut m2 = d2.get_map("map");
+        let mut m2 = d2.get_or_insert_map("map");
 
         let entries = Rc::new(RefCell::new(None));
         let entries_c = entries.clone();
@@ -806,7 +806,7 @@ mod test {
 
     fn map_transactions() -> [Box<dyn Fn(&mut Doc, &mut StdRng)>; 3] {
         fn set(doc: &mut Doc, rng: &mut StdRng) {
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
             let mut txn = doc.transact_mut();
             let key = ["one", "two"].choose(rng).unwrap();
             let value: String = random_string(rng);
@@ -814,7 +814,7 @@ mod test {
         }
 
         fn set_type(doc: &mut Doc, rng: &mut StdRng) {
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
             let mut txn = doc.transact_mut();
             let key = ["one", "two", "three"].choose(rng).unwrap();
             if rng.gen_bool(0.33) {
@@ -839,7 +839,7 @@ mod test {
         }
 
         fn delete(doc: &mut Doc, rng: &mut StdRng) {
-            let map = doc.get_map("map");
+            let map = doc.get_or_insert_map("map");
             let mut txn = doc.transact_mut();
             let key = ["one", "two"].choose(rng).unwrap();
             map.remove(&mut txn, key);
@@ -859,7 +859,7 @@ mod test {
     #[test]
     fn observe_deep() {
         let doc = Doc::with_client_id(1);
-        let mut map = doc.get_map("map");
+        let mut map = doc.get_or_insert_map("map");
 
         let paths = Rc::new(RefCell::new(vec![]));
         let calls = Rc::new(RefCell::new(0));
@@ -930,7 +930,7 @@ mod test {
                 sleep(Duration::from_millis(millis));
 
                 let doc = d2.write().unwrap();
-                let map = doc.get_map("test");
+                let map = doc.get_or_insert_map("test");
                 let mut txn = doc.transact_mut();
                 map.insert(&mut txn, "key", 1);
             }
@@ -943,7 +943,7 @@ mod test {
                 sleep(Duration::from_millis(millis));
 
                 let doc = d3.write().unwrap();
-                let map = doc.get_map("test");
+                let map = doc.get_or_insert_map("test");
                 let mut txn = doc.transact_mut();
                 map.insert(&mut txn, "key", 2);
             }
@@ -953,7 +953,7 @@ mod test {
         h2.join().unwrap();
 
         let doc = doc.read().unwrap();
-        let map = doc.get_map("test");
+        let map = doc.get_or_insert_map("test");
         let txn = doc.transact();
         let value = map.get(&txn, "key").unwrap().to_json(&txn);
 

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1057,7 +1057,7 @@ mod test {
     #[test]
     fn insert_empty_string() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         assert_eq!(txt.get_string(&txn).as_str(), "");
@@ -1073,7 +1073,7 @@ mod test {
     #[test]
     fn append_single_character_blocks() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "a");
@@ -1086,7 +1086,7 @@ mod test {
     #[test]
     fn append_mutli_character_blocks() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "hello");
@@ -1099,7 +1099,7 @@ mod test {
     #[test]
     fn prepend_single_character_blocks() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "a");
@@ -1112,7 +1112,7 @@ mod test {
     #[test]
     fn prepend_mutli_character_blocks() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "hello");
@@ -1125,7 +1125,7 @@ mod test {
     #[test]
     fn insert_after_block() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "hello");
@@ -1139,7 +1139,7 @@ mod test {
     #[test]
     fn insert_inside_of_block() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "it was expected");
@@ -1151,13 +1151,13 @@ mod test {
     #[test]
     fn insert_concurrent_root() {
         let d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("test");
+        let txt1 = d1.get_or_insert_text("test");
         let mut t1 = d1.transact_mut();
 
         txt1.insert(&mut t1, 0, "hello ");
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("test");
+        let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
 
         txt2.insert(&mut t2, 0, "world");
@@ -1181,14 +1181,14 @@ mod test {
     #[test]
     fn insert_concurrent_in_the_middle() {
         let d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("test");
+        let txt1 = d1.get_or_insert_text("test");
         let mut t1 = d1.transact_mut();
 
         txt1.insert(&mut t1, 0, "I expect that");
         assert_eq!(txt1.get_string(&t1).as_str(), "I expect that");
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("test");
+        let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
 
         let d2_sv = t2.state_vector().encode_v1();
@@ -1221,14 +1221,14 @@ mod test {
     #[test]
     fn append_concurrent() {
         let d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("test");
+        let txt1 = d1.get_or_insert_text("test");
         let mut t1 = d1.transact_mut();
 
         txt1.insert(&mut t1, 0, "aaa");
         assert_eq!(txt1.get_string(&t1).as_str(), "aaa");
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("test");
+        let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
 
         let d2_sv = t2.state_vector().encode_v1();
@@ -1262,7 +1262,7 @@ mod test {
     #[test]
     fn delete_single_block_start() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "bbb");
@@ -1276,7 +1276,7 @@ mod test {
     #[test]
     fn delete_single_block_end() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "bbb");
@@ -1289,7 +1289,7 @@ mod test {
     #[test]
     fn delete_multiple_whole_blocks() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "a");
@@ -1309,7 +1309,7 @@ mod test {
     #[test]
     fn delete_slice_of_block() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "abc");
@@ -1321,7 +1321,7 @@ mod test {
     #[test]
     fn delete_multiple_blocks_with_slicing() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "hello ");
@@ -1335,7 +1335,7 @@ mod test {
     #[test]
     fn insert_after_delete() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "hello ");
@@ -1348,7 +1348,7 @@ mod test {
     #[test]
     fn concurrent_insert_delete() {
         let d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("test");
+        let txt1 = d1.get_or_insert_text("test");
         let mut t1 = d1.transact_mut();
 
         txt1.insert(&mut t1, 0, "hello world");
@@ -1357,7 +1357,7 @@ mod test {
         let u1 = t1.encode_state_as_update_v1(&StateVector::default());
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("test");
+        let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
         assert_eq!(txt2.get_string(&t2).as_str(), "hello world");
@@ -1390,7 +1390,7 @@ mod test {
     #[test]
     fn insert_and_remove_event_changes() {
         let d1 = Doc::with_client_id(1);
-        let mut txt = d1.get_text("text");
+        let mut txt = d1.get_or_insert_text("text");
         let delta = Rc::new(RefCell::new(None));
         let delta_c = delta.clone();
         let _sub = txt.observe(move |txn, e| {
@@ -1432,7 +1432,7 @@ mod test {
 
         // replicate data to another peer
         let d2 = Doc::with_client_id(2);
-        let mut txt = d2.get_text("text");
+        let mut txt = d2.get_or_insert_text("text");
         let delta_c = delta.clone();
         let _sub = txt.observe(move |txn, e| {
             *delta_c.borrow_mut() = Some(e.delta(txn).to_vec());
@@ -1459,7 +1459,7 @@ mod test {
         let mut options = Options::with_client_id(1);
         options.offset_kind = OffsetKind::Utf32;
         let doc = Doc::with_options(options);
-        let txt = doc.get_text("content");
+        let txt = doc.get_or_insert_text("content");
 
         txt.insert(&mut doc.transact_mut(), 0, r#"“”"#); // these chars are 3B long each
         txt.insert(&mut doc.transact_mut(), 1, r#"test"#);
@@ -1474,14 +1474,14 @@ mod test {
             options.offset_kind = OffsetKind::Utf32;
             Doc::with_options(options)
         };
-        let txt1 = d1.get_text("test");
+        let txt1 = d1.get_or_insert_text("test");
 
         let d2 = {
             let mut options = Options::with_client_id(2);
             options.offset_kind = OffsetKind::Bytes;
             Doc::with_options(options)
         };
-        let txt2 = d2.get_text("test");
+        let txt2 = d2.get_or_insert_text("test");
 
         {
             let mut txn = d1.transact_mut();
@@ -1519,7 +1519,7 @@ mod test {
 
     fn text_transactions() -> [Box<dyn Fn(&mut Doc, &mut StdRng)>; 2] {
         fn insert_text(doc: &mut Doc, rng: &mut StdRng) {
-            let ytext = doc.get_text("text");
+            let ytext = doc.get_or_insert_text("text");
             let mut txn = doc.transact_mut();
             let pos = rng.between(0, ytext.len(&txn));
             let word = rng.random_string();
@@ -1527,7 +1527,7 @@ mod test {
         }
 
         fn delete_text(doc: &mut Doc, rng: &mut StdRng) {
-            let ytext = doc.get_text("text");
+            let ytext = doc.get_or_insert_text("text");
             let mut txn = doc.transact_mut();
             let len = ytext.len(&txn);
             if len > 0 {
@@ -1552,7 +1552,7 @@ mod test {
     #[test]
     fn basic_format() {
         let d1 = Doc::with_client_id(1);
-        let mut txt1 = d1.get_text("text");
+        let mut txt1 = d1.get_or_insert_text("text");
 
         let delta1 = Rc::new(RefCell::new(None));
         let delta_clone = delta1.clone();
@@ -1561,7 +1561,7 @@ mod test {
         });
 
         let d2 = Doc::with_client_id(2);
-        let mut txt2 = d2.get_text("text");
+        let mut txt2 = d2.get_or_insert_text("text");
 
         let delta2 = Rc::new(RefCell::new(None));
         let delta_clone = delta2.clone();
@@ -1732,7 +1732,7 @@ mod test {
     #[test]
     fn embed_with_attributes() {
         let d1 = Doc::with_client_id(1);
-        let mut txt1 = d1.get_text("text");
+        let mut txt1 = d1.get_or_insert_text("text");
 
         let delta1 = Rc::new(RefCell::new(None));
         let delta_clone = delta1.clone();
@@ -1777,7 +1777,7 @@ mod test {
     #[test]
     fn issue_101() {
         let d1 = Doc::with_client_id(1);
-        let mut txt1 = d1.get_text("text");
+        let mut txt1 = d1.get_or_insert_text("text");
         let delta = Rc::new(RefCell::new(None));
         let delta_copy = delta.clone();
 
@@ -1815,21 +1815,21 @@ mod test {
         let text2 = r#"test"#;
 
         {
-            let text = doc.get_text("content");
+            let text = doc.get_or_insert_text("content");
             let mut txn = doc.transact_mut();
             text.insert(&mut txn, 0, text1);
             txn.commit();
         }
 
         {
-            let text = doc.get_text("content");
+            let text = doc.get_or_insert_text("content");
             let mut txn = doc.transact_mut();
             text.insert(&mut txn, 100, text2);
             txn.commit();
         }
 
         {
-            let mut text = doc.get_text("content");
+            let mut text = doc.get_or_insert_text("content");
             let mut txn = doc.transact_mut();
 
             let c1 = text1.chars().count();
@@ -1846,7 +1846,7 @@ mod test {
         }
 
         {
-            let text = doc.get_text("content");
+            let text = doc.get_or_insert_text("content");
             assert_eq!(text.get_string(&text.transact()), "");
         }
     }
@@ -1854,7 +1854,7 @@ mod test {
     #[test]
     fn text_diff_adjacent() {
         let doc = Doc::with_client_id(1);
-        let txt = doc.get_text("text");
+        let txt = doc.get_or_insert_text("text");
         let mut txn = doc.transact_mut();
         let attrs1 = Attrs::from([("a".into(), "a".into())]);
         txt.insert_with_attributes(&mut txn, 0, "abc", attrs1.clone());
@@ -1872,7 +1872,7 @@ mod test {
     #[test]
     fn text_remove_4_byte_range() {
         let d1 = Doc::new();
-        let txt = d1.get_text("test");
+        let txt = d1.get_or_insert_text("test");
 
         txt.insert(&mut d1.transact_mut(), 0, "😭😊");
 
@@ -1883,14 +1883,14 @@ mod test {
         assert_eq!(txt.get_string(&txt.transact()).as_str(), "😊");
 
         exchange_updates(&[&d1, &d2]);
-        let txt = d2.get_text("test");
+        let txt = d2.get_or_insert_text("test");
         assert_eq!(txt.get_string(&txt.transact()).as_str(), "😊");
     }
 
     #[test]
     fn text_remove_3_byte_range() {
         let d1 = Doc::new();
-        let txt = d1.get_text("test");
+        let txt = d1.get_or_insert_text("test");
 
         txt.insert(&mut d1.transact_mut(), 0, "⏰⏳");
 
@@ -1901,13 +1901,13 @@ mod test {
         assert_eq!(txt.get_string(&txt.transact()).as_str(), "⏳");
 
         exchange_updates(&[&d1, &d2]);
-        let txt = d2.get_text("test");
+        let txt = d2.get_or_insert_text("test");
         assert_eq!(txt.get_string(&txt.transact()).as_str(), "⏳");
     }
     #[test]
     fn delete_4_byte_character_from_middle() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "😊😭");
@@ -1921,7 +1921,7 @@ mod test {
     #[test]
     fn delete_3_byte_character_from_middle_1() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "⏰⏳");
@@ -1935,7 +1935,7 @@ mod test {
     #[test]
     fn delete_3_byte_character_from_middle_2() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "👯🙇‍♀️🙇‍♀️⏰👩‍❤️‍💋‍👨");
@@ -1954,7 +1954,7 @@ mod test {
     #[test]
     fn delete_3_byte_character_from_middle_after_insert_and_format() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "🙇‍♀️🙇‍♀️⏰👩‍❤️‍💋‍👨");
@@ -1975,7 +1975,7 @@ mod test {
     #[test]
     fn delete_multi_byte_character_from_middle_after_insert_and_format() {
         let doc = Doc::with_client_id(1);
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         txt.insert(&mut txn, 0, "❤️❤️🙇‍♀️🙇‍♀️⏰👩‍❤️‍💋‍👨👩‍❤️‍💋‍👨");
@@ -2004,7 +2004,7 @@ mod test {
     #[test]
     fn insert_string_with_no_attribute() {
         let doc = Doc::new();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let mut txn = doc.transact_mut();
 
         let attrs = Attrs::from([("a".into(), "a".into())]);
@@ -2023,7 +2023,7 @@ mod test {
     #[test]
     fn snapshots() {
         let doc = Doc::with_client_id(1);
-        let text = doc.get_text("text");
+        let text = doc.get_or_insert_text("text");
         text.insert(&mut doc.transact_mut(), 0, "hello");
         let prev = doc.transact_mut().snapshot();
         text.insert(&mut doc.transact_mut(), 5, " world");
@@ -2063,7 +2063,7 @@ mod test {
                 sleep(Duration::from_millis(millis));
 
                 let doc = d2.write().unwrap();
-                let txt = doc.get_text("test");
+                let txt = doc.get_or_insert_text("test");
                 let mut txn = doc.transact_mut();
                 txt.push(&mut txn, "a");
             }
@@ -2076,7 +2076,7 @@ mod test {
                 sleep(Duration::from_millis(millis));
 
                 let doc = d3.write().unwrap();
-                let txt = doc.get_text("test");
+                let txt = doc.get_or_insert_text("test");
                 let mut txn = txt.transact_mut();
                 txt.push(&mut txn, "b");
             }
@@ -2086,7 +2086,7 @@ mod test {
         h2.join().unwrap();
 
         let doc = doc.read().unwrap();
-        let txt = doc.get_text("test");
+        let txt = doc.get_or_insert_text("test");
         let len = txt.len(&doc.transact());
         assert_eq!(len, 20);
     }

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -674,7 +674,7 @@ pub trait XmlFragment: AsRef<Branch> {
     /// use yrs::{Doc, Text, Xml, XmlNode, Transact, XmlFragment, XmlElementPrelim, XmlTextPrelim, GetString};
     ///
     /// let doc = Doc::new();
-    /// let mut html = doc.get_xml_fragment("div");
+    /// let mut html = doc.get_or_insert_xml_fragment("div");
     /// let mut txn = doc.transact_mut();
     /// let p = html.push_back(&mut txn, XmlElementPrelim::empty("p"));
     /// let txt = p.push_back(&mut txn, XmlTextPrelim("Hello "));
@@ -1039,14 +1039,14 @@ mod test {
     #[test]
     fn insert_attribute() {
         let d1 = Doc::with_client_id(1);
-        let f = d1.get_xml_fragment("xml");
+        let f = d1.get_or_insert_xml_fragment("xml");
         let mut t1 = d1.transact_mut();
         let xml1 = f.push_back(&mut t1, XmlElementPrelim::empty("div"));
         xml1.insert_attribute(&mut t1, "height", 10.to_string());
         assert_eq!(xml1.get_attribute(&t1, "height"), Some("10".to_string()));
 
         let d2 = Doc::with_client_id(1);
-        let f = d2.get_xml_fragment("xml");
+        let f = d2.get_or_insert_xml_fragment("xml");
         let mut t2 = d2.transact_mut();
         let xml2 = f.push_back(&mut t2, XmlElementPrelim::empty("div"));
         let u = t1.encode_state_as_update_v1(&StateVector::default());
@@ -1057,7 +1057,7 @@ mod test {
     #[test]
     fn tree_walker() {
         let doc = Doc::with_client_id(1);
-        let root = doc.get_xml_fragment("xml");
+        let root = doc.get_or_insert_xml_fragment("xml");
         let mut txn = doc.transact_mut();
         /*
             <UNDEFINED>
@@ -1090,7 +1090,7 @@ mod test {
     #[test]
     fn text_attributes() {
         let doc = Doc::with_client_id(1);
-        let f = doc.get_xml_fragment("test");
+        let f = doc.get_or_insert_xml_fragment("test");
         let mut txn = doc.transact_mut();
         let txt = f.push_back(&mut txn, XmlTextPrelim(""));
         txt.insert_attribute(&mut txn, "test", 42.to_string());
@@ -1103,7 +1103,7 @@ mod test {
     #[test]
     fn siblings() {
         let doc = Doc::with_client_id(1);
-        let root = doc.get_xml_fragment("root");
+        let root = doc.get_or_insert_xml_fragment("root");
         let mut txn = doc.transact_mut();
         let first = root.push_back(&mut txn, XmlTextPrelim("hello"));
         let second = root.push_back(&mut txn, XmlElementPrelim::empty("p"));
@@ -1134,7 +1134,7 @@ mod test {
     #[test]
     fn serialization() {
         let d1 = Doc::with_client_id(1);
-        let r1 = d1.get_xml_fragment("root");
+        let r1 = d1.get_or_insert_xml_fragment("root");
         let mut t1 = d1.transact_mut();
         let first = r1.push_back(&mut t1, XmlTextPrelim("hello"));
         r1.push_back(&mut t1, XmlElementPrelim::empty("p"));
@@ -1145,7 +1145,7 @@ mod test {
         let u1 = t1.encode_state_as_update_v1(&StateVector::default());
 
         let d2 = Doc::with_client_id(2);
-        let r2 = d2.get_xml_fragment("root");
+        let r2 = d2.get_or_insert_xml_fragment("root");
         let mut t2 = d2.transact_mut();
 
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
@@ -1155,7 +1155,7 @@ mod test {
     #[test]
     fn serialization_compatibility() {
         let d1 = Doc::with_client_id(1);
-        let r1 = d1.get_xml_fragment("root");
+        let r1 = d1.get_or_insert_xml_fragment("root");
         let mut t1 = d1.transact_mut();
         let first = r1.push_back(&mut t1, XmlTextPrelim("hello"));
         r1.push_back(&mut t1, XmlElementPrelim::empty("p"));
@@ -1183,7 +1183,7 @@ mod test {
     #[test]
     fn event_observers() {
         let d1 = Doc::with_client_id(1);
-        let mut xml = d1.get_xml_element("test");
+        let mut xml = d1.get_or_insert_xml_element("test");
 
         let attributes = Rc::new(RefCell::new(None));
         let nodes = Rc::new(RefCell::new(None));
@@ -1273,7 +1273,7 @@ mod test {
 
         // copy updates over
         let d2 = Doc::with_client_id(2);
-        let mut xml2 = d2.get_xml_element("test");
+        let mut xml2 = d2.get_or_insert_xml_element("test");
 
         let attributes = Rc::new(RefCell::new(None));
         let nodes = Rc::new(RefCell::new(None));
@@ -1311,7 +1311,7 @@ mod test {
     #[test]
     fn xml_text_to_string() {
         let doc = Doc::new();
-        let f = doc.get_xml_fragment("test");
+        let f = doc.get_or_insert_xml_fragment("test");
         let mut txn = doc.transact_mut();
         let text = f.push_back(&mut txn, XmlTextPrelim("hello world"));
         text.format(

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1068,11 +1068,11 @@ mod test {
     #[test]
     fn update_merge() {
         let d1 = Doc::with_client_id(1);
-        let txt1 = d1.get_text("test");
+        let txt1 = d1.get_or_insert_text("test");
         let mut t1 = d1.transact_mut();
 
         let d2 = Doc::with_client_id(2);
-        let txt2 = d2.get_text("test");
+        let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
 
         txt1.insert(&mut t1, 0, "aaa");
@@ -1095,7 +1095,7 @@ mod test {
         let u12 = Update::merge_updates(vec![u1, u2]);
 
         let d3 = Doc::with_client_id(3);
-        let txt3 = d3.get_text("test");
+        let txt3 = d3.get_or_insert_text("test");
         let mut t3 = d3.transact_mut();
         t3.apply_update(u12);
 

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -174,7 +174,7 @@ impl YDoc {
     /// onto `YText` instance.
     #[wasm_bindgen(js_name = getText)]
     pub fn get_text(&mut self, name: &str) -> YText {
-        self.0.get_text(name).into()
+        self.0.get_or_insert_text(name).into()
     }
 
     /// Returns a `YArray` shared data type, that's accessible for subsequent accesses using given
@@ -186,7 +186,7 @@ impl YDoc {
     /// onto `YArray` instance.
     #[wasm_bindgen(js_name = getArray)]
     pub fn get_array(&mut self, name: &str) -> YArray {
-        self.0.get_array(name).into()
+        self.0.get_or_insert_array(name).into()
     }
 
     /// Returns a `YMap` shared data type, that's accessible for subsequent accesses using given
@@ -198,7 +198,7 @@ impl YDoc {
     /// onto `YMap` instance.
     #[wasm_bindgen(js_name = getMap)]
     pub fn get_map(&mut self, name: &str) -> YMap {
-        self.0.get_map(name).into()
+        self.0.get_or_insert_map(name).into()
     }
 
     /// Returns a `YXmlFragment` shared data type, that's accessible for subsequent accesses using
@@ -210,7 +210,7 @@ impl YDoc {
     /// onto `YXmlFragment` instance.
     #[wasm_bindgen(js_name = getXmlFragment)]
     pub fn get_xml_fragment(&mut self, name: &str) -> YXmlFragment {
-        YXmlFragment(self.0.get_xml_fragment(name))
+        YXmlFragment(self.0.get_or_insert_xml_fragment(name))
     }
 
     /// Returns a `YXmlElement` shared data type, that's accessible for subsequent accesses using
@@ -222,7 +222,7 @@ impl YDoc {
     /// onto `YXmlElement` instance.
     #[wasm_bindgen(js_name = getXmlElement)]
     pub fn get_xml_element(&mut self, name: &str) -> YXmlElement {
-        YXmlElement(self.0.get_xml_element(name))
+        YXmlElement(self.0.get_or_insert_xml_element(name))
     }
 
     /// Returns a `YXmlText` shared data type, that's accessible for subsequent accesses using given
@@ -234,7 +234,7 @@ impl YDoc {
     /// onto `YXmlText` instance.
     #[wasm_bindgen(js_name = getXmlText)]
     pub fn get_xml_text(&mut self, name: &str) -> YXmlText {
-        YXmlText(self.0.get_xml_text(name))
+        YXmlText(self.0.get_or_insert_xml_text(name))
     }
 
     /// Subscribes given function to be called any time, a remote update is being applied to this


### PR DESCRIPTION
This PR resolves confusion around root-level type creation:

1. All root level types that were responsible for getting or creating root-level types have changed the naming convention: `Doc::get_*` to `Doc::get_or_insert_*`. Naming convention is taken from Rust standard library (eg. [Option::get_or_insert](https://doc.rust-lang.org/std/option/enum.Option.html#method.get_or_insert_default))
2. Readonly transaction now have read-only accessor for these root-level types. These methods are using a convention of `Transaction::get_{X}(self, name: &str) -> Option<{X}>`. If the type was not defined previously a `None` case will be returned.
3. Yffi has a function to reflect pt. 2 -> `ytype_get` - since yffi function returns an ambiguous branch pointer, it doesn't need to be typed per each Y-type (functions that may create root-level types still exists per each y-type as root-level type creation sets up type-ref flag of that particular type).