### PR TITLE
Enable shared types to be passed into Text::insert_embed

### DIFF
--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -14,6 +14,7 @@
       }
     },
     "../ywasm/pkg": {
+      "name": "ywasm",
       "version": "0.14.1",
       "license": "MIT"
     },

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -7,7 +7,7 @@ use std::ops::Deref;
 use std::os::raw::{c_char, c_float, c_int, c_long, c_longlong, c_uchar, c_uint, c_ulong};
 use std::ptr::{null, null_mut};
 use std::rc::Rc;
-use yrs::block::{ClientID, ItemContent, Prelim};
+use yrs::block::{ClientID, ItemContent, Prelim, Unused};
 use yrs::types::array::ArrayEvent;
 use yrs::types::array::ArrayIter as NativeArrayIter;
 use yrs::types::map::MapEvent;
@@ -2453,7 +2453,7 @@ impl Drop for YInput {
 }
 
 impl Prelim for YInput {
-    type Return = ();
+    type Return = Unused;
 
     fn into_content<'doc>(self, _: &mut yrs::TransactionMut<'doc>) -> (ItemContent, Option<Self>) {
         unsafe {

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1286,10 +1286,10 @@ pub unsafe extern "C" fn ytext_insert_embed(
     let index = index as u32;
     let content: Any = content.read().into();
     if attrs.is_null() {
-        txt.insert_embed(txn, index, content)
+        txt.insert_embed(txn, index, content);
     } else {
         if let Some(attrs) = map_attrs(attrs.read().into()) {
-            txt.insert_embed_with_attributes(txn, index, content, attrs)
+            txt.insert_embed_with_attributes(txn, index, content, attrs);
         } else {
             panic!("ytext_insert_embed: passed attributes are not of map type")
         }
@@ -2193,10 +2193,10 @@ pub unsafe extern "C" fn yxmltext_insert_embed(
     let index = index as u32;
     let content: Any = content.read().into();
     if attrs.is_null() {
-        txt.insert_embed(txn, index, content)
+        txt.insert_embed(txn, index, content);
     } else {
         if let Some(attrs) = map_attrs(attrs.read().into()) {
-            txt.insert_embed_with_attributes(txn, index, content, attrs)
+            txt.insert_embed_with_attributes(txn, index, content, attrs);
         } else {
             panic!("yxmltext_insert_embed: passed attributes are not of map type")
         }
@@ -2453,6 +2453,8 @@ impl Drop for YInput {
 }
 
 impl Prelim for YInput {
+    type Return = ();
+
     fn into_content<'doc>(self, _: &mut yrs::TransactionMut<'doc>) -> (ItemContent, Option<Self>) {
         unsafe {
             if self.tag <= 0 {

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -443,7 +443,7 @@ impl BlockIter {
         }
     }
 
-    pub fn insert_contents<V: Prelim>(&mut self, txn: &mut TransactionMut, value: V) {
+    pub fn insert_contents<V: Prelim>(&mut self, txn: &mut TransactionMut, value: V) -> BlockPtr {
         self.reduce_moves(txn);
         self.split_rel(txn);
         let id = {
@@ -488,6 +488,8 @@ impl BlockIter {
             self.next_item = left;
             self.reached_end = true;
         }
+
+        block_ptr
     }
 
     pub fn insert_move(

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -18,8 +18,9 @@ use lib0::any::Any;
 use lib0::error::Error;
 use rand::Rng;
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fmt::Formatter;
-use std::ops::DerefMut;
+use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -450,6 +451,19 @@ impl std::fmt::Display for Doc {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let options = self.options();
         write!(f, "Doc(id: {}, guid: {})", options.client_id, options.guid)
+    }
+}
+
+impl TryFrom<BlockPtr> for Doc {
+    type Error = BlockPtr;
+
+    fn try_from(value: BlockPtr) -> Result<Self, Self::Error> {
+        if let Block::Item(item) = value.deref() {
+            if let ItemContent::Doc(_, doc) = &item.content {
+                return Ok(doc.clone());
+            }
+        }
+        Err(value)
     }
 }
 
@@ -1538,8 +1552,7 @@ mod test {
         });
         {
             let mut txn = doc.transact_mut();
-            subdocs.insert(&mut txn, "a", doc_a);
-            let doc_a_ref = subdocs.get(&txn, "a").unwrap().to_ydoc().unwrap();
+            let doc_a_ref = subdocs.insert(&mut txn, "a", doc_a);
             doc_a_ref.load(&mut txn);
         }
 
@@ -1602,8 +1615,7 @@ mod test {
         });
         {
             let mut txn = doc.transact_mut();
-            subdocs.insert(&mut txn, "c", doc_c);
-            let doc_c_ref = subdocs.get(&txn, "c").unwrap().to_ydoc().unwrap();
+            let doc_c_ref = subdocs.insert(&mut txn, "c", doc_c);
             doc_c_ref.load(&mut txn);
         }
         let actual = event.take();
@@ -1683,8 +1695,7 @@ mod test {
         });
         let mut doc_ref = {
             let mut txn = doc.transact_mut();
-            array.insert(&mut txn, 0, subdoc_1);
-            let doc_ref = array.get(&txn, 0).unwrap().to_ydoc().unwrap();
+            let doc_ref = array.insert(&mut txn, 0, subdoc_1);
             let o = doc_ref.options();
             assert!(o.should_load);
             assert!(!o.auto_load);
@@ -1767,8 +1778,7 @@ mod test {
 
         let mut subdoc_1 = {
             let mut txn = doc.transact_mut();
-            array.insert(&mut txn, 0, subdoc_1);
-            array.get(&txn, 0).unwrap().to_ydoc().unwrap()
+            array.insert(&mut txn, 0, subdoc_1)
         };
         assert!(subdoc_1.options().should_load);
         assert!(subdoc_1.options().auto_load);

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -748,6 +748,8 @@ where
 }
 
 impl Prelim for Doc {
+    type Return = Doc;
+
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         if self.parent_doc().is_some() {
             panic!("Cannot integrate the document, because it's already being used as a sub-document elsewhere");

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -317,6 +317,8 @@ impl Decode for Move {
 }
 
 impl Prelim for Move {
+    type Return = ();
+
     #[inline]
     fn into_content(self, _: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         (ItemContent::Move(Box::new(self)), None)

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -1,4 +1,4 @@
-use crate::block::{Block, BlockPtr, ItemContent, Prelim};
+use crate::block::{Block, BlockPtr, ItemContent, Prelim, Unused};
 use crate::block_iter::BlockIter;
 use crate::transaction::TransactionMut;
 use crate::types::BranchPtr;
@@ -317,7 +317,7 @@ impl Decode for Move {
 }
 
 impl Prelim for Move {
-    type Return = ();
+    type Return = Unused;
 
     #[inline]
     fn into_content(self, _: &mut TransactionMut) -> (ItemContent, Option<Self>) {

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockPtr, ItemContent, Prelim};
+use crate::block::{BlockPtr, ItemContent, Prelim, Unused};
 use crate::block_iter::BlockIter;
 use crate::moving::RelativePosition;
 use crate::transaction::TransactionMut;
@@ -11,7 +11,7 @@ use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::collections::HashSet;
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
@@ -113,10 +113,20 @@ pub trait Array: AsRef<Branch> {
     /// that value at the end of it.
     ///
     /// Using `index` value that's higher than current array length results in panic.
-    fn insert<V: Prelim>(&self, txn: &mut TransactionMut, index: u32, value: V) {
+    ///
+    /// Returns a reference to an integrated preliminary input.
+    fn insert<V>(&self, txn: &mut TransactionMut, index: u32, value: V) -> V::Return
+    where
+        V: Prelim,
+    {
         let mut walker = BlockIter::new(BranchPtr::from(self.as_ref()));
         if walker.try_forward(txn, index) {
-            walker.insert_contents(txn, value)
+            let ptr = walker.insert_contents(txn, value);
+            if let Ok(integrated) = ptr.try_into() {
+                integrated
+            } else {
+                panic!("Defect: unexpected integrated type")
+            }
         } else {
             panic!("Index {} is outside of the range of an array", index);
         }
@@ -132,17 +142,27 @@ pub trait Array: AsRef<Branch> {
         T: IntoIterator<Item = V>,
         V: Into<Any>,
     {
-        self.insert(txn, index, RangePrelim(values))
+        self.insert(txn, index, RangePrelim(values));
     }
 
     /// Inserts given `value` at the end of the current array.
-    fn push_back<V: Prelim>(&self, txn: &mut TransactionMut, value: V) {
+    ///
+    /// Returns a reference to an integrated preliminary input.
+    fn push_back<V>(&self, txn: &mut TransactionMut, value: V) -> V::Return
+    where
+        V: Prelim,
+    {
         let len = self.len(txn);
         self.insert(txn, len, value)
     }
 
     /// Inserts given `value` at the beginning of the current array.
-    fn push_front<V: Prelim>(&self, txn: &mut TransactionMut, content: V) {
+    ///
+    /// Returns a reference to an integrated preliminary input.
+    fn push_front<V>(&self, txn: &mut TransactionMut, content: V) -> V::Return
+    where
+        V: Prelim,
+    {
         self.insert(txn, 0, content)
     }
 
@@ -357,7 +377,7 @@ where
     T: IntoIterator<Item = V>,
     V: Into<Any>,
 {
-    type Return = ();
+    type Return = Unused;
 
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         let vec: Vec<Any> = self.0.into_iter().map(|v| v.into()).collect();
@@ -1004,27 +1024,19 @@ mod test {
             let yarray = doc.get_or_insert_array("array");
             let mut txn = doc.transact_mut();
             let pos = rng.between(0, yarray.len(&txn));
-            yarray.insert(&mut txn, pos, ArrayPrelim::from([1, 2, 3, 4]));
-            if let Value::YArray(array2) = yarray.get(&txn, pos).unwrap() {
-                let expected: Box<[Any]> = (1..=4).map(|i| Any::Number(i as f64)).collect();
-                assert_eq!(array2.to_json(&txn), Any::Array(expected));
-            } else {
-                panic!("should not happen")
-            }
+            let array2 = yarray.insert(&mut txn, pos, ArrayPrelim::from([1, 2, 3, 4]));
+            let expected: Box<[Any]> = (1..=4).map(|i| Any::Number(i as f64)).collect();
+            assert_eq!(array2.to_json(&txn), Any::Array(expected));
         }
 
         fn insert_type_map(doc: &mut Doc, rng: &mut StdRng) {
             let yarray = doc.get_or_insert_array("array");
             let mut txn = doc.transact_mut();
             let pos = rng.between(0, yarray.len(&txn));
-            yarray.insert(&mut txn, pos, MapPrelim::<i32>::from(HashMap::default()));
-            if let Value::YMap(map) = yarray.get(&txn, pos).unwrap() {
-                map.insert(&mut txn, "someprop".to_string(), 42);
-                map.insert(&mut txn, "someprop".to_string(), 43);
-                map.insert(&mut txn, "someprop".to_string(), 44);
-            } else {
-                panic!("should not happen")
-            }
+            let map = yarray.insert(&mut txn, pos, MapPrelim::<i32>::from(HashMap::default()));
+            map.insert(&mut txn, "someprop".to_string(), 42);
+            map.insert(&mut txn, "someprop".to_string(), 43);
+            map.insert(&mut txn, "someprop".to_string(), 44);
         }
 
         fn delete(doc: &mut Doc, rng: &mut StdRng) {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -206,7 +206,6 @@ pub trait Text: AsRef<Branch> {
     fn insert_embed<V>(&self, txn: &mut TransactionMut, index: u32, content: V) -> V::Return
     where
         V: Prelim + 'static,
-        <V as Prelim>::Return: TryFrom<BlockPtr>,
     {
         let this = BranchPtr::from(self.as_ref());
         if let Some(pos) = find_position(this, txn, index) {
@@ -239,7 +238,6 @@ pub trait Text: AsRef<Branch> {
     ) -> V::Return
     where
         V: Prelim + 'static,
-        <V as Prelim>::Return: TryFrom<BlockPtr>,
     {
         let this = BranchPtr::from(self.as_ref());
         if let Some(mut pos) = find_position(this, txn, index) {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1,4 +1,4 @@
-use crate::block::{Block, BlockPtr, Item, ItemContent, ItemPosition, Prelim};
+use crate::block::{Block, BlockPtr, Item, ItemContent, ItemPosition, Prelim, PrelimEmbed};
 use crate::block_store::Snapshot;
 use crate::transaction::TransactionMut;
 use crate::types::{
@@ -7,8 +7,10 @@ use crate::types::{
 use crate::utils::OptionExt;
 use crate::*;
 use lib0::any::Any;
+use std::borrow::Borrow;
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
+use std::convert::{TryFrom, TryInto};
 use std::fmt::Formatter;
 use std::ops::{Deref, DerefMut};
 
@@ -53,7 +55,7 @@ impl Observable for TextRef {
 
 impl GetString for TextRef {
     /// Converts context of this text data structure into a single string value.
-    fn get_string<T: ReadTxn>(&self, _txn: &T) -> String {
+    fn get_string<T: ReadTxn>(&self, txn: &T) -> String {
         let mut start = self.as_ref().start;
         let mut s = String::new();
         while let Some(Block::Item(item)) = start.as_deref() {
@@ -74,9 +76,21 @@ impl Into<XmlTextRef> for TextRef {
     }
 }
 
+impl TryFrom<BlockPtr> for TextRef {
+    type Error = BlockPtr;
+
+    fn try_from(value: BlockPtr) -> Result<Self, Self::Error> {
+        if let Some(branch) = value.clone().as_branch() {
+            Ok(TextRef::from(branch))
+        } else {
+            Err(value)
+        }
+    }
+}
+
 pub trait Text: AsRef<Branch> {
     /// Returns a number of characters visible in a current text data structure.
-    fn len<T: ReadTxn>(&self, _txn: &T) -> u32 {
+    fn len<T: ReadTxn>(&self, txn: &T) -> u32 {
         self.as_ref().content_len
     }
 
@@ -189,11 +203,20 @@ pub trait Text: AsRef<Branch> {
     /// the end of it.
     ///
     /// This method will panic if provided `index` is greater than the length of a current text.
-    fn insert_embed(&self, txn: &mut TransactionMut, index: u32, content: Any) {
+    fn insert_embed<V>(&self, txn: &mut TransactionMut, index: u32, content: V) -> V::Return
+    where
+        V: Prelim + 'static,
+        <V as Prelim>::Return: TryFrom<BlockPtr>,
+    {
         let this = BranchPtr::from(self.as_ref());
         if let Some(pos) = find_position(this, txn, index) {
-            let value = crate::block::PrelimEmbed(content);
-            txn.create_item(&pos, value, None);
+            let value = PrelimEmbed::new(content);
+            let ptr = txn.create_item(&pos, value, None);
+            if let Ok(integrated) = ptr.try_into() {
+                integrated
+            } else {
+                panic!("Defect: embedded return type doesn't match.")
+            }
         } else {
             panic!("The type or the position doesn't exist!");
         }
@@ -207,26 +230,35 @@ pub trait Text: AsRef<Branch> {
     /// a formatting blocks.
     ///
     /// This method will panic if provided `index` is greater than the length of a current text.
-    fn insert_embed_with_attributes(
+    fn insert_embed_with_attributes<V>(
         &self,
         txn: &mut TransactionMut,
         index: u32,
-        embed: Any,
+        embed: V,
         mut attributes: Attrs,
-    ) {
+    ) -> V::Return
+    where
+        V: Prelim + 'static,
+        <V as Prelim>::Return: TryFrom<BlockPtr>,
+    {
         let this = BranchPtr::from(self.as_ref());
         if let Some(mut pos) = find_position(this, txn, index) {
             pos.unset_missing(&mut attributes);
             minimize_attr_changes(&mut pos, &attributes);
             let negated_attrs = insert_attributes(this, txn, &mut pos, attributes);
 
-            let value = crate::block::PrelimEmbed(embed);
+            let value = PrelimEmbed::new(embed);
             let item = txn.create_item(&pos, value, None);
 
-            pos.right = Some(item);
+            pos.right = Some(item.clone());
             pos.forward();
 
             insert_negated_attributes(this, txn, &mut pos, negated_attrs);
+            if let Ok(integrated) = item.try_into() {
+                integrated
+            } else {
+                panic!("Defect: unexpected returned integrated type")
+            }
         } else {
             panic!("The type or the position doesn't exist!");
         }
@@ -261,7 +293,7 @@ pub trait Text: AsRef<Branch> {
         }
     }
 
-    fn diff<T, D, F>(&self, _txn: &T, compute_ychange: F) -> Vec<Diff<D>>
+    fn diff<T, D, F>(&self, txn: &T, compute_ychange: F) -> Vec<Diff<D>>
     where
         T: ReadTxn,
         F: Fn(YChange) -> D,
@@ -1108,21 +1140,30 @@ impl TextEvent {
     }
 }
 
-/// A preliminary text. It's can be used to initialize a Text, when it's about to be nested
+/// A preliminary text. It's can be used to initialize a [TextRef], when it's about to be nested
 /// into another Yrs data collection, such as [Map] or [Array].
 #[derive(Debug)]
-pub struct TextPrelim<'a>(pub &'a str);
+pub struct TextPrelim<T: Borrow<str>>(T);
 
-impl Prelim for TextPrelim<'_> {
+impl<T: Borrow<str>> TextPrelim<T> {
+    pub fn new(value: T) -> Self {
+        TextPrelim(value)
+    }
+}
+
+impl<T: Borrow<str>> Prelim for TextPrelim<T> {
+    type Return = TextRef;
+
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         let inner = Branch::new(TYPE_REFS_TEXT, None);
         (ItemContent::Type(inner), Some(self))
     }
 
     fn integrate(self, txn: &mut TransactionMut, inner_ref: BranchPtr) {
-        if !self.0.is_empty() {
+        let borrowed = self.0.borrow();
+        if !borrowed.is_empty() {
             let text = TextRef::from(inner_ref);
-            text.push(txn, self.0);
+            text.push(txn, borrowed);
         }
     }
 }

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -653,10 +653,9 @@ pub trait XmlFragment: AsRef<Branch> {
     fn insert<V>(&self, txn: &mut TransactionMut, index: u32, xml_node: V) -> V::Return
     where
         V: XmlPrelim,
-        <V as Prelim>::Return: TryFrom<BlockPtr>,
     {
         let ptr = self.as_ref().insert_at(txn, index, xml_node);
-        if let Ok(integrated) = <V as Prelim>::Return::try_from(ptr) {
+        if let Ok(integrated) = V::Return::try_from(ptr) {
             integrated
         } else {
             panic!("Defect: inserted XML element returned primitive value block")
@@ -667,7 +666,6 @@ pub trait XmlFragment: AsRef<Branch> {
     fn push_back<V>(&self, txn: &mut TransactionMut, xml_node: V) -> V::Return
     where
         V: XmlPrelim,
-        <V as Prelim>::Return: TryFrom<BlockPtr>,
     {
         let len = self.len(txn);
         self.insert(txn, len, xml_node)
@@ -677,7 +675,6 @@ pub trait XmlFragment: AsRef<Branch> {
     fn push_front<V>(&self, txn: &mut TransactionMut, xml_node: V) -> V::Return
     where
         V: XmlPrelim,
-        <V as Prelim>::Return: TryFrom<BlockPtr>,
     {
         self.insert(txn, 0, xml_node)
     }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -785,8 +785,7 @@ mod test {
         assert_eq!(map1.get(&d1.transact(), "a").unwrap(), 1.into());
 
         // testing sub-types and if it can restore a whole type
-        map1.insert(&mut d1.transact_mut(), "a", MapPrelim::<u32>::new());
-        let sub_type = map1.get(&d1.transact(), "a").unwrap().to_ymap().unwrap();
+        let sub_type = map1.insert(&mut d1.transact_mut(), "a", MapPrelim::<u32>::new());
         sub_type.insert(&mut d1.transact_mut(), "x", 42);
         let actual = map1.to_json(&d1.transact());
         let expected = Any::from_json(r#"{ "a": { "x": 42 } }"#).unwrap();
@@ -861,8 +860,7 @@ mod test {
         array1.remove_range(&mut d1.transact_mut(), 0, 5);
 
         // test nested structure
-        array1.insert(&mut d1.transact_mut(), 0, MapPrelim::<u32>::new());
-        let map = array1.get(&d1.transact(), 0).unwrap().to_ymap().unwrap();
+        let map = array1.insert(&mut d1.transact_mut(), 0, MapPrelim::<u32>::new());
         let actual = array1.to_json(&d1.transact());
         let expected = Any::from_json(r#"[{}]"#).unwrap();
         assert_eq!(actual, expected);
@@ -1008,17 +1006,15 @@ mod test {
         let d2 = Doc::with_client_id(2);
         let arr2 = d2.get_or_insert_array("array");
 
-        arr1.push_back(
+        let map1a = arr1.push_back(
             &mut d1.transact_mut(),
             MapPrelim::from([("hello".to_owned(), "world".to_owned())]),
         );
-        let map1a = arr1.get(&d1.transact(), 0).unwrap().to_ymap().unwrap();
 
-        arr1.push_back(
+        let map1b = arr1.push_back(
             &mut d1.transact_mut(),
             MapPrelim::from([("key".to_owned(), "value".to_owned())]),
         );
-        let map1b = arr1.get(&d1.transact(), 1).unwrap().to_ymap().unwrap();
 
         exchange_updates(&[&d1, &d2]);
 
@@ -1279,8 +1275,7 @@ mod test {
                     "blocks",
                     MapPrelim::from([("text".to_owned(), "1".to_owned())]),
                 )]),
-            );
-            design.get(&txn, "text").unwrap().to_ymap().unwrap()
+            )
         };
         {
             let mut txn = doc.transact_mut();
@@ -1413,7 +1408,7 @@ mod test {
     }
 
     #[test]
-    fn undo_in_Embed() {
+    fn undo_in_embed() {
         let d1 = Doc::with_client_id(1);
         let txt1 = d1.get_or_insert_text("test");
         let mut mgr = UndoManager::new(&d1, &txt1);

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -1901,17 +1901,17 @@ impl YText {
                 let content = js_into_any(&embed).unwrap();
                 if let Some(txn) = get_txn_mut(txn) {
                     if let Some(attrs) = Self::parse_attrs(attributes) {
-                        v.insert_embed_with_attributes(txn, index, content, attrs)
+                        v.insert_embed_with_attributes(txn, index, content, attrs);
                     } else {
-                        v.insert_embed(txn, index, content)
+                        v.insert_embed(txn, index, content);
                     }
                 } else {
                     let mut txn = v.transact_mut();
 
                     if let Some(attrs) = Self::parse_attrs(attributes) {
-                        v.insert_embed_with_attributes(&mut txn, index, content, attrs)
+                        v.insert_embed_with_attributes(&mut txn, index, content, attrs);
                     } else {
-                        v.insert_embed(&mut txn, index, content)
+                        v.insert_embed(&mut txn, index, content);
                     }
                 }
             }
@@ -3297,17 +3297,17 @@ impl YXmlText {
         if let Some(txn) = get_txn_mut(txn) {
             if let Some(attrs) = YText::parse_attrs(attributes) {
                 self.0
-                    .insert_embed_with_attributes(txn, index, content, attrs)
+                    .insert_embed_with_attributes(txn, index, content, attrs);
             } else {
-                self.0.insert_embed(txn, index, content)
+                self.0.insert_embed(txn, index, content);
             }
         } else {
             let mut txn = self.0.transact_mut();
             if let Some(attrs) = YText::parse_attrs(attributes) {
                 self.0
-                    .insert_embed_with_attributes(&mut txn, index, content, attrs)
+                    .insert_embed_with_attributes(&mut txn, index, content, attrs);
             } else {
-                self.0.insert_embed(&mut txn, index, content)
+                self.0.insert_embed(&mut txn, index, content);
             }
         }
     }
@@ -3644,6 +3644,8 @@ pub struct YUndoObserver(UndoEventSubscription);
 struct JsValueWrapper(JsValue);
 
 impl Prelim for JsValueWrapper {
+    type Return = ();
+
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         let content = if let Some(any) = js_into_any(&self.0) {
             ItemContent::Any(vec![any])

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -11,7 +11,7 @@ use wasm_bindgen::__rt::{Ref, RefMut};
 use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
-use yrs::block::{ClientID, ItemContent, Prelim};
+use yrs::block::{ClientID, ItemContent, Prelim, Unused};
 use yrs::types::array::ArrayEvent;
 use yrs::types::map::MapEvent;
 use yrs::types::text::{ChangeKind, Diff, TextEvent, YChange};
@@ -3644,7 +3644,7 @@ pub struct YUndoObserver(UndoEventSubscription);
 struct JsValueWrapper(JsValue);
 
 impl Prelim for JsValueWrapper {
-    type Return = ();
+    type Return = Unused;
 
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         let content = if let Some(any) = js_into_any(&self.0) {


### PR DESCRIPTION
1. `Text::insert_embed`/`Text::insert_embed_with_attributes` now can accept shared preliminary types (eg. YMap, YArray). These types are also correctly serialized deserialized, and insert embed methods return a reference to integrated types eg. `txt.insert_embed(txn, 0, TextPrelim::new("init value"))` returns a `TextRef`.
2. Same for return values of `Map::insert`, `Array::insert`, `Array::push_back` and `Array::push_front` - all of them now return an integrated value. This simplifies situations when we wanted to insert a nested shared type, which we wanted to work with right afterwards.