### PR TITLE
Expose RelativePosition API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "atomic_refcell"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b5e5f48b927f04e952dedc932f31995a65a0bf65ec971c74436e51bf6e970d"
+checksum = "857253367827bd9d0fd973f0ef15506a96e79e41b0ad7aa691203a4e3214f6c8"
 
 [[package]]
 name = "atty"
@@ -14,22 +14,22 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
  "bit-vec",
 ]
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byteorder"
@@ -72,12 +72,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cast"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
-dependencies = [
- "rustc_version",
-]
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cfg-if"
@@ -93,9 +90,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "bitflags",
  "textwrap",
@@ -114,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
@@ -140,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
  "itertools",
@@ -150,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -160,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -171,25 +168,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
 ]
 
 [[package]]
@@ -200,7 +196,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -216,9 +212,18 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "fnv"
@@ -241,13 +246,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -266,10 +271,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.1"
+name = "hermit-abi"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -281,10 +304,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
-name = "js-sys"
-version = "0.3.57"
+name = "itoa"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -309,30 +338,30 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -345,22 +374,28 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "oorandom"
@@ -370,9 +405,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "plotters"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -383,24 +418,24 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
@@ -408,16 +443,16 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
- "unicode-xid 0.2.2",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -432,7 +467,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
@@ -474,11 +509,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
- "proc-macro2 1.0.32",
+ "proc-macro2 1.0.50",
 ]
 
 [[package]]
@@ -491,19 +526,18 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -523,7 +557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -537,11 +571,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -554,62 +588,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "regex-syntax",
 ]
@@ -622,9 +644,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -633,15 +655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
 ]
 
 [[package]]
