### PR TITLE
Fix embeds V2 decoding

### DIFF
--- a/yrs/src/updates/decoder.rs
+++ b/yrs/src/updates/decoder.rs
@@ -349,7 +349,8 @@ impl<'a> Decoder for DecoderV2<'a> {
     }
 
     fn read_json(&mut self) -> Result<Any, Error> {
-        Any::decode(&mut self.cursor)
+        let src = self.read_string()?;
+        Any::from_json(src)
     }
 
     fn read_key(&mut self) -> Result<Rc<str>, Error> {


### PR DESCRIPTION
Embeds are encoded to JSON but read as if there were binary encoded.

```
thread 'types::text::test::embed_with_attributes' panicked at 'Unable to read Any content'
```