### PR TITLE
release v0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib0"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -1015,7 +1015,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yffi"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "lib0",
  "rand 0.7.3",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "atomic_refcell",
  "criterion",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/lib0/Cargo.toml
+++ b/lib0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib0"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,8 +12,8 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.14.1" }
-yrs = { path = "../yrs", version = "0.14.1" }
+lib0 = { path = "../lib0", version = "0.15.0" }
+yrs = { path = "../yrs", version = "0.15.0" }
 rand = "0.7.0"
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.14.1"
+version = "0.15.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
@@ -13,7 +13,7 @@ readme = "./README.md"
 [dependencies]
 thiserror = "1"
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
-lib0 = { path = "../lib0", version = "0.14.1" }
+lib0 = { path = "../lib0", version = "0.15.0" }
 smallstr = { version = "0.2", features = ["union"]}
 smallvec = { version = "1.10", features = ["union", "const_generics", "const_new"]}
 atomic_refcell = "0.1"

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -117,6 +117,10 @@ impl Doc {
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a text (in such case a sequence component of complex data type will be
     /// interpreted as a list of text chunks).
+    ///
+    /// **Note**: this method requires an exclusive access to an underlying document store. If there
+    /// is another transaction in process, it will panic. It's advised to define all root shared
+    /// types during the document creation.
     pub fn get_or_insert_text(&self, name: &str) -> TextRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
@@ -137,6 +141,10 @@ impl Doc {
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a map (in such case a map component of complex data type will be
     /// interpreted as native map).
+    ///
+    /// **Note**: this method requires an exclusive access to an underlying document store. If there
+    /// is another transaction in process, it will panic. It's advised to define all root shared
+    /// types during the document creation.
     pub fn get_or_insert_map(&self, name: &str) -> MapRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
@@ -156,6 +164,10 @@ impl Doc {
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as an array (in such case a sequence component of complex data type will be
     /// interpreted as a list of inserted values).
+    ///
+    /// **Note**: this method requires an exclusive access to an underlying document store. If there
+    /// is another transaction in process, it will panic. It's advised to define all root shared
+    /// types during the document creation.
     pub fn get_or_insert_array(&self, name: &str) -> ArrayRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
@@ -177,6 +189,10 @@ impl Doc {
     /// reinterpreted as a XML element (in such case a map component of complex data type will be
     /// interpreted as map of its attributes, while a sequence component - as a list of its child
     /// XML nodes).
+    ///
+    /// **Note**: this method requires an exclusive access to an underlying document store. If there
+    /// is another transaction in process, it will panic. It's advised to define all root shared
+    /// types during the document creation.
     pub fn get_or_insert_xml_fragment(&self, name: &str) -> XmlFragmentRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
@@ -198,6 +214,10 @@ impl Doc {
     /// reinterpreted as a XML element (in such case a map component of complex data type will be
     /// interpreted as map of its attributes, while a sequence component - as a list of its child
     /// XML nodes).
+    ///
+    /// **Note**: this method requires an exclusive access to an underlying document store. If there
+    /// is another transaction in process, it will panic. It's advised to define all root shared
+    /// types during the document creation.
     pub fn get_or_insert_xml_element(&self, name: &str) -> XmlElementRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
@@ -217,6 +237,10 @@ impl Doc {
     /// If a structure under defined `name` already existed, but its type was different it will be
     /// reinterpreted as a text (in such case a sequence component of complex data type will be
     /// interpreted as a list of text chunks).
+    ///
+    /// **Note**: this method requires an exclusive access to an underlying document store. If there
+    /// is another transaction in process, it will panic. It's advised to define all root shared
+    /// types during the document creation.
     pub fn get_or_insert_xml_text(&self, name: &str) -> XmlTextRef {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,8 +17,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.14.1" }
-yrs = { path = "../yrs", version = "0.14.1" }
+lib0 = { path = "../lib0", version = "0.15.0" }
+yrs = { path = "../yrs", version = "0.15.0" }
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/ywasm/LICENSE
+++ b/ywasm/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2020
   - Kevin Jahns <kevin.jahns@pm.me>.
+  - Bartosz Sypytkowski <b.sypytkowski@gmail.com>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Introduction of `UndoManager`.
- Transactions can now define origins - see: `Doc::transact_mut_with`.
- `Text::insert_embed` and `Text::insert_embed_with_attributes` now accept preliminary types - including shared y-types. These methods will now return a references to an integrated types.
- `Map::insert`, `Array::insert`, `Array::push_back` and `Array::push_front` will now return a reference to an integrated type if a nested preliminary shared y-type was inserted via these methods.