@@ -658,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -673,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -684,16 +697,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
-
-[[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
@@ -710,22 +717,22 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -753,29 +760,29 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.81"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "unicode-xid 0.2.2",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -792,22 +799,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -821,22 +828,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "wait-timeout"
@@ -866,15 +873,15 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -882,24 +889,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
+ "once_cell",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -909,38 +916,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote 1.0.10",
+ "quote 1.0.23",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
- "syn 1.0.81",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.28"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f1aa7971fdf61ef0f353602102dbea75a56e225ed036c1e3740564b91e6b7e"
+checksum = "09d2fff962180c3fadf677438054b1db62bee4aa32af26a45388af07d1287e1d"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -952,19 +959,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.28"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006f79628dfeb96a86d4db51fbf1344cd7fd8408f06fc9aa3c84913a4789688"
+checksum = "4683da3dfc016f704c9f82cf401520c4f1cb3ee440f7f52b3d6ac29506a49ca7"
 dependencies = [
- "proc-macro2 1.0.32",
- "quote 1.0.10",
+ "proc-macro2 1.0.50",
+ "quote 1.0.23",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -80,6 +80,8 @@ typedef struct YXmlTreeWalker {} YXmlTreeWalker;
 
 typedef struct YUndoManager {} YUndoManager;
 
+typedef struct RelativePosition {} RelativePosition;
+
 
 #include <stdarg.h>
 #include <stdbool.h>
@@ -864,6 +866,20 @@ typedef struct YUndoEvent {
   struct YDeleteSet insertions;
   struct YDeleteSet deletions;
 } YUndoEvent;
+
+/**
+ * A relative position is based on the Yjs model and is not affected by document changes.
+ * E.g. If you place a relative position before a certain character, it will always point to this character.
+ * If you place a relative position at the end of a type, it will always point to the end of the type.
+ *
+ * A numeric position is often unsuited for user selections, because it does not change when content is inserted
+ * before or after.
+ *
+ * ```Insert(0, 'x')('a|bc') = 'xa|bc'``` Where | is the relative position.
+ *
+ * Instances of `YRelativePosition` can be freed using `yrelative_position_destroy`.
+ */
+typedef RelativePosition YRelativePosition;
 
 /**
  * Returns default ceonfiguration for `YOptions`.
@@ -2262,5 +2278,54 @@ void yundo_manager_unobserve_popped(YUndoManager *mgr, unsigned int subscription
  * `Y_XML_ELEM`, `Y_XML_TEXT`.
  */
 char ytype_kind(const Branch *branch);
+
+/**
+ * Releases resources allocated by `YRelativePosition` pointers.
+ */
+void yrelative_position_destroy(YRelativePosition *pos);
+
+/**
+ * Returns association of current `YRelativePosition`.
+ * If association is **after** the referenced inserted character, returned number will be >= 0.
+ * If association is **before** the referenced inserted character, returned number will be < 0.
+ */
+int yrelative_position_assoc(const YRelativePosition *pos);
+
+/**
+ * Retrieves a `YRelativePosition` corresponding to a given human-readable `index` pointing into
+ * the shared y-type `branch`. Unlike standard indexes relative position enables to track
+ * the location inside of a shared y-types, even in the face of concurrent updates.
+ *
+ * If association is >= 0, the resulting position will point to location **after** the referenced index.
+ * If association is < 0, the resulting position will point to location **before** the referenced index.
+ */
+YRelativePosition *yrelative_position_from_index(const Branch *branch,
+                                                 YTransaction *txn,
+                                                 int index,
+                                                 int assoc);
+
+/**
+ * Serializes `YRelativePosition` into binary representation. `len` parameter is updated with byte
+ * length of the generated binary. Returned binary can be free'd using `ybinary_destroy`.
+ */
+unsigned char *yrelative_position_encode(const YRelativePosition *pos, int *len);
+
+/**
+ * Deserializes `YRelativePosition` from the payload previously serialized using `yrelative_position_encode`.
+ */
+YRelativePosition *yrelative_position_decode(const unsigned char *binary,
+                                             int len);
+
+/**
+ * Given `YRelativePosition` and transaction reference, if computes a human-readable index in a
+ * context of the referenced shared y-type.
+ *
+ * `out_branch` is getting assigned with a corresponding shared y-type reference.
+ * `out_index` will be used to store computed human-readable index.
+ */
+void yrelative_position_read(const YRelativePosition *pos,
+                             const YTransaction *txn,
+                             Branch **out_branch,
+                             int *out_index);
 
 #endif

--- a/tests-wasm/index.js
+++ b/tests-wasm/index.js
@@ -4,6 +4,7 @@ import * as text from './y-text.tests.js'
 import * as xml from './y-xml.tests.js'
 import * as doc from './y-doc.tests.js'
 import * as undo from './y-undo.tests.js'
+import * as relativePosition from './relative-position.tests.js'
 
 import { runTests } from 'lib0/testing'
 import { isBrowser, isNode } from 'lib0/environment'
@@ -13,7 +14,7 @@ if (isBrowser) {
     log.createVConsole(document.body)
 }
 runTests({
-    array, text, map, xml, doc, undo
+    array, text, map, xml, doc, undo, relativePosition
 }).then(success => {
     /* istanbul ignore next */
     if (isNode) {

--- a/tests-wasm/relative-position.tests.js
+++ b/tests-wasm/relative-position.tests.js
@@ -1,0 +1,104 @@
+import * as Y from 'ywasm'
+import * as t from 'lib0/testing'
+
+/**
+ * @param {Y.YDoc} ydoc
+ * @param {Y.YText} ytext
+ */
+const checkRelativePositions = (ydoc, ytext) => {
+    // test if all positions are encoded and restored correctly
+    for (let i = 0; i < ytext.length; i++) {
+        // for all types of associations..
+        for (let assoc = -1; assoc < 2; assoc++) {
+            const rpos = Y.createRelativePositionFromTypeIndex(ytext, i, assoc)
+            const encodedRpos = Y.encodeRelativePosition(rpos)
+            const decodedRpos = Y.decodeRelativePosition(encodedRpos)
+            const absPos = (Y.createAbsolutePositionFromRelativePosition(decodedRpos, ydoc))
+            t.assert(absPos.index === i)
+            t.assert(absPos.assoc === assoc)
+        }
+    }
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionCase1 = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    ytext.insert(0, '1')
+    ytext.insert(0, 'abc')
+    ytext.insert(0, 'z')
+    ytext.insert(0, 'y')
+    ytext.insert(0, 'x')
+    checkRelativePositions(ydoc, ytext)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionCase2 = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    ytext.insert(0, 'abc')
+    checkRelativePositions(ydoc, ytext)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionCase3 = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    ytext.insert(0, 'abc')
+    ytext.insert(0, '1')
+    ytext.insert(0, 'xyz')
+    checkRelativePositions(ydoc, ytext)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionCase4 = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    ytext.insert(0, '1')
+    checkRelativePositions(ydoc, ytext)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionCase5 = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    ytext.insert(0, '2')
+    ytext.insert(0, '1')
+    checkRelativePositions(ydoc, ytext)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionCase6 = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    checkRelativePositions(ydoc, ytext)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRelativePositionAssociationDifference = tc => {
+    const ydoc = new Y.YDoc()
+    const ytext = ydoc.getText('test')
+    ytext.insert(0, '2')
+    ytext.insert(0, '1')
+    const rposRight = Y.createRelativePositionFromTypeIndex(ytext, 1, 0)
+    const rposLeft = Y.createRelativePositionFromTypeIndex(ytext, 1, -1)
+    ytext.insert(1, 'x')
+    const posRight = Y.createAbsolutePositionFromRelativePosition(rposRight, ydoc)
+    const posLeft = Y.createAbsolutePositionFromRelativePosition(rposLeft, ydoc)
+    t.assert(posRight != null && posRight.index === 2)
+    t.assert(posLeft != null && posLeft.index === 1)
+}

--- a/yffi/cbindgen.toml
+++ b/yffi/cbindgen.toml
@@ -83,6 +83,8 @@ typedef struct YXmlAttrIter {} YXmlAttrIter;
 typedef struct YXmlTreeWalker {} YXmlTreeWalker;
 
 typedef struct YUndoManager {} YUndoManager;
+
+typedef struct RelativePosition {} RelativePosition;
 """
 
 trailer = """

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -2,7 +2,7 @@ use crate::block::{Block, BlockPtr, Item, ItemContent, Prelim};
 use crate::moving::{Move, RelativePosition};
 use crate::transaction::{ReadTxn, TransactionMut};
 use crate::types::{BranchPtr, TypePtr, Value};
-use crate::ID;
+use crate::{Assoc, ID};
 use std::ops::DerefMut;
 
 #[derive(Debug, Clone)]
@@ -280,7 +280,9 @@ impl BlockIter {
 
             let moved_item = stack_item.moved_to.as_item().unwrap();
             if let ItemContent::Move(m) = &moved_item.content {
-                if m.start.assoc && (m.start.within_range(start)) || (m.end.within_range(end)) {
+                if m.start.assoc == Assoc::Before && (m.start.within_range(start))
+                    || (m.end.within_range(end))
+                {
                     let (s, e) = m.get_moved_coords(txn);
                     start = s;
                     end = e;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -61,6 +61,11 @@ pub use crate::doc::{
 };
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
+pub use crate::moving::AbsolutePosition;
+pub use crate::moving::Assoc;
+pub use crate::moving::RelativeIndex;
+pub use crate::moving::RelativePosition;
+pub use crate::moving::RelativePositionContext;
 pub use crate::observer::{Observer, Subscription, SubscriptionId};
 pub use crate::store::Store;
 pub use crate::transaction::Origin;

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -519,7 +519,7 @@ impl RelativePosition {
         }
     }
 
-    pub(crate) fn from_type_index(
+    pub fn from_type_index(
         txn: &mut TransactionMut,
         branch: BranchPtr,
         mut index: u32,

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -391,8 +391,6 @@ impl std::fmt::Display for Move {
 ///
 /// ```Insert(0, 'x')('a|bc') = 'xa|bc'``` Where | is the relative position.
 ///
-/// One of the properties must be defined.
-///
 /// Example:
 ///
 /// ```rust

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -1,16 +1,14 @@
 use crate::block::{Block, BlockPtr, ItemContent, Prelim, Unused};
 use crate::block_iter::BlockIter;
 use crate::transaction::TransactionMut;
-use crate::types::BranchPtr;
+use crate::types::{Branch, BranchPtr};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::{ReadTxn, WriteTxn, ID};
 use lib0::error::Error;
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
-
-/// Association type. If true, associate with right block. Otherwise with the left one.
-pub type Assoc = bool;
+use std::rc::Rc;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Move {
@@ -38,21 +36,34 @@ impl Move {
     }
 
     pub fn is_collapsed(&self) -> bool {
-        self.start.id == self.end.id
+        match (&self.start.context, &self.end.context) {
+            (RelativePositionContext::Relative(id1), RelativePositionContext::Relative(id2)) => {
+                id1.eq(id2)
+            }
+            _ => false,
+        }
     }
 
     pub(crate) fn get_moved_coords_mut<T: WriteTxn>(
         &self,
         txn: &mut T,
     ) -> (Option<BlockPtr>, Option<BlockPtr>) {
-        let start = Self::get_item_ptr_mut(txn, &self.start.id, self.start.assoc);
-        let end = Self::get_item_ptr_mut(txn, &self.end.id, self.end.assoc);
+        let start = if let Some(start) = self.start.item() {
+            Self::get_item_ptr_mut(txn, start, self.start.assoc)
+        } else {
+            None
+        };
+        let end = if let Some(end) = self.end.item() {
+            Self::get_item_ptr_mut(txn, end, self.end.assoc)
+        } else {
+            None
+        };
         (start, end)
     }
 
     fn get_item_ptr_mut<T: WriteTxn>(txn: &mut T, id: &ID, assoc: Assoc) -> Option<BlockPtr> {
         let store = txn.store_mut();
-        if assoc {
+        if assoc == Assoc::After {
             let slice = store.blocks.get_item_clean_start(id)?;
             if slice.adjacent() {
                 Some(slice.as_ptr())
@@ -78,13 +89,21 @@ impl Move {
         &self,
         txn: &T,
     ) -> (Option<BlockPtr>, Option<BlockPtr>) {
-        let start = Self::get_item_ptr(txn, &self.start.id, self.start.assoc);
-        let end = Self::get_item_ptr(txn, &self.end.id, self.end.assoc);
+        let start = if let Some(start) = self.start.item() {
+            Self::get_item_ptr(txn, start, self.start.assoc)
+        } else {
+            None
+        };
+        let end = if let Some(end) = self.end.item() {
+            Self::get_item_ptr(txn, end, self.end.assoc)
+        } else {
+            None
+        };
         (start, end)
     }
 
     fn get_item_ptr<T: ReadTxn>(txn: &T, id: &ID, assoc: Assoc) -> Option<BlockPtr> {
-        if assoc {
+        if assoc == Assoc::After {
             let slice = txn.store().blocks.get_item_clean_start(id)?;
             debug_assert!(slice.adjacent()); //TODO: remove once confirmed that slice always fits block range
             Some(slice.as_ptr())
@@ -276,21 +295,23 @@ impl Encode for Move {
             if is_collapsed {
                 b |= 0b0000_0001
             }
-            if self.start.assoc {
+            if self.start.assoc == Assoc::After {
                 b |= 0b0000_0010
             }
-            if self.end.assoc {
+            if self.end.assoc == Assoc::After {
                 b |= 0b0000_0100
             }
             b |= self.priority << 6;
             b
         };
         encoder.write_var(flags);
-        encoder.write_var(self.start.id.client);
-        encoder.write_var(self.start.id.clock);
+        let id = self.start.item().unwrap();
+        encoder.write_var(id.client);
+        encoder.write_var(id.clock);
         if !is_collapsed {
-            encoder.write_var(self.end.id.client);
-            encoder.write_var(self.end.id.clock);
+            let id = self.end.item().unwrap();
+            encoder.write_var(id.client);
+            encoder.write_var(id.clock);
         }
     }
 }
@@ -299,8 +320,16 @@ impl Decode for Move {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
         let flags: i32 = decoder.read_var()?;
         let is_collapsed = flags & 0b0000_0001 != 0;
-        let start_assoc = flags & 0b0000_0010 != 0;
-        let end_assoc = flags & 0b0000_0100 != 0;
+        let start_assoc = if flags & 0b0000_0010 != 0 {
+            Assoc::After
+        } else {
+            Assoc::Before
+        };
+        let end_assoc = if flags & 0b0000_0100 != 0 {
+            Assoc::After
+        } else {
+            Assoc::Before
+        };
         //TODO use BIT3 & BIT4 to indicate the case `null` is the start/end
         // BIT5 is reserved for future extensions
         let priority = flags >> 6;
@@ -310,8 +339,8 @@ impl Decode for Move {
         } else {
             ID::new(decoder.read_var()?, decoder.read_var()?)
         };
-        let start = RelativePosition::create(start_id, start_assoc);
-        let end = RelativePosition::create(end_id, end_assoc);
+        let start = RelativePosition::new(RelativePositionContext::Relative(start_id), start_assoc);
+        let end = RelativePosition::new(RelativePositionContext::Relative(end_id), end_assoc);
         Ok(Move::new(start, end, priority))
     }
 }
@@ -353,16 +382,141 @@ impl std::fmt::Display for Move {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+/// A relative position is based on the Yjs model and is not affected by document changes.
+/// E.g. If you place a relative position before a certain character, it will always point to this character.
+/// If you place a relative position at the end of a type, it will always point to the end of the type.
+///
+/// A numeric position is often unsuited for user selections, because it does not change when content is inserted
+/// before or after.
+///
+/// ```Insert(0, 'x')('a|bc') = 'xa|bc'``` Where | is the relative position.
+///
+/// One of the properties must be defined.
+///
+/// Example:
+///
+/// ```rust
+/// use yrs::{Assoc, Doc, RelativeIndex, Text, Transact};
+///
+/// let doc = Doc::new();
+/// let txt = doc.get_or_insert_text("text");
+/// let mut txn = doc.transact_mut();
+/// txt.insert(&mut txn, 0, "abc"); // => 'abc'
+///
+/// // create relative position tracker (marked as . in the comments)
+/// let pos = txt.position_at(&mut txn, 2, Assoc::After).unwrap(); // => 'ab.c'
+///
+/// // modify text
+/// txt.insert(&mut txn, 1, "def"); // => 'adefb.c'
+/// txt.remove_range(&mut txn, 4, 1); // => 'adef.c'
+///
+/// // get absolute position
+/// let a = pos.absolute(&txn).unwrap();
+/// assert_eq!(a.index, 4);
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct RelativePosition {
-    pub id: ID,
+    context: RelativePositionContext,
     /// If true - associate to the right block. Otherwise associate to the left one.
     pub assoc: Assoc,
 }
 
 impl RelativePosition {
-    pub(crate) fn create(id: ID, assoc: Assoc) -> Self {
-        RelativePosition { id, assoc }
+    #[inline]
+    pub fn new(context: RelativePositionContext, assoc: Assoc) -> Self {
+        RelativePosition { context, assoc }
+    }
+
+    #[inline]
+    pub fn context(&self) -> &RelativePositionContext {
+        &self.context
+    }
+
+    pub fn item(&self) -> Option<&ID> {
+        if let RelativePositionContext::Relative(id) = &self.context {
+            Some(id)
+        } else {
+            None
+        }
+    }
+
+    pub fn absolute<T: ReadTxn>(&self, txn: &T) -> Option<AbsolutePosition> {
+        let mut branch = None;
+        let mut index = 0;
+
+        match &self.context {
+            RelativePositionContext::Relative(right_id) => {
+                let store = txn.store();
+                if store.blocks.get_state(&right_id.client) <= right_id.clock {
+                    // type does not exist yet
+                    return None;
+                }
+                let (right, diff) = store.follow_redone(right_id);
+                if let Block::Item(item) = right.deref() {
+                    if let Some(b) = item.parent.as_branch() {
+                        branch = Some(b.clone());
+                        match b.item {
+                            Some(i) if i.is_deleted() => { /* do nothing */ }
+                            _ => {
+                                // adjust position based on left association if necessary
+                                index = if item.is_deleted() || !item.is_countable() {
+                                    0
+                                } else if self.assoc == Assoc::After {
+                                    diff
+                                } else {
+                                    diff + 1
+                                };
+                                let encoding = store.options.offset_kind;
+                                let mut n = item.left;
+                                while let Some(Block::Item(item)) = n.as_deref() {
+                                    if !item.is_deleted() && item.is_countable() {
+                                        index += item.content_len(encoding);
+                                    }
+                                    n = item.left;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            RelativePositionContext::Nested(id) => {
+                let store = txn.store();
+                if store.blocks.get_state(&id.client) <= id.clock {
+                    // type does not exist yet
+                    return None;
+                }
+                let (ptr, _) = store.follow_redone(id);
+                let item = ptr.as_item()?; // early return if ptr is GC
+                if let ItemContent::Type(b) = &item.content {
+                    branch = Some(BranchPtr::from(b));
+                } // else - branch remains null
+            }
+            RelativePositionContext::Root(name) => {
+                branch = txn.store().get_type(name.clone());
+                if let Some(ptr) = branch.as_ref() {
+                    index = if self.assoc == Assoc::After {
+                        ptr.content_len
+                    } else {
+                        0
+                    };
+                }
+            }
+        }
+
+        if let Some(ptr) = branch {
+            Some(AbsolutePosition::new(ptr, index, self.assoc))
+        } else {
+            None
+        }
+    }
+
+    fn get_context<T: ReadTxn>(branch: BranchPtr, txn: &T) -> RelativePositionContext {
+        if let Some(ptr) = branch.item {
+            RelativePositionContext::Nested(*ptr.id())
+        } else {
+            let root = txn.store().get_type_key(branch).unwrap().clone();
+            RelativePositionContext::Root(root)
+        }
     }
 
     pub(crate) fn from_type_index(
@@ -371,9 +525,10 @@ impl RelativePosition {
         mut index: u32,
         assoc: Assoc,
     ) -> Option<Self> {
-        if !assoc {
+        if assoc == Assoc::Before {
             if index == 0 {
-                return None;
+                let context = Self::get_context(branch, txn);
+                return Some(Self::new(context, assoc));
             }
             index -= 1;
         }
@@ -383,53 +538,207 @@ impl RelativePosition {
             panic!("Block iter couldn't move forward");
         }
         if walker.finished() {
-            if !assoc {
-                let ptr = walker.next_item()?;
-                let id = ptr.last_id();
-                Some(Self::create(id, assoc))
+            if assoc == Assoc::Before {
+                let context = if let Some(ptr) = walker.next_item() {
+                    RelativePositionContext::Relative(ptr.last_id())
+                } else {
+                    Self::get_context(branch, txn)
+                };
+                Some(Self::new(context, assoc))
             } else {
                 None
             }
         } else {
-            let ptr = walker.next_item()?;
-            let mut id = ptr.id().clone();
-            id.clock += walker.rel();
-            Some(Self::create(id, assoc))
+            let context = if let Some(ptr) = walker.next_item() {
+                let mut id = ptr.id().clone();
+                id.clock += walker.rel();
+                RelativePositionContext::Relative(id)
+            } else {
+                Self::get_context(branch, txn)
+            };
+            Some(Self::new(context, assoc))
         }
     }
 
     pub(crate) fn within_range(&self, ptr: Option<BlockPtr>) -> bool {
-        if !self.assoc {
+        if self.assoc == Assoc::Before {
             return false;
         } else if let Some(Block::Item(item)) = ptr.as_deref() {
-            match item.left {
-                Some(ptr) => ptr.last_id() != self.id,
-                None => false,
+            if let Some(ptr) = item.left {
+                if let Some(pos) = self.item() {
+                    return ptr.last_id() != *pos;
+                }
             }
+            false
         } else {
             true
         }
     }
 }
 
+impl Encode for RelativePosition {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        self.context.encode(encoder);
+        self.assoc.encode(encoder);
+    }
+}
+
+impl Decode for RelativePosition {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
+        let context = RelativePositionContext::decode(decoder)?;
+        let assoc = Assoc::decode(decoder)?;
+        Ok(Self::new(context, assoc))
+    }
+}
+
 impl std::fmt::Display for RelativePosition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if !self.assoc {
+        if self.assoc == Assoc::Before {
             write!(f, "<")?;
         }
-        write!(f, "{}", self.id)?;
-        if self.assoc {
+        if let Some(id) = self.item() {
+            write!(f, "{}", id)?;
+        }
+        if self.assoc == Assoc::After {
             write!(f, ">")?;
         }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct AbsolutePosition {
-    branch: BranchPtr,
-    index: u32,
-    assoc: Assoc,
+/// Struct describing context in which [RelativePosition] is placed. For items pointing inside of
+/// the shared typed sequence it's always [RelativePosition::Relative] which refers to a block [ID]
+/// found under corresponding position.
+///
+/// In case when a containing collection is empty, there's a no block [ID] that can be used as point
+/// of reference. In that case we store either a parent collection root type name or its branch [ID]
+/// instead (if collection is nested into another).
+///
+/// Using [ID]s guarantees that corresponding [RelativePosition] doesn't shift under incoming
+/// concurrent updates.
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum RelativePositionContext {
+    /// [RelativePosition] is relative to a given block [ID]. This is what happens most of the time.
+    Relative(ID),
+    /// If a containing collection is a nested y-type, which is empty, this case allows us to
+    /// identify that nested type.
+    Nested(ID),
+    /// If a containing collection is a root-level y-type, which is empty, this case allows us to
+    /// identify that nested type.
+    Root(Rc<str>),
+}
+
+impl Encode for RelativePositionContext {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        match self {
+            RelativePositionContext::Relative(id) => {
+                encoder.write_var(0);
+                encoder.write_var(id.client);
+                encoder.write_var(id.clock);
+            }
+            RelativePositionContext::Nested(id) => {
+                encoder.write_var(2);
+                encoder.write_var(id.client);
+                encoder.write_var(id.clock);
+            }
+            RelativePositionContext::Root(type_name) => {
+                encoder.write_var(1);
+                encoder.write_string(&type_name);
+            }
+        }
+    }
+}
+
+impl Decode for RelativePositionContext {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
+        let tag: u8 = decoder.read_var()?;
+        match tag {
+            0 => {
+                let client = decoder.read_var()?;
+                let clock = decoder.read_var()?;
+                Ok(RelativePositionContext::Relative(ID::new(client, clock)))
+            }
+            1 => {
+                let type_name = decoder.read_string()?;
+                Ok(RelativePositionContext::Root(type_name.into()))
+            }
+            2 => {
+                let client = decoder.read_var()?;
+                let clock = decoder.read_var()?;
+                Ok(RelativePositionContext::Nested(ID::new(client, clock)))
+            }
+            _ => Err(Error::UnexpectedValue),
+        }
+    }
+}
+
+/// Association type used by [RelativePosition]. In general [RelativePosition] refers to a cursor
+/// space between two elements (eg. "ab.c" where "abc" is our string and `.` is the [RelativePosition]
+/// placement). However in a situation when another peer is updating a collection concurrently,
+/// a new set of elements may be inserted into that space, expanding it in the result. In such case
+/// [Assoc] tells us if the [RelativePosition] should stick to location before or after referenced index.
+#[repr(i8)]
+#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub enum Assoc {
+    /// The corresponding [RelativePosition] points to space **after** the referenced [ID].
+    After = 0,
+    /// The corresponding [RelativePosition] points to space **before** the referenced [ID].
+    Before = -1,
+}
+
+impl Default for Assoc {
+    #[inline]
+    fn default() -> Self {
+        Assoc::After
+    }
+}
+
+impl Encode for Assoc {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        match self {
+            Assoc::Before => encoder.write_var(-1),
+            Assoc::After => encoder.write_var(0),
+        }
+    }
+}
+
+impl Decode for Assoc {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
+        let tag: i8 = decoder.read_var()?;
+        Ok(if tag >= 0 {
+            Assoc::After
+        } else {
+            Assoc::Before
+        })
+    }
+}
+
+/// Trait used to retrieve a [RelativePosition] corresponding to a given human-readable index.
+/// Unlike standard indexes relative position enables to track the location inside of a shared
+/// y-types, even in the face of concurrent updates.
+pub trait RelativeIndex: AsRef<Branch> {
+    /// Returns a [RelativePosition] equivalent to a human-readable `index`.
+    /// Returns `None` if `index` is beyond the length of current sequence.
+    fn position_at(
+        &self,
+        txn: &mut TransactionMut,
+        index: u32,
+        assoc: Assoc,
+    ) -> Option<RelativePosition> {
+        RelativePosition::from_type_index(txn, BranchPtr::from(self.as_ref()), index, assoc)
+    }
+}
+
+/// [AbsolutePosition] is a result of mapping of [RelativePosition] onto document store at a current
+/// point in time.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct AbsolutePosition {
+    /// Pointer to a collection type [AbsolutePosition] refers to.
+    pub branch: BranchPtr,
+    /// Human readable index corresponding to this [AbsolutePosition].
+    pub index: u32,
+    /// Association type used by [RelativePosition] this structure was created from.
+    pub assoc: Assoc,
 }
 
 impl AbsolutePosition {
@@ -439,5 +748,125 @@ impl AbsolutePosition {
             index,
             assoc,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::moving::Assoc;
+    use crate::updates::decoder::Decode;
+    use crate::updates::encoder::Encode;
+    use crate::{Doc, RelativeIndex, RelativePosition, Text, TextRef, Transact};
+
+    fn check_relative_positions(text: &TextRef) {
+        // test if all positions are encoded and restored correctly
+        let mut txn = text.transact_mut();
+        let len = text.len(&txn);
+        for i in 0..len {
+            // for all types of associations..
+            for assoc in [Assoc::After, Assoc::Before] {
+                let rel_pos = text.position_at(&mut txn, i, assoc).unwrap();
+                let encoded = rel_pos.encode_v1();
+                let decoded = RelativePosition::decode_v1(&encoded).unwrap();
+                let abs_pos = decoded.absolute(&txn).expect(&format!(
+                    "absolute position not found for index {} of {}",
+                    i, decoded
+                ));
+                assert_eq!(abs_pos.index, i);
+                assert_eq!(abs_pos.assoc, assoc);
+            }
+        }
+    }
+
+    #[test]
+    fn relative_position_case_1() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+
+        {
+            let mut txn = doc.transact_mut();
+            txt.insert(&mut txn, 0, "1");
+            txt.insert(&mut txn, 0, "abc");
+            txt.insert(&mut txn, 0, "z");
+            txt.insert(&mut txn, 0, "y");
+            txt.insert(&mut txn, 0, "x");
+        }
+
+        check_relative_positions(&txt);
+    }
+
+    #[test]
+    fn relative_position_case_2() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+
+        txt.insert(&mut doc.transact_mut(), 0, "abc");
+        check_relative_positions(&txt);
+    }
+
+    #[test]
+    fn relative_position_case_3() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+
+        {
+            let mut txn = doc.transact_mut();
+            txt.insert(&mut txn, 0, "abc");
+            txt.insert(&mut txn, 0, "1");
+            txt.insert(&mut txn, 0, "xyz");
+        }
+
+        check_relative_positions(&txt);
+    }
+
+    #[test]
+    fn relative_position_case_4() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+
+        txt.insert(&mut doc.transact_mut(), 0, "1");
+        check_relative_positions(&txt);
+    }
+
+    #[test]
+    fn relative_position_case_5() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+
+        {
+            let mut txn = doc.transact_mut();
+            txt.insert(&mut txn, 0, "2");
+            txt.insert(&mut txn, 0, "1");
+        }
+
+        check_relative_positions(&txt);
+    }
+
+    #[test]
+    fn relative_position_case_6() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+        check_relative_positions(&txt);
+    }
+
+    #[test]
+    fn relative_position_association_difference() {
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+
+        let mut txn = doc.transact_mut();
+        txt.insert(&mut txn, 0, "2");
+        txt.insert(&mut txn, 0, "1");
+
+        let rpos_right = txt.position_at(&mut txn, 1, Assoc::After).unwrap();
+        let rpos_left = txt.position_at(&mut txn, 1, Assoc::Before).unwrap();
+
+        txt.insert(&mut txn, 1, "x");
+
+        let pos_right = rpos_right.absolute(&txn).unwrap();
+        let pos_left = rpos_left.absolute(&txn).unwrap();
+
+        assert_eq!(pos_right.index, 2);
+        assert_eq!(pos_left.index, 1);
     }
 }

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -32,6 +32,7 @@ use std::ops::{Deref, DerefMut};
 pub struct TextRef(BranchPtr);
 
 impl Text for TextRef {}
+impl RelativeIndex for TextRef {}
 
 impl Observable for TextRef {
     type Event = TextEvent;

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -7,7 +7,7 @@ use crate::types::{
     EntryChange, EventHandler, MapRef, Observers, Path, ToJson, TypePtr, Value,
     TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_FRAGMENT, TYPE_REFS_XML_TEXT,
 };
-use crate::{GetString, Map, Observable, ReadTxn, Text, ID};
+use crate::{GetString, Map, Observable, ReadTxn, RelativeIndex, Text, ID};
 use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -118,6 +118,7 @@ pub struct XmlElementRef(BranchPtr);
 
 impl Xml for XmlElementRef {}
 impl XmlFragment for XmlElementRef {}
+impl RelativeIndex for XmlElementRef {}
 
 impl Into<XmlFragmentRef> for XmlElementRef {
     fn into(self) -> XmlFragmentRef {
@@ -289,6 +290,7 @@ pub struct XmlTextRef(BranchPtr);
 
 impl Xml for XmlTextRef {}
 impl Text for XmlTextRef {}
+impl RelativeIndex for XmlTextRef {}
 
 impl Observable for XmlTextRef {
     type Event = XmlTextEvent;
@@ -407,6 +409,7 @@ impl Prelim for XmlTextPrelim<'_> {
 pub struct XmlFragmentRef(BranchPtr);
 
 impl XmlFragment for XmlFragmentRef {}
+impl RelativeIndex for XmlFragmentRef {}
 
 impl XmlFragmentRef {
     pub fn parent(&self) -> Option<XmlNode> {

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -334,14 +334,16 @@ impl Update {
                 }
 
                 if let ItemContent::Move(m) = &item.content {
-                    let start = m.start.id;
-                    if start.clock >= local_sv.get(&start.client) {
-                        return Some(start.client);
+                    if let Some(start) = m.start.item() {
+                        if start.clock >= local_sv.get(&start.client) {
+                            return Some(start.client);
+                        }
                     }
                     if !m.is_collapsed() {
-                        let end = m.end.id;
-                        if end.clock >= local_sv.get(&end.client) {
-                            return Some(end.client);
+                        if let Some(end) = m.end.item() {
+                            if end.clock >= local_sv.get(&end.client) {
+                                return Some(end.client);
+                            }
                         }
                     }
                 }

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -1,6 +1,5 @@
 use js_sys::{Object, Reflect, Uint8Array};
 use lib0::any::Any;
-use lib0::error::Error;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -162,7 +161,7 @@ impl YDoc {
     /// const text = doc.getText('name')
     /// doc.transact(txn => text.insert(txn, 0, 'hello world'))
     /// ```
-    #[wasm_bindgen(js_name = readTransaction)]
+    #[wasm_bindgen(method, js_name = readTransaction)]
     pub fn read_transaction(&mut self) -> YTransaction {
         YTransaction::from(self.as_ref().transact())
     }
@@ -194,7 +193,7 @@ impl YDoc {
     /// const text = doc.getText('name')
     /// doc.transact(txn => text.insert(txn, 0, 'hello world'))
     /// ```
-    #[wasm_bindgen(js_name = writeTransaction)]
+    #[wasm_bindgen(method, js_name = writeTransaction)]
     pub fn write_transaction(&mut self, origin: JsValue) -> YTransaction {
         if origin.is_null() || origin.is_undefined() {
             YTransaction::from(self.as_ref().transact_mut())
@@ -211,7 +210,7 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YText` instance.
-    #[wasm_bindgen(js_name = getText)]
+    #[wasm_bindgen(method, js_name = getText)]
     pub fn get_text(&mut self, name: &str) -> YText {
         self.as_ref().get_or_insert_text(name).into()
     }
@@ -223,7 +222,7 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YArray` instance.
-    #[wasm_bindgen(js_name = getArray)]
+    #[wasm_bindgen(method, js_name = getArray)]
     pub fn get_array(&mut self, name: &str) -> YArray {
         self.as_ref().get_or_insert_array(name).into()
     }
@@ -235,7 +234,7 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YMap` instance.
-    #[wasm_bindgen(js_name = getMap)]
+    #[wasm_bindgen(method, js_name = getMap)]
     pub fn get_map(&mut self, name: &str) -> YMap {
         self.as_ref().get_or_insert_map(name).into()
     }
@@ -247,7 +246,7 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YXmlFragment` instance.
-    #[wasm_bindgen(js_name = getXmlFragment)]
+    #[wasm_bindgen(method, js_name = getXmlFragment)]
     pub fn get_xml_fragment(&mut self, name: &str) -> YXmlFragment {
         YXmlFragment(self.as_ref().get_or_insert_xml_fragment(name))
     }
@@ -259,7 +258,7 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YXmlElement` instance.
-    #[wasm_bindgen(js_name = getXmlElement)]
+    #[wasm_bindgen(method, js_name = getXmlElement)]
     pub fn get_xml_element(&mut self, name: &str) -> YXmlElement {
         YXmlElement(self.as_ref().get_or_insert_xml_element(name))
     }
@@ -271,7 +270,7 @@ impl YDoc {
     ///
     /// If there was an instance with this name, but it was of different type, it will be projected
     /// onto `YXmlText` instance.
-    #[wasm_bindgen(js_name = getXmlText)]
+    #[wasm_bindgen(method, js_name = getXmlText)]
     pub fn get_xml_text(&mut self, name: &str) -> YXmlText {
         YXmlText(self.as_ref().get_or_insert_xml_text(name))
     }
@@ -281,7 +280,7 @@ impl YDoc {
     /// update.
     ///
     /// Returns an observer, which can be freed in order to unsubscribe this callback.
-    #[wasm_bindgen(js_name = onUpdate)]
+    #[wasm_bindgen(method, js_name = onUpdate)]
     pub fn on_update(&mut self, f: js_sys::Function) -> YUpdateObserver {
         self.as_ref()
             .observe_update_v1(move |_, e| {
@@ -297,7 +296,7 @@ impl YDoc {
     /// update.
     ///
     /// Returns an observer, which can be freed in order to unsubscribe this callback.
-    #[wasm_bindgen(js_name = onUpdateV2)]
+    #[wasm_bindgen(method, js_name = onUpdateV2)]
     pub fn on_update_v2(&mut self, f: js_sys::Function) -> YUpdateObserver {
         self.as_ref()
             .observe_update_v2(move |_, e| {
@@ -312,7 +311,7 @@ impl YDoc {
     /// being committed.
     ///
     /// Returns an observer, which can be freed in order to unsubscribe this callback.
-    #[wasm_bindgen(js_name = onAfterTransaction)]
+    #[wasm_bindgen(method, js_name = onAfterTransaction)]
     pub fn on_after_transaction(&mut self, f: js_sys::Function) -> YAfterTransactionObserver {
         self.as_ref()
             .observe_transaction_cleanup(move |_, e| {
@@ -327,7 +326,7 @@ impl YDoc {
     /// or loaded as children of a current document.
     ///
     /// Returns an observer, which can be freed in order to unsubscribe this callback.
-    #[wasm_bindgen(js_name = onSubdocs)]
+    #[wasm_bindgen(method, js_name = onSubdocs)]
     pub fn on_subdocs(&mut self, f: js_sys::Function) -> YSubdocsObserver {
         self.as_ref()
             .observe_subdocs(move |_, e| {
@@ -341,7 +340,7 @@ impl YDoc {
     /// Subscribes given function to be called, whenever current document is being destroyed.
     ///
     /// Returns an observer, which can be freed in order to unsubscribe this callback.
-    #[wasm_bindgen(js_name = onDestroy)]
+    #[wasm_bindgen(method, js_name = onDestroy)]
     pub fn on_destroy(&mut self, f: js_sys::Function) -> YDestroyObserver {
         self.as_ref()
             .observe_destroy(move |_, e| {
@@ -354,7 +353,7 @@ impl YDoc {
 
     /// Notify the parent document that you request to load data into this subdocument
     /// (if it is a subdocument).
-    #[wasm_bindgen(js_name = load)]
+    #[wasm_bindgen(method, js_name = load)]
     pub fn load(&self, parent_txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(parent_txn) {
             self.0.load(txn)
@@ -367,7 +366,7 @@ impl YDoc {
     }
 
     /// Emit `onDestroy` event and unregister all event handlers.
-    #[wasm_bindgen(js_name = destroy)]
+    #[wasm_bindgen(method, js_name = destroy)]
     pub fn destroy(&mut self, parent_txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(parent_txn) {
             self.0.destroy(txn)
@@ -380,7 +379,7 @@ impl YDoc {
     }
 
     /// Returns a list of sub-documents existings within the scope of this document.
-    #[wasm_bindgen(js_name = getSubdocs)]
+    #[wasm_bindgen(method, js_name = getSubdocs)]
     pub fn subdocs(&self, txn: &ImplicitTransaction) -> js_sys::Array {
         let doc = self.as_ref();
         let buf = js_sys::Array::new();
@@ -401,7 +400,7 @@ impl YDoc {
 
     /// Returns a list of unique identifiers of the sub-documents existings within the scope of
     /// this document.
-    #[wasm_bindgen(js_name = getSubdocGuids)]
+    #[wasm_bindgen(method, js_name = getSubdocGuids)]
     pub fn subdoc_guids(&self, txn: &ImplicitTransaction) -> js_sys::Set {
         let doc = self.as_ref();
         let buf = js_sys::Set::new(&js_sys::Array::new());
@@ -492,13 +491,13 @@ fn parse_options(js: &JsValue) -> Options {
 ///
 /// applyUpdate(localDoc, remoteDelta)
 /// ```
-#[wasm_bindgen(js_name = encodeStateVector)]
+#[wasm_bindgen(method, js_name = encodeStateVector)]
 pub fn encode_state_vector(doc: &mut YDoc) -> Uint8Array {
     doc.read_transaction().state_vector_v1()
 }
 
 /// Returns a string dump representation of a given `update` encoded using lib0 v1 encoding.
-#[wasm_bindgen(js_name = debugUpdateV1)]
+#[wasm_bindgen(method, js_name = debugUpdateV1)]
 pub fn debug_update_v1(update: Uint8Array) -> Result<String, JsValue> {
     let update: Vec<u8> = update.to_vec();
     let mut decoder = DecoderV1::from(update.as_slice());
@@ -509,7 +508,7 @@ pub fn debug_update_v1(update: Uint8Array) -> Result<String, JsValue> {
 }
 
 /// Returns a string dump representation of a given `update` encoded using lib0 v2 encoding.
-#[wasm_bindgen(js_name = debugUpdateV2)]
+#[wasm_bindgen(method, js_name = debugUpdateV2)]
 pub fn debug_update_v2(update: Uint8Array) -> Result<String, JsValue> {
     let mut update: Vec<u8> = update.to_vec();
     match Update::decode_v2(update.as_mut_slice()) {
@@ -538,7 +537,7 @@ pub fn debug_update_v2(update: Uint8Array) -> Result<String, JsValue> {
 ///
 /// applyUpdate(localDoc, remoteDelta)
 /// ```
-#[wasm_bindgen(js_name = encodeStateAsUpdate)]
+#[wasm_bindgen(method, js_name = encodeStateAsUpdate)]
 pub fn encode_state_as_update(
     doc: &mut YDoc,
     vector: Option<Uint8Array>,
@@ -566,7 +565,7 @@ pub fn encode_state_as_update(
 ///
 /// applyUpdate(localDoc, remoteDelta)
 /// ```
-#[wasm_bindgen(catch, js_name = encodeStateAsUpdateV2)]
+#[wasm_bindgen(method, catch, js_name = encodeStateAsUpdateV2)]
 pub fn encode_state_as_update_v2(
     doc: &mut YDoc,
     vector: Option<Uint8Array>,
@@ -592,7 +591,7 @@ pub fn encode_state_as_update_v2(
 ///
 /// applyUpdateV2(localDoc, remoteDelta)
 /// ```
-#[wasm_bindgen(catch, js_name = applyUpdate)]
+#[wasm_bindgen(method, catch, js_name = applyUpdate)]
 pub fn apply_update(doc: &mut YDoc, diff: Uint8Array, origin: JsValue) -> Result<(), JsValue> {
     doc.write_transaction(origin).apply_v1(diff)
 }
@@ -615,7 +614,7 @@ pub fn apply_update(doc: &mut YDoc, diff: Uint8Array, origin: JsValue) -> Result
 ///
 /// applyUpdateV2(localDoc, remoteDelta)
 /// ```
-#[wasm_bindgen(catch, js_name = applyUpdateV2)]
+#[wasm_bindgen(method, catch, js_name = applyUpdateV2)]
 pub fn apply_update_v2(doc: &mut YDoc, diff: Uint8Array, origin: JsValue) -> Result<(), JsValue> {
     doc.write_transaction(origin).apply_v2(diff)
 }
@@ -756,7 +755,7 @@ impl<'doc> From<TransactionMut<'doc>> for YTransaction {
 #[wasm_bindgen]
 impl YTransaction {
     /// Returns true if current transaction can be used only for read operations.
-    #[wasm_bindgen(js_name = isReadOnly)]
+    #[wasm_bindgen(method, getter, js_name = isReadOnly)]
     pub fn is_readonly(&mut self) -> bool {
         match &self.0 {
             InnerTxn::ReadOnly(_) => true,
@@ -765,13 +764,13 @@ impl YTransaction {
     }
 
     /// Returns true if current transaction can be used only for updating the document store.
-    #[wasm_bindgen(js_name = isWriteable)]
+    #[wasm_bindgen(method, getter, js_name = isWriteable)]
     pub fn is_writeable(&mut self) -> bool {
         !self.is_readonly()
     }
 
     /// Returns true if current transaction can be used only for updating the document store.
-    #[wasm_bindgen(getter, js_name = origin)]
+    #[wasm_bindgen(method, getter, js_name = origin)]
     pub fn origin(&mut self) -> JsValue {
         match &self.0 {
             InnerTxn::ReadOnly(_) => JsValue::NULL,
@@ -789,7 +788,7 @@ impl YTransaction {
     /// Triggers a post-update series of operations without `free`ing the transaction. This includes
     /// compaction and optimization of internal representation of updates, triggering events etc.
     /// ywasm transactions are auto-committed when they are `free`d.
-    #[wasm_bindgen(js_name = commit)]
+    #[wasm_bindgen(method, js_name = commit)]
     pub fn commit(&mut self) {
         match &mut self.0 {
             InnerTxn::ReadOnly(_) => {}
@@ -824,7 +823,7 @@ impl YTransaction {
     ///     remoteTxn.free()
     /// }
     /// ```
-    #[wasm_bindgen(js_name = stateVectorV1)]
+    #[wasm_bindgen(method, js_name = stateVectorV1)]
     pub fn state_vector_v1(&self) -> Uint8Array {
         let sv = self.state_vector();
         let payload = sv.encode_v1();
@@ -858,7 +857,7 @@ impl YTransaction {
     ///     remoteTxn.free()
     /// }
     /// ```
-    #[wasm_bindgen(catch, js_name = diffV1)]
+    #[wasm_bindgen(method, catch, js_name = diffV1)]
     pub fn diff_v1(&self, vector: Option<Uint8Array>) -> Result<Uint8Array, JsValue> {
         let mut encoder = EncoderV1::new();
         let sv = if let Some(vector) = vector {
@@ -903,7 +902,7 @@ impl YTransaction {
     ///     remoteTxn.free()
     /// }
     /// ```
-    #[wasm_bindgen(catch, js_name = diffV2)]
+    #[wasm_bindgen(method, catch, js_name = diffV2)]
     pub fn diff_v2(&self, vector: Option<Uint8Array>) -> Result<Uint8Array, JsValue> {
         let mut encoder = EncoderV2::new();
         let sv = if let Some(vector) = vector {
@@ -946,7 +945,7 @@ impl YTransaction {
     ///     remoteTxn.free()
     /// }
     /// ```
-    #[wasm_bindgen(catch, js_name = applyV1)]
+    #[wasm_bindgen(method, catch, js_name = applyV1)]
     pub fn apply_v1(&mut self, diff: Uint8Array) -> Result<(), JsValue> {
         let diff: Vec<u8> = diff.to_vec();
         let mut decoder = DecoderV1::from(diff.as_slice());
@@ -992,7 +991,7 @@ impl YTransaction {
     ///     remoteTxn.free()
     /// }
     /// ```
-    #[wasm_bindgen(catch, js_name = applyV2)]
+    #[wasm_bindgen(method, catch, js_name = applyV2)]
     pub fn apply_v2(&mut self, diff: Uint8Array) -> Result<(), JsValue> {
         let mut diff: Vec<u8> = diff.to_vec();
         match Update::decode_v2(&mut diff) {
@@ -1001,7 +1000,7 @@ impl YTransaction {
         }
     }
 
-    #[wasm_bindgen(js_name = encodeUpdate)]
+    #[wasm_bindgen(method, js_name = encodeUpdate)]
     pub fn encode_update(&mut self) -> Uint8Array {
         let out = match &self.0 {
             InnerTxn::ReadOnly(_) => vec![0u8, 0u8],
@@ -1010,7 +1009,7 @@ impl YTransaction {
         Uint8Array::from(&out[..out.len()])
     }
 
-    #[wasm_bindgen(js_name = encodeUpdateV2)]
+    #[wasm_bindgen(method, js_name = encodeUpdateV2)]
     pub fn encode_update_v2(&mut self) -> Uint8Array {
         let out = match &self.0 {
             InnerTxn::ReadOnly(_) => vec![0u8, 0u8],
@@ -1815,7 +1814,7 @@ impl YText {
 
     /// Returns length of an underlying string stored in this `YText` instance,
     /// understood as a number of UTF-8 encoded bytes.
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -1830,7 +1829,7 @@ impl YText {
     }
 
     /// Returns an underlying shared string stored in this data type.
-    #[wasm_bindgen(js_name = toString)]
+    #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(&self, txn: &ImplicitTransaction) -> String {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -1845,7 +1844,7 @@ impl YText {
     }
 
     /// Returns an underlying shared string stored in this data type.
-    #[wasm_bindgen(js_name = toJson)]
+    #[wasm_bindgen(method, js_name = toJson)]
     pub fn to_json(&self, txn: &ImplicitTransaction) -> JsValue {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -1864,7 +1863,7 @@ impl YText {
     /// Optional object with defined `attributes` will be used to wrap provided text `chunk`
     /// with a formatting blocks.`attributes` are only supported for a `YText` instance which
     /// already has been integrated into document store.
-    #[wasm_bindgen(js_name = insert)]
+    #[wasm_bindgen(method, js_name = insert)]
     pub fn insert(&self, index: u32, chunk: &str, attributes: JsValue, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -1898,7 +1897,7 @@ impl YText {
     /// Optional object with defined `attributes` will be used to wrap provided `embed`
     /// with a formatting blocks.`attributes` are only supported for a `YText` instance which
     /// already has been integrated into document store.
-    #[wasm_bindgen(js_name = insertEmbed)]
+    #[wasm_bindgen(method, js_name = insertEmbed)]
     pub fn insert_embed(
         &self,
         index: u32,
@@ -1934,7 +1933,7 @@ impl YText {
     /// Wraps an existing piece of text within a range described by `index`-`length` parameters with
     /// formatting blocks containing provided `attributes` metadata. This method only works for
     /// `YText` instances that already have been integrated into document store.
-    #[wasm_bindgen(js_name = format)]
+    #[wasm_bindgen(method, js_name = format)]
     pub fn format(&self, index: u32, length: u32, attributes: JsValue, txn: &ImplicitTransaction) {
         if let Some(attrs) = Self::parse_attrs(attributes) {
             match &mut *self.0.borrow_mut() {
@@ -1975,7 +1974,7 @@ impl YText {
     /// Optional object with defined `attributes` will be used to wrap provided text `chunk`
     /// with a formatting blocks.`attributes` are only supported for a `YText` instance which
     /// already has been integrated into document store.
-    #[wasm_bindgen(js_name = push)]
+    #[wasm_bindgen(method, js_name = push)]
     pub fn push(&self, chunk: &str, attributes: JsValue, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2006,7 +2005,7 @@ impl YText {
 
     /// Deletes a specified range of of characters, starting at a given `index`.
     /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
-    #[wasm_bindgen(js_name = delete)]
+    #[wasm_bindgen(method, js_name = delete)]
     pub fn delete(&mut self, index: u32, length: u32, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2024,7 +2023,7 @@ impl YText {
     }
 
     /// Returns the Delta representation of this YText type.
-    #[wasm_bindgen(js_name = toDelta)]
+    #[wasm_bindgen(method, js_name = toDelta)]
     pub fn to_delta(
         &self,
         snapshot: Option<YSnapshot>,
@@ -2079,7 +2078,7 @@ impl YText {
     /// Subscribes to all operations happening over this instance of `YText`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YTextObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observe)]
+    #[wasm_bindgen(method, js_name = observe)]
     pub fn observe(&mut self, f: js_sys::Function) -> YTextObserver {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2100,7 +2099,7 @@ impl YText {
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observeDeep)]
+    #[wasm_bindgen(method, js_name = observeDeep)]
     pub fn observe_deep(&mut self, f: js_sys::Function) -> YEventObserver {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2253,7 +2252,7 @@ impl YArray {
     }
 
     /// Returns a number of elements stored within this instance of `YArray`.
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2268,7 +2267,7 @@ impl YArray {
     }
 
     /// Converts an underlying contents of this `YArray` instance into their JSON representation.
-    #[wasm_bindgen(js_name = toJson)]
+    #[wasm_bindgen(method, js_name = toJson)]
     pub fn to_json(&self, txn: &ImplicitTransaction) -> JsValue {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2290,7 +2289,7 @@ impl YArray {
     }
 
     /// Inserts a given range of `items` into this `YArray` instance, starting at given `index`.
-    #[wasm_bindgen(js_name = insert)]
+    #[wasm_bindgen(method, js_name = insert)]
     pub fn insert(&self, index: u32, items: Vec<JsValue>, txn: &ImplicitTransaction) {
         let mut j = index;
         match &mut *self.0.borrow_mut() {
@@ -2312,7 +2311,7 @@ impl YArray {
     }
 
     /// Appends a range of `items` at the end of this `YArray` instance.
-    #[wasm_bindgen(js_name = push)]
+    #[wasm_bindgen(method, js_name = push)]
     pub fn push(&self, items: Vec<JsValue>, txn: &ImplicitTransaction) {
         let index = self.length(txn);
         self.insert(index, items, txn);
@@ -2320,7 +2319,7 @@ impl YArray {
 
     /// Deletes a range of items of given `length` from current `YArray` instance,
     /// starting from given `index`.
-    #[wasm_bindgen(js_name = delete)]
+    #[wasm_bindgen(method, js_name = delete)]
     pub fn delete(&self, index: u32, length: u32, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2338,7 +2337,7 @@ impl YArray {
     }
 
     /// Moves element found at `source` index into `target` index position.
-    #[wasm_bindgen(js_name = move)]
+    #[wasm_bindgen(method, js_name = move)]
     pub fn move_content(&self, source: u32, target: u32, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2358,7 +2357,7 @@ impl YArray {
     }
 
     /// Returns an element stored under given `index`.
-    #[wasm_bindgen(catch, js_name = get)]
+    #[wasm_bindgen(method, catch, js_name = get)]
     pub fn get(&self, index: u32, txn: &ImplicitTransaction) -> Result<JsValue, JsValue> {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2408,7 +2407,7 @@ impl YArray {
     ///     txn.free()
     /// }
     /// ```
-    #[wasm_bindgen(js_name = values)]
+    #[wasm_bindgen(method, js_name = values)]
     pub fn values(&self, txn: &ImplicitTransaction) -> JsValue {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2431,7 +2430,7 @@ impl YArray {
     /// Subscribes to all operations happening over this instance of `YArray`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observe)]
+    #[wasm_bindgen(method, js_name = observe)]
     pub fn observe(&mut self, f: js_sys::Function) -> YArrayObserver {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2452,7 +2451,7 @@ impl YArray {
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observeDeep)]
+    #[wasm_bindgen(method, js_name = observeDeep)]
     pub fn observe_deep(&mut self, f: js_sys::Function) -> YEventObserver {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => v
@@ -2604,7 +2603,7 @@ impl YMap {
     }
 
     /// Returns a number of entries stored within this instance of `YMap`.
-    #[wasm_bindgen(method)]
+    #[wasm_bindgen(method, js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2619,7 +2618,7 @@ impl YMap {
     }
 
     /// Converts contents of this `YMap` instance into a JSON representation.
-    #[wasm_bindgen(js_name = toJson)]
+    #[wasm_bindgen(method, js_name = toJson)]
     pub fn to_json(&self, txn: &ImplicitTransaction) -> JsValue {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2642,7 +2641,7 @@ impl YMap {
 
     /// Sets a given `key`-`value` entry within this instance of `YMap`. If another entry was
     /// already stored under given `key`, it will be overridden with new `value`.
-    #[wasm_bindgen(js_name = set)]
+    #[wasm_bindgen(method, js_name = set)]
     pub fn set(&self, key: &str, value: JsValue, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2660,7 +2659,7 @@ impl YMap {
     }
 
     /// Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
-    #[wasm_bindgen(js_name = delete)]
+    #[wasm_bindgen(method, js_name = delete)]
     pub fn delete(&mut self, key: &str, txn: &ImplicitTransaction) {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2679,7 +2678,7 @@ impl YMap {
 
     /// Returns value of an entry stored under given `key` within this instance of `YMap`,
     /// or `undefined` if no such entry existed.
-    #[wasm_bindgen(js_name = get)]
+    #[wasm_bindgen(method, js_name = get)]
     pub fn get(&self, key: &str, txn: &ImplicitTransaction) -> JsValue {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2728,7 +2727,7 @@ impl YMap {
     ///     txn.free()
     /// }
     /// ```
-    #[wasm_bindgen(js_name = entries)]
+    #[wasm_bindgen(method, js_name = entries)]
     pub fn entries(&self, txn: &ImplicitTransaction) -> JsValue {
         match &*self.0.borrow() {
             SharedType::Integrated(v) => {
@@ -2756,7 +2755,7 @@ impl YMap {
     /// Subscribes to all operations happening over this instance of `YMap`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observe)]
+    #[wasm_bindgen(method, js_name = observe)]
     pub fn observe(&mut self, f: js_sys::Function) -> YMapObserver {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => {
@@ -2777,7 +2776,7 @@ impl YMap {
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observeDeep)]
+    #[wasm_bindgen(method, js_name = observeDeep)]
     pub fn observe_deep(&mut self, f: js_sys::Function) -> YEventObserver {
         match &mut *self.0.borrow_mut() {
             SharedType::Integrated(v) => v
@@ -2818,7 +2817,7 @@ impl YXmlElement {
     }
 
     /// Returns a number of child XML nodes stored within this `YXMlElement` instance.
-    #[wasm_bindgen(js_name = length)]
+    #[wasm_bindgen(method, js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
         if let Some(txn) = get_txn(txn) {
             self.0.len(txn)
@@ -2829,7 +2828,7 @@ impl YXmlElement {
     }
 
     /// Inserts a new instance of `YXmlElement` as a child of this XML node and returns it.
-    #[wasm_bindgen(js_name = insertXmlElement)]
+    #[wasm_bindgen(method, js_name = insertXmlElement)]
     pub fn insert_xml_element(
         &self,
         index: u32,
@@ -2848,7 +2847,7 @@ impl YXmlElement {
     }
 
     /// Inserts a new instance of `YXmlText` as a child of this XML node and returns it.
-    #[wasm_bindgen(js_name = insertXmlText)]
+    #[wasm_bindgen(method, js_name = insertXmlText)]
     pub fn insert_xml_text(&self, index: u32, txn: &ImplicitTransaction) -> YXmlText {
         if let Some(txn) = get_txn_mut(txn) {
             YXmlText(self.0.insert(txn, index, XmlTextPrelim("")))
@@ -2860,7 +2859,7 @@ impl YXmlElement {
 
     /// Removes a range of children XML nodes from this `YXmlElement` instance,
     /// starting at given `index`.
-    #[wasm_bindgen(js_name = delete)]
+    #[wasm_bindgen(method, js_name = delete)]
     pub fn delete(&self, index: u32, length: u32, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.remove_range(txn, index, length)
@@ -2871,7 +2870,7 @@ impl YXmlElement {
     }
 
     /// Appends a new instance of `YXmlElement` as the last child of this XML node and returns it.
-    #[wasm_bindgen(js_name = pushXmlElement)]
+    #[wasm_bindgen(method, js_name = pushXmlElement)]
     pub fn push_xml_element(&self, name: &str, txn: &ImplicitTransaction) -> YXmlElement {
         if let Some(txn) = get_txn_mut(txn) {
             YXmlElement(self.0.push_back(txn, XmlElementPrelim::empty(name)))
@@ -2882,7 +2881,7 @@ impl YXmlElement {
     }
 
     /// Appends a new instance of `YXmlText` as the last child of this XML node and returns it.
-    #[wasm_bindgen(js_name = pushXmlText)]
+    #[wasm_bindgen(method, js_name = pushXmlText)]
     pub fn push_xml_text(&self, txn: &ImplicitTransaction) -> YXmlText {
         if let Some(txn) = get_txn_mut(txn) {
             YXmlText(self.0.push_back(txn, XmlTextPrelim("")))
@@ -2894,7 +2893,7 @@ impl YXmlElement {
 
     /// Returns a first child of this XML node.
     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node has not children.
-    #[wasm_bindgen(js_name = firstChild)]
+    #[wasm_bindgen(method, js_name = firstChild)]
     pub fn first_child(&self) -> JsValue {
         if let Some(xml) = self.0.first_child() {
             xml_into_js(xml)
@@ -2906,7 +2905,7 @@ impl YXmlElement {
     /// Returns a next XML sibling node of this XMl node.
     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
     /// parent XML node.
-    #[wasm_bindgen(js_name = nextSibling)]
+    #[wasm_bindgen(method, js_name = nextSibling)]
     pub fn next_sibling(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn_mut(txn) {
             let mut siblings = self.0.siblings(txn);
@@ -2927,7 +2926,7 @@ impl YXmlElement {
     /// Returns a previous XML sibling node of this XMl node.
     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
     /// of parent XML node.
-    #[wasm_bindgen(js_name = prevSibling)]
+    #[wasm_bindgen(method, js_name = prevSibling)]
     pub fn prev_sibling(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn_mut(txn) {
             let mut siblings = self.0.siblings(txn);
@@ -2946,7 +2945,7 @@ impl YXmlElement {
     }
 
     /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
-    #[wasm_bindgen(js_name = parent)]
+    #[wasm_bindgen(method, getter, js_name = parent)]
     pub fn parent(&self) -> JsValue {
         if let Some(xml) = self.0.parent() {
             xml_into_js(xml)
@@ -2956,7 +2955,7 @@ impl YXmlElement {
     }
 
     /// Returns a string representation of this XML node.
-    #[wasm_bindgen(js_name = toString)]
+    #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(&self, txn: &ImplicitTransaction) -> String {
         if let Some(txn) = get_txn(txn) {
             self.0.get_string(txn)
@@ -2967,7 +2966,7 @@ impl YXmlElement {
 
     /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
     /// `name` already existed on that node, its value with be overridden with a provided one.
-    #[wasm_bindgen(js_name = setAttribute)]
+    #[wasm_bindgen(method, js_name = setAttribute)]
     pub fn set_attribute(&self, name: &str, value: &str, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.insert_attribute(txn, name, value)
@@ -2979,7 +2978,7 @@ impl YXmlElement {
 
     /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
     /// `null` will be returned.
-    #[wasm_bindgen(js_name = getAttribute)]
+    #[wasm_bindgen(method, js_name = getAttribute)]
     pub fn get_attribute(&self, name: &str, txn: &ImplicitTransaction) -> Option<String> {
         if let Some(txn) = get_txn(txn) {
             self.0.get_attribute(txn, name)
@@ -2990,7 +2989,7 @@ impl YXmlElement {
     }
 
     /// Removes an attribute from this XML node, given its `name`.
-    #[wasm_bindgen(js_name = removeAttribute)]
+    #[wasm_bindgen(method, js_name = removeAttribute)]
     pub fn remove_attribute(&self, name: &str, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.remove_attribute(txn, &name);
@@ -3002,7 +3001,7 @@ impl YXmlElement {
 
     /// Returns an iterator that enables to traverse over all attributes of this XML node in
     /// unspecified order.
-    #[wasm_bindgen(js_name = attributes)]
+    #[wasm_bindgen(method, js_name = attributes)]
     pub fn attributes(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn(txn) {
             let attrs = self.0.attributes(txn);
@@ -3016,7 +3015,7 @@ impl YXmlElement {
 
     /// Returns an iterator that enables a deep traversal of this XML node - starting from first
     /// child over this XML node successors using depth-first strategy.
-    #[wasm_bindgen(js_name = treeWalker)]
+    #[wasm_bindgen(method, js_name = treeWalker)]
     pub fn tree_walker(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn(txn) {
             let tree_walker = self.0.successors(txn);
@@ -3031,7 +3030,7 @@ impl YXmlElement {
     /// Subscribes to all operations happening over this instance of `YXmlElement`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observe)]
+    #[wasm_bindgen(method, js_name = observe)]
     pub fn observe(&mut self, f: js_sys::Function) -> YXmlObserver {
         let sub = self.0.observe(move |txn, e| {
             let e = YXmlEvent::new(e, txn);
@@ -3045,7 +3044,7 @@ impl YXmlElement {
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observeDeep)]
+    #[wasm_bindgen(method, js_name = observeDeep)]
     pub fn observe_deep(&mut self, f: js_sys::Function) -> YEventObserver {
         let sub = self.0.observe_deep(move |txn, e| {
             let arg = events_into_js(txn, e);
@@ -3076,7 +3075,7 @@ impl YXmlFragment {
     }
 
     /// Inserts a new instance of `YXmlElement` as a child of this XML node and returns it.
-    #[wasm_bindgen(js_name = insertXmlElement)]
+    #[wasm_bindgen(method, js_name = insertXmlElement)]
     pub fn insert_xml_element(
         &self,
         index: u32,
@@ -3095,7 +3094,7 @@ impl YXmlFragment {
     }
 
     /// Inserts a new instance of `YXmlText` as a child of this XML node and returns it.
-    #[wasm_bindgen(js_name = insertXmlText)]
+    #[wasm_bindgen(method, js_name = insertXmlText)]
     pub fn insert_xml_text(&self, index: u32, txn: &ImplicitTransaction) -> YXmlText {
         if let Some(txn) = get_txn_mut(txn) {
             YXmlText(self.0.insert(txn, index, XmlTextPrelim("")))
@@ -3107,7 +3106,7 @@ impl YXmlFragment {
 
     /// Removes a range of children XML nodes from this `YXmlElement` instance,
     /// starting at given `index`.
-    #[wasm_bindgen(js_name = delete)]
+    #[wasm_bindgen(method, js_name = delete)]
     pub fn delete(&self, index: u32, length: u32, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.remove_range(txn, index, length)
@@ -3118,7 +3117,7 @@ impl YXmlFragment {
     }
 
     /// Appends a new instance of `YXmlElement` as the last child of this XML node and returns it.
-    #[wasm_bindgen(js_name = pushXmlElement)]
+    #[wasm_bindgen(method, js_name = pushXmlElement)]
     pub fn push_xml_element(&self, name: &str, txn: &ImplicitTransaction) -> YXmlElement {
         if let Some(txn) = get_txn_mut(txn) {
             YXmlElement(self.0.push_back(txn, XmlElementPrelim::empty(name)))
@@ -3129,7 +3128,7 @@ impl YXmlFragment {
     }
 
     /// Appends a new instance of `YXmlText` as the last child of this XML node and returns it.
-    #[wasm_bindgen(js_name = pushXmlText)]
+    #[wasm_bindgen(method, js_name = pushXmlText)]
     pub fn push_xml_text(&self, txn: &ImplicitTransaction) -> YXmlText {
         if let Some(txn) = get_txn_mut(txn) {
             YXmlText(self.0.push_back(txn, XmlTextPrelim("")))
@@ -3141,7 +3140,7 @@ impl YXmlFragment {
 
     /// Returns a first child of this XML node.
     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node has not children.
-    #[wasm_bindgen(js_name = firstChild)]
+    #[wasm_bindgen(method, js_name = firstChild)]
     pub fn first_child(&self) -> JsValue {
         if let Some(xml) = self.0.first_child() {
             xml_into_js(xml)
@@ -3151,7 +3150,7 @@ impl YXmlFragment {
     }
 
     /// Returns a string representation of this XML node.
-    #[wasm_bindgen(js_name = toString)]
+    #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(&self, txn: &ImplicitTransaction) -> String {
         if let Some(txn) = get_txn(txn) {
             self.0.get_string(txn)
@@ -3162,7 +3161,7 @@ impl YXmlFragment {
 
     /// Returns an iterator that enables a deep traversal of this XML node - starting from first
     /// child over this XML node successors using depth-first strategy.
-    #[wasm_bindgen(js_name = treeWalker)]
+    #[wasm_bindgen(method, js_name = treeWalker)]
     pub fn tree_walker(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn(txn) {
             let tree_walker = self.0.successors(txn);
@@ -3177,7 +3176,7 @@ impl YXmlFragment {
     /// Subscribes to all operations happening over this instance of `YXmlElement`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observe)]
+    #[wasm_bindgen(method, js_name = observe)]
     pub fn observe(&mut self, f: js_sys::Function) -> YXmlObserver {
         let sub = self.0.observe(move |txn, e| {
             let e = YXmlEvent::new(e, txn);
@@ -3191,7 +3190,7 @@ impl YXmlFragment {
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observeDeep)]
+    #[wasm_bindgen(method, js_name = observeDeep)]
     pub fn observe_deep(&mut self, f: js_sys::Function) -> YEventObserver {
         let sub = self.0.observe_deep(move |txn, e| {
             let arg = events_into_js(txn, e);
@@ -3238,7 +3237,7 @@ impl YXmlText {
     ///
     /// Optional object with defined `attributes` will be used to wrap provided text `chunk`
     /// with a formatting blocks.
-    #[wasm_bindgen(js_name = insert)]
+    #[wasm_bindgen(method, js_name = insert)]
     pub fn insert(&self, index: i32, chunk: &str, attrs: JsValue, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             if let Some(attrs) = YText::parse_attrs(attrs) {
@@ -3260,7 +3259,7 @@ impl YXmlText {
 
     /// Formats text within bounds specified by `index` and `len` with a given formatting
     /// attributes.
-    #[wasm_bindgen(js_name = format)]
+    #[wasm_bindgen(method, js_name = format)]
     pub fn format(&self, index: i32, len: i32, attrs: JsValue, txn: &ImplicitTransaction) {
         if let Some(attrs) = YText::parse_attrs(attrs) {
             if let Some(txn) = get_txn_mut(txn) {
@@ -3279,7 +3278,7 @@ impl YXmlText {
     /// Optional object with defined `attributes` will be used to wrap provided `embed`
     /// with a formatting blocks.`attributes` are only supported for a `YXmlText` instance which
     /// already has been integrated into document store.
-    #[wasm_bindgen(js_name = insertEmbed)]
+    #[wasm_bindgen(method, js_name = insertEmbed)]
     pub fn insert_embed(
         &self,
         index: u32,
@@ -3310,7 +3309,7 @@ impl YXmlText {
     ///
     /// Optional object with defined `attributes` will be used to wrap provided text `chunk`
     /// with a formatting blocks.
-    #[wasm_bindgen(js_name = push)]
+    #[wasm_bindgen(method, js_name = push)]
     pub fn push(&self, chunk: &str, attrs: JsValue, txn: &ImplicitTransaction) {
         let index = if let Some(txn) = get_txn(txn) {
             self.0.len(txn)
@@ -3323,7 +3322,7 @@ impl YXmlText {
 
     /// Deletes a specified range of of characters, starting at a given `index`.
     /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
-    #[wasm_bindgen(js_name = delete)]
+    #[wasm_bindgen(method, js_name = delete)]
     pub fn delete(&self, index: u32, length: u32, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.remove_range(txn, index, length)
@@ -3336,7 +3335,7 @@ impl YXmlText {
     /// Returns a next XML sibling node of this XMl node.
     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a last child of
     /// parent XML node.
-    #[wasm_bindgen(js_name = nextSibling)]
+    #[wasm_bindgen(method, js_name = nextSibling)]
     pub fn next_sibling(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn_mut(txn) {
             let mut siblings = self.0.siblings(txn);
@@ -3357,7 +3356,7 @@ impl YXmlText {
     /// Returns a previous XML sibling node of this XMl node.
     /// It can be either `YXmlElement`, `YXmlText` or `undefined` if current node is a first child
     /// of parent XML node.
-    #[wasm_bindgen(js_name = prevSibling)]
+    #[wasm_bindgen(method, js_name = prevSibling)]
     pub fn prev_sibling(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn_mut(txn) {
             let mut siblings = self.0.siblings(txn);
@@ -3376,7 +3375,7 @@ impl YXmlText {
     }
 
     /// Returns a parent `YXmlElement` node or `undefined` if current node has no parent assigned.
-    #[wasm_bindgen(js_name = parent)]
+    #[wasm_bindgen(method, getter, js_name = parent)]
     pub fn parent(&self) -> JsValue {
         if let Some(xml) = self.0.parent() {
             xml_into_js(xml)
@@ -3386,7 +3385,7 @@ impl YXmlText {
     }
 
     /// Returns an underlying string stored in this `YXmlText` instance.
-    #[wasm_bindgen(js_name = toString)]
+    #[wasm_bindgen(method, js_name = toString)]
     pub fn to_string(&self, txn: &ImplicitTransaction) -> String {
         if let Some(txn) = get_txn(txn) {
             self.0.get_string(txn)
@@ -3398,7 +3397,7 @@ impl YXmlText {
 
     /// Sets a `name` and `value` as new attribute for this XML node. If an attribute with the same
     /// `name` already existed on that node, its value with be overridden with a provided one.
-    #[wasm_bindgen(js_name = setAttribute)]
+    #[wasm_bindgen(method, js_name = setAttribute)]
     pub fn set_attribute(&self, name: &str, value: &str, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.insert_attribute(txn, name, value);
@@ -3410,7 +3409,7 @@ impl YXmlText {
 
     /// Returns a value of an attribute given its `name`. If no attribute with such name existed,
     /// `null` will be returned.
-    #[wasm_bindgen(js_name = getAttribute)]
+    #[wasm_bindgen(method, js_name = getAttribute)]
     pub fn get_attribute(&self, name: &str, txn: &ImplicitTransaction) -> Option<String> {
         if let Some(txn) = get_txn(txn) {
             self.0.get_attribute(txn, name)
@@ -3421,7 +3420,7 @@ impl YXmlText {
     }
 
     /// Removes an attribute from this XML node, given its `name`.
-    #[wasm_bindgen(js_name = removeAttribute)]
+    #[wasm_bindgen(method, js_name = removeAttribute)]
     pub fn remove_attribute(&self, name: &str, txn: &ImplicitTransaction) {
         if let Some(txn) = get_txn_mut(txn) {
             self.0.remove_attribute(txn, &name);
@@ -3433,7 +3432,7 @@ impl YXmlText {
 
     /// Returns an iterator that enables to traverse over all attributes of this XML node in
     /// unspecified order.
-    #[wasm_bindgen(js_name = attributes)]
+    #[wasm_bindgen(method, js_name = attributes)]
     pub fn attributes(&self, txn: &ImplicitTransaction) -> JsValue {
         if let Some(txn) = get_txn(txn) {
             let attrs = self.0.attributes(txn);
@@ -3448,7 +3447,7 @@ impl YXmlText {
     /// Subscribes to all operations happening over this instance of `YXmlText`. All changes are
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observe)]
+    #[wasm_bindgen(method, js_name = observe)]
     pub fn observe(&mut self, f: js_sys::Function) -> YXmlTextObserver {
         let sub = self.0.observe(move |txn, e| {
             let e = YXmlTextEvent::new(e, txn);
@@ -3462,7 +3461,7 @@ impl YXmlText {
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
-    #[wasm_bindgen(js_name = observeDeep)]
+    #[wasm_bindgen(method, js_name = observeDeep)]
     pub fn observe_deep(&mut self, f: js_sys::Function) -> YEventObserver {
         let sub = self.0.observe_deep(move |txn, e| {
             let arg = events_into_js(txn, e);
@@ -3503,7 +3502,7 @@ impl YUndoManager {
         YUndoManager(UndoManager::with_options(doc, &scope, o))
     }
 
-    #[wasm_bindgen(js_name = addToScope)]
+    #[wasm_bindgen(method, js_name = addToScope)]
     pub fn add_to_scope(&mut self, ytypes: js_sys::Array) {
         for js in ytypes.iter() {
             let scope = JsValueWrapper(js);
@@ -3511,17 +3510,17 @@ impl YUndoManager {
         }
     }
 
-    #[wasm_bindgen(js_name = addTrackedOrigin)]
+    #[wasm_bindgen(method, js_name = addTrackedOrigin)]
     pub fn add_tracked_origin(&mut self, origin: JsValue) {
         self.0.include_origin(JsValueWrapper(origin))
     }
 
-    #[wasm_bindgen(js_name = removeTrackedOrigin)]
+    #[wasm_bindgen(method, js_name = removeTrackedOrigin)]
     pub fn remove_tracked_origin(&mut self, origin: JsValue) {
         self.0.exclude_origin(JsValueWrapper(origin))
     }
 
-    #[wasm_bindgen(catch, js_name = clear)]
+    #[wasm_bindgen(method, catch, js_name = clear)]
     pub fn clear(&mut self) -> Result<(), JsValue> {
         if let Err(err) = self.0.clear() {
             Err(JsValue::from_str(&err.to_string()))
@@ -3530,12 +3529,12 @@ impl YUndoManager {
         }
     }
 
-    #[wasm_bindgen(js_name = stopCapturing)]
+    #[wasm_bindgen(method, js_name = stopCapturing)]
     pub fn stop_capturing(&mut self) {
         self.0.reset()
     }
 
-    #[wasm_bindgen(catch, js_name = undo)]
+    #[wasm_bindgen(method, catch, js_name = undo)]
     pub fn undo(&mut self) -> Result<(), JsValue> {
         if let Err(err) = self.0.undo() {
             Err(JsValue::from_str(&err.to_string()))
@@ -3544,7 +3543,7 @@ impl YUndoManager {
         }
     }
 
-    #[wasm_bindgen(catch, js_name = redo)]
+    #[wasm_bindgen(method, catch, js_name = redo)]
     pub fn redo(&mut self) -> Result<(), JsValue> {
         if let Err(err) = self.0.redo() {
             Err(JsValue::from_str(&err.to_string()))
@@ -3553,17 +3552,17 @@ impl YUndoManager {
         }
     }
 
-    #[wasm_bindgen(js_name = canUndo)]
+    #[wasm_bindgen(method, getter, js_name = canUndo)]
     pub fn can_undo(&mut self) -> bool {
         self.0.can_undo()
     }
 
-    #[wasm_bindgen(js_name = canRedo)]
+    #[wasm_bindgen(method, getter, js_name = canRedo)]
     pub fn can_redo(&mut self) -> bool {
         self.0.can_redo()
     }
 
-    #[wasm_bindgen(js_name = onStackItemAdded)]
+    #[wasm_bindgen(method, js_name = onStackItemAdded)]
     pub fn on_item_added(&mut self, callback: js_sys::Function) -> YUndoObserver {
         YUndoObserver(self.0.observe_item_added(move |_, e| {
             let arg: JsValue = YUndoEvent::new(e).into();
@@ -3571,7 +3570,7 @@ impl YUndoManager {
         }))
     }
 
-    #[wasm_bindgen(js_name = onStackItemPopped)]
+    #[wasm_bindgen(method, js_name = onStackItemPopped)]
     pub fn on_item_popped(&mut self, callback: js_sys::Function) -> YUndoObserver {
         YUndoObserver(self.0.observe_item_popped(move |_, e| {
             let arg: JsValue = YUndoEvent::new(e).into();
@@ -3589,15 +3588,15 @@ pub struct YUndoEvent {
 
 #[wasm_bindgen]
 impl YUndoEvent {
-    #[wasm_bindgen(getter, js_name = origin)]
+    #[wasm_bindgen(method, getter, js_name = origin)]
     pub fn origin(&self) -> JsValue {
         self.origin.clone()
     }
-    #[wasm_bindgen(getter, js_name = kind)]
+    #[wasm_bindgen(method, getter, js_name = kind)]
     pub fn kind(&self) -> JsValue {
         self.kind.clone()
     }
-    #[wasm_bindgen(getter, js_name = stackItem)]
+    #[wasm_bindgen(method, getter, js_name = stackItem)]
     pub fn stack_item(&self) -> JsValue {
         self.stack_item.clone()
     }
@@ -4006,7 +4005,6 @@ pub fn create_relative_position_from_type_index(
     assoc: i32,
     txn: &ImplicitTransaction,
 ) -> Result<JsValue, JsValue> {
-    use yrs::RelativeIndex;
     if let Ok(shared) = Shared::try_from(ytype) {
         if shared.is_prelim() {
             return Err(JsValue::from_str(
@@ -4041,23 +4039,18 @@ pub fn create_absolute_position_from_relative_position(
     rpos: &JsValue,
     doc: &YDoc,
 ) -> Result<JsValue, JsValue> {
-    if let Some(pos) = relative_position_from_js(rpos) {
-        let txn = doc.0.transact();
-        if let Some(abs) = pos.absolute(&txn) {
-            Ok(abs.into_js())
-        } else {
-            Ok(JsValue::NULL)
-        }
+    let pos = relative_position_from_js(rpos)?;
+    let txn = doc.0.transact();
+    if let Some(abs) = pos.absolute(&txn) {
+        Ok(abs.into_js())
     } else {
-        Err(JsValue::from_str(
-            "passed parameter is not RelativePosition",
-        ))
+        Ok(JsValue::NULL)
     }
 }
 
 #[wasm_bindgen(catch, js_name=encodeRelativePosition)]
 pub fn encode_relative_position(rpos: &JsValue) -> Result<Uint8Array, JsValue> {
-    if let Some(pos) = relative_position_from_js(rpos) {
+    if let Ok(pos) = relative_position_from_js(rpos) {
         let bytes = Uint8Array::from(pos.encode_v1().as_slice());
         Ok(bytes)
     } else {
@@ -4076,41 +4069,53 @@ pub fn decode_relative_position(bin: Uint8Array) -> Result<JsValue, JsValue> {
     }
 }
 
-fn relative_position_from_js(js: &JsValue) -> Option<RelativePosition> {
-    let value = Reflect::get(js, &JsValue::from_str("item")).ok()?;
+fn relative_position_from_js(js: &JsValue) -> Result<RelativePosition, JsValue> {
+    let value = Reflect::get(js, &JsValue::from_str("item"))?;
     let context = if value.is_undefined() || value.is_null() {
-        let value = Reflect::get(js, &JsValue::from_str("item")).ok()?;
-        let id = id_from_js(&value)?;
-        RelativePositionContext::Relative(id)
-    } else {
-        let value = Reflect::get(js, &JsValue::from_str("tname")).ok()?;
+        let value = Reflect::get(js, &JsValue::from_str("tname"))?;
         if value.is_undefined() || value.is_null() {
-            let value = Reflect::get(js, &JsValue::from_str("type")).ok()?;
+            let value = Reflect::get(js, &JsValue::from_str("type"))?;
             let id = id_from_js(&value)?;
             RelativePositionContext::Nested(id)
         } else {
-            let tname = value.as_string()?;
-            RelativePositionContext::Root(tname.into())
+            if let Some(tname) = value.as_string() {
+                RelativePositionContext::Root(tname.into())
+            } else {
+                return Err(value);
+            }
         }
-    };
-    let assoc = Reflect::get(js, &JsValue::from_str("item")).ok()?;
-    let assoc = if assoc.as_f64()? >= 0.0 {
-        Assoc::After
     } else {
-        Assoc::Before
+        let id = id_from_js(&value)?;
+        RelativePositionContext::Relative(id)
+    };
+    let assoc = Reflect::get(js, &JsValue::from_str("assoc"))?;
+    let assoc = if let Some(a) = assoc.as_f64() {
+        if a >= 0.0 {
+            Assoc::After
+        } else {
+            Assoc::Before
+        }
+    } else {
+        return Err(assoc);
     };
 
-    Some(RelativePosition::new(context, assoc))
+    Ok(RelativePosition::new(context, assoc))
 }
 
-fn id_from_js(js: &JsValue) -> Option<ID> {
-    let client = Reflect::get(js, &JsValue::from_str("client"))
-        .ok()?
-        .as_f64()? as ClientID;
-    let clock = Reflect::get(js, &JsValue::from_str("clock"))
-        .ok()?
-        .as_f64()? as u32;
-    Some(ID::new(client, clock))
+fn id_from_js(js: &JsValue) -> Result<ID, JsValue> {
+    let value = Reflect::get(js, &JsValue::from_str("client"))?;
+    let client = if let Ok(client) = u64::try_from(value) {
+        client as ClientID
+    } else {
+        return Err(JsValue::from_str("ID.client was not a number"));
+    };
+    let value = Reflect::get(js, &JsValue::from_str("clock"))?;
+    let clock = if let Some(clock) = value.as_f64() {
+        clock as u32
+    } else {
+        return Err(JsValue::from_str("ID.clock was not a number"));
+    };
+    Ok(ID::new(client, clock))
 }
 
 impl IntoJs for ID {

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -3998,6 +3998,12 @@ impl<'a> Shared<'a> {
     }
 }
 
+/// Retrieves a relative position corresponding to a given human-readable `index` pointing into
+/// the shared `ytype`. Unlike standard indexes relative position enables to track
+/// the location inside of a shared y-types, even in the face of concurrent updates.
+///
+/// If association is >= 0, the resulting position will point to location **after** the referenced index.
+/// If association is < 0, the resulting position will point to location **before** the referenced index.
 #[wasm_bindgen(catch, js_name=createRelativePositionFromTypeIndex)]
 pub fn create_relative_position_from_type_index(
     ytype: &JsValue,
@@ -4034,6 +4040,8 @@ pub fn create_relative_position_from_type_index(
     Err(JsValue::from_str("shared type parameter is not indexable"))
 }
 
+/// Converts a relative position (see: `createRelativePositionFromTypeIndex`) into an object
+/// containing human-readable index.
 #[wasm_bindgen(catch, js_name=createAbsolutePositionFromRelativePosition)]
 pub fn create_absolute_position_from_relative_position(
     rpos: &JsValue,
@@ -4048,6 +4056,8 @@ pub fn create_absolute_position_from_relative_position(
     }
 }
 
+/// Serializes relative position created by `createRelativePositionFromTypeIndex` into a binary
+/// payload.
 #[wasm_bindgen(catch, js_name=encodeRelativePosition)]
 pub fn encode_relative_position(rpos: &JsValue) -> Result<Uint8Array, JsValue> {
     if let Ok(pos) = relative_position_from_js(rpos) {
@@ -4060,6 +4070,7 @@ pub fn encode_relative_position(rpos: &JsValue) -> Result<Uint8Array, JsValue> {
     }
 }
 
+/// Deserializes relative position serialized previously by `encodeRelativePosition`.
 #[wasm_bindgen(catch, js_name=decodeRelativePosition)]
 pub fn decode_relative_position(bin: Uint8Array) -> Result<JsValue, JsValue> {
     let data: Vec<u8> = bin.to_vec();


### PR DESCRIPTION
This PR changes a `RelativePosition` in order to make it into an exposed structure. It basically allows us to have a "sticky" point of reference for the index in a shared y-type collection that will always place into the same position even when concurrent updates are about to happen. This is very useful i.e. in rich text editors that want to keep cursor position while other peers change the document.

Relative position is serializable and can be turned back and forth between an actual index (as interpreted by humans).

Related to: #241 and #184