### PR TITLE
Rename RelativePosition to StickyIndex

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -875,11 +875,11 @@ typedef struct YUndoEvent {
  * A numeric position is often unsuited for user selections, because it does not change when content is inserted
  * before or after.
  *
- * ```Insert(0, 'x')('a|bc') = 'xa|bc'``` Where | is the relative position.
+ * ```Insert(0, 'x')('a.bc') = 'xa|bc'``` Where `.` is the relative position.
  *
- * Instances of `YRelativePosition` can be freed using `yrelative_position_destroy`.
+ * Instances of `YRelativePosition` can be freed using `yperma_index_destroy`.
  */
-typedef RelativePosition YRelativePosition;
+typedef PermaIndex YPermaIndex;
 
 /**
  * Returns default ceonfiguration for `YOptions`.
@@ -2282,14 +2282,14 @@ char ytype_kind(const Branch *branch);
 /**
  * Releases resources allocated by `YRelativePosition` pointers.
  */
-void yrelative_position_destroy(YRelativePosition *pos);
+void yperma_index_destroy(YPermaIndex *pos);
 
 /**
  * Returns association of current `YRelativePosition`.
  * If association is **after** the referenced inserted character, returned number will be >= 0.
  * If association is **before** the referenced inserted character, returned number will be < 0.
  */
-int yrelative_position_assoc(const YRelativePosition *pos);
+int yperma_index_assoc(const YPermaIndex *pos);
 
 /**
  * Retrieves a `YRelativePosition` corresponding to a given human-readable `index` pointing into
@@ -2299,22 +2299,22 @@ int yrelative_position_assoc(const YRelativePosition *pos);
  * If association is >= 0, the resulting position will point to location **after** the referenced index.
  * If association is < 0, the resulting position will point to location **before** the referenced index.
  */
-YRelativePosition *yrelative_position_from_index(const Branch *branch,
-                                                 YTransaction *txn,
-                                                 int index,
-                                                 int assoc);
+YPermaIndex *yperma_index_from_index(const Branch *branch,
+                                     YTransaction *txn,
+                                     int index,
+                                     int assoc);
 
 /**
  * Serializes `YRelativePosition` into binary representation. `len` parameter is updated with byte
  * length of the generated binary. Returned binary can be free'd using `ybinary_destroy`.
  */
-unsigned char *yrelative_position_encode(const YRelativePosition *pos, int *len);
+unsigned char *yperma_index_encode(const YPermaIndex *pos, int *len);
 
 /**
- * Deserializes `YRelativePosition` from the payload previously serialized using `yrelative_position_encode`.
+ * Deserializes `YRelativePosition` from the payload previously serialized using `yperma_index_encode`.
  */
-YRelativePosition *yrelative_position_decode(const unsigned char *binary,
-                                             int len);
+YPermaIndex *yperma_index_decode(const unsigned char *binary,
+                                 int len);
 
 /**
  * Given `YRelativePosition` and transaction reference, if computes a human-readable index in a
@@ -2323,9 +2323,9 @@ YRelativePosition *yrelative_position_decode(const unsigned char *binary,
  * `out_branch` is getting assigned with a corresponding shared y-type reference.
  * `out_index` will be used to store computed human-readable index.
  */
-void yrelative_position_read(const YRelativePosition *pos,
-                             const YTransaction *txn,
-                             Branch **out_branch,
-                             int *out_index);
+void yperma_index_read(const YPermaIndex *pos,
+                       const YTransaction *txn,
+                       Branch **out_branch,
+                       int *out_index);
 
 #endif

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -80,7 +80,7 @@ typedef struct YXmlTreeWalker {} YXmlTreeWalker;
 
 typedef struct YUndoManager {} YUndoManager;
 
-typedef struct RelativePosition {} RelativePosition;
+typedef struct StickyIndex {} StickyIndex;
 
 
 #include <stdarg.h>
@@ -868,18 +868,18 @@ typedef struct YUndoEvent {
 } YUndoEvent;
 
 /**
- * A relative position is based on the Yjs model and is not affected by document changes.
- * E.g. If you place a relative position before a certain character, it will always point to this character.
- * If you place a relative position at the end of a type, it will always point to the end of the type.
+ * A sticky index is based on the Yjs model and is not affected by document changes.
+ * E.g. If you place a sticky index before a certain character, it will always point to this character.
+ * If you place a sticky index at the end of a type, it will always point to the end of the type.
  *
  * A numeric position is often unsuited for user selections, because it does not change when content is inserted
  * before or after.
  *
- * ```Insert(0, 'x')('a.bc') = 'xa|bc'``` Where `.` is the relative position.
+ * ```Insert(0, 'x')('a.bc') = 'xa.bc'``` Where `.` is the sticky index position.
  *
- * Instances of `YRelativePosition` can be freed using `yperma_index_destroy`.
+ * Instances of `YStickyIndex` can be freed using `ysticky_index_destroy`.
  */
-typedef PermaIndex YPermaIndex;
+typedef StickyIndex YStickyIndex;
 
 /**
  * Returns default ceonfiguration for `YOptions`.
@@ -2280,52 +2280,51 @@ void yundo_manager_unobserve_popped(YUndoManager *mgr, unsigned int subscription
 char ytype_kind(const Branch *branch);
 
 /**
- * Releases resources allocated by `YRelativePosition` pointers.
+ * Releases resources allocated by `YStickyIndex` pointers.
  */
-void yperma_index_destroy(YPermaIndex *pos);
+void ysticky_index_destroy(YStickyIndex *pos);
 
 /**
- * Returns association of current `YRelativePosition`.
+ * Returns association of current `YStickyIndex`.
  * If association is **after** the referenced inserted character, returned number will be >= 0.
  * If association is **before** the referenced inserted character, returned number will be < 0.
  */
-int yperma_index_assoc(const YPermaIndex *pos);
+int ysticky_index_assoc(const YStickyIndex *pos);
 
 /**
- * Retrieves a `YRelativePosition` corresponding to a given human-readable `index` pointing into
- * the shared y-type `branch`. Unlike standard indexes relative position enables to track
+ * Retrieves a `YStickyIndex` corresponding to a given human-readable `index` pointing into
+ * the shared y-type `branch`. Unlike standard indexes sticky one enables to track
  * the location inside of a shared y-types, even in the face of concurrent updates.
  *
  * If association is >= 0, the resulting position will point to location **after** the referenced index.
  * If association is < 0, the resulting position will point to location **before** the referenced index.
  */
-YPermaIndex *yperma_index_from_index(const Branch *branch,
-                                     YTransaction *txn,
-                                     int index,
-                                     int assoc);
+YStickyIndex *ysticky_index_from_index(const Branch *branch,
+                                       YTransaction *txn,
+                                       int index,
+                                       int assoc);
 
 /**
- * Serializes `YRelativePosition` into binary representation. `len` parameter is updated with byte
+ * Serializes `YStickyIndex` into binary representation. `len` parameter is updated with byte
  * length of the generated binary. Returned binary can be free'd using `ybinary_destroy`.
  */
-unsigned char *yperma_index_encode(const YPermaIndex *pos, int *len);
+unsigned char *ysticky_index_encode(const YStickyIndex *pos, int *len);
 
 /**
- * Deserializes `YRelativePosition` from the payload previously serialized using `yperma_index_encode`.
+ * Deserializes `YStickyIndex` from the payload previously serialized using `ysticky_index_encode`.
  */
-YPermaIndex *yperma_index_decode(const unsigned char *binary,
-                                 int len);
+YStickyIndex *ysticky_index_decode(const unsigned char *binary, int len);
 
 /**
- * Given `YRelativePosition` and transaction reference, if computes a human-readable index in a
+ * Given `YStickyIndex` and transaction reference, if computes a human-readable index in a
  * context of the referenced shared y-type.
  *
  * `out_branch` is getting assigned with a corresponding shared y-type reference.
  * `out_index` will be used to store computed human-readable index.
  */
-void yperma_index_read(const YPermaIndex *pos,
-                       const YTransaction *txn,
-                       Branch **out_branch,
-                       int *out_index);
+void ysticky_index_read(const YStickyIndex *pos,
+                        const YTransaction *txn,
+                        Branch **out_branch,
+                        int *out_index);
 
 #endif

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1741,23 +1741,23 @@ TEST_CASE("Relative position") {
     for (int i = 0; i < length; ++i) {
         for (int assoc = -1; assoc <= 0; ++assoc) {
 
-            YRelativePosition* pos = yrelative_position_from_index(txt, txn, i, assoc);
+            YPermaIndex* pos = yperma_index_from_index(txt, txn, i, assoc);
             int bin_len = 0;
-            unsigned char* bin = yrelative_position_encode(pos, &bin_len);
-            YRelativePosition* pos2 = yrelative_position_decode(bin, bin_len);
+            unsigned char* bin = yperma_index_encode(pos, &bin_len);
+            YPermaIndex* pos2 = yperma_index_decode(bin, bin_len);
 
             Branch* actual_branch;
             int actual_index;
 
-            yrelative_position_read(pos2, txn, &actual_branch, &actual_index);
+            yperma_index_read(pos2, txn, &actual_branch, &actual_index);
 
             REQUIRE_EQ(actual_index, i);
             REQUIRE_EQ(actual_branch, txt);
-            REQUIRE_EQ(yrelative_position_assoc(pos2), assoc);
+            REQUIRE_EQ(yperma_index_assoc(pos2), assoc);
 
             ybinary_destroy(bin, bin_len);
-            yrelative_position_destroy(pos);
-            yrelative_position_destroy(pos2);
+            yperma_index_destroy(pos);
+            yperma_index_destroy(pos2);
         }
     }
 

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1741,23 +1741,23 @@ TEST_CASE("Relative position") {
     for (int i = 0; i < length; ++i) {
         for (int assoc = -1; assoc <= 0; ++assoc) {
 
-            YPermaIndex* pos = yperma_index_from_index(txt, txn, i, assoc);
+            YStickyIndex* pos = ysticky_index_from_index(txt, txn, i, assoc);
             int bin_len = 0;
-            unsigned char* bin = yperma_index_encode(pos, &bin_len);
-            YPermaIndex* pos2 = yperma_index_decode(bin, bin_len);
+            unsigned char* bin = ysticky_index_encode(pos, &bin_len);
+            YStickyIndex* pos2 = ysticky_index_decode(bin, bin_len);
 
             Branch* actual_branch;
             int actual_index;
 
-            yperma_index_read(pos2, txn, &actual_branch, &actual_index);
+            ysticky_index_read(pos2, txn, &actual_branch, &actual_index);
 
             REQUIRE_EQ(actual_index, i);
             REQUIRE_EQ(actual_branch, txt);
-            REQUIRE_EQ(yperma_index_assoc(pos2), assoc);
+            REQUIRE_EQ(ysticky_index_assoc(pos2), assoc);
 
             ybinary_destroy(bin, bin_len);
-            yperma_index_destroy(pos);
-            yperma_index_destroy(pos2);
+            ysticky_index_destroy(pos);
+            ysticky_index_destroy(pos2);
         }
     }
 

--- a/tests-wasm/index.js
+++ b/tests-wasm/index.js
@@ -4,7 +4,7 @@ import * as text from './y-text.tests.js'
 import * as xml from './y-xml.tests.js'
 import * as doc from './y-doc.tests.js'
 import * as undo from './y-undo.tests.js'
-import * as relativePosition from './relative-position.tests.js'
+import * as stickyIndex from './sticky-index.tests.js'
 
 import { runTests } from 'lib0/testing'
 import { isBrowser, isNode } from 'lib0/environment'
@@ -14,7 +14,7 @@ if (isBrowser) {
     log.createVConsole(document.body)
 }
 runTests({
-    array, text, map, xml, doc, undo, relativePosition
+    array, text, map, xml, doc, undo, stickyIndex
 }).then(success => {
     /* istanbul ignore next */
     if (isNode) {

--- a/tests-wasm/sticky-index.tests.js
+++ b/tests-wasm/sticky-index.tests.js
@@ -5,15 +5,15 @@ import * as t from 'lib0/testing'
  * @param {Y.YDoc} ydoc
  * @param {Y.YText} ytext
  */
-const checkRelativePositions = (ydoc, ytext) => {
+const checkStickyIndex = (ydoc, ytext) => {
     // test if all positions are encoded and restored correctly
     for (let i = 0; i < ytext.length; i++) {
         // for all types of associations..
         for (let assoc = -1; assoc < 2; assoc++) {
-            const rpos = Y.createRelativePositionFromTypeIndex(ytext, i, assoc)
-            const encodedRpos = Y.encodeRelativePosition(rpos)
-            const decodedRpos = Y.decodeRelativePosition(encodedRpos)
-            const absPos = (Y.createAbsolutePositionFromRelativePosition(decodedRpos, ydoc))
+            const rpos = Y.createStickyIndexFromType(ytext, i, assoc)
+            const encodedRpos = Y.encodeStickyIndex(rpos)
+            const decodedRpos = Y.decodeStickyIndex(encodedRpos)
+            const absPos = (Y.createOffsetFromStickyIndex(decodedRpos, ydoc))
             t.assert(absPos.index === i)
             t.assert(absPos.assoc === assoc)
         }
@@ -23,7 +23,7 @@ const checkRelativePositions = (ydoc, ytext) => {
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionCase1 = tc => {
+export const testStickyIndexCase1 = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
     ytext.insert(0, '1')
@@ -31,74 +31,74 @@ export const testRelativePositionCase1 = tc => {
     ytext.insert(0, 'z')
     ytext.insert(0, 'y')
     ytext.insert(0, 'x')
-    checkRelativePositions(ydoc, ytext)
+    checkStickyIndex(ydoc, ytext)
 }
 
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionCase2 = tc => {
+export const testStickyIndexCase2 = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
     ytext.insert(0, 'abc')
-    checkRelativePositions(ydoc, ytext)
+    checkStickyIndex(ydoc, ytext)
 }
 
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionCase3 = tc => {
+export const testStickyIndexCase3 = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
     ytext.insert(0, 'abc')
     ytext.insert(0, '1')
     ytext.insert(0, 'xyz')
-    checkRelativePositions(ydoc, ytext)
+    checkStickyIndex(ydoc, ytext)
 }
 
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionCase4 = tc => {
+export const testStickyIndexCase4 = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
     ytext.insert(0, '1')
-    checkRelativePositions(ydoc, ytext)
+    checkStickyIndex(ydoc, ytext)
 }
 
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionCase5 = tc => {
+export const testStickyIndexCase5 = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
     ytext.insert(0, '2')
     ytext.insert(0, '1')
-    checkRelativePositions(ydoc, ytext)
+    checkStickyIndex(ydoc, ytext)
 }
 
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionCase6 = tc => {
+export const testStickyIndexCase6 = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
-    checkRelativePositions(ydoc, ytext)
+    checkStickyIndex(ydoc, ytext)
 }
 
 /**
  * @param {t.TestCase} tc
  */
-export const testRelativePositionAssociationDifference = tc => {
+export const testStickyIndexAssociationDifference = tc => {
     const ydoc = new Y.YDoc()
     const ytext = ydoc.getText('test')
     ytext.insert(0, '2')
     ytext.insert(0, '1')
-    const rposRight = Y.createRelativePositionFromTypeIndex(ytext, 1, 0)
-    const rposLeft = Y.createRelativePositionFromTypeIndex(ytext, 1, -1)
+    const rposRight = Y.createStickyIndexFromType(ytext, 1, 0)
+    const rposLeft = Y.createStickyIndexFromType(ytext, 1, -1)
     ytext.insert(1, 'x')
-    const posRight = Y.createAbsolutePositionFromRelativePosition(rposRight, ydoc)
-    const posLeft = Y.createAbsolutePositionFromRelativePosition(rposLeft, ydoc)
+    const posRight = Y.createOffsetFromStickyIndex(rposRight, ydoc)
+    const posLeft = Y.createOffsetFromStickyIndex(rposLeft, ydoc)
     t.assert(posRight != null && posRight.index === 2)
     t.assert(posLeft != null && posLeft.index === 1)
 }

--- a/yffi/cbindgen.toml
+++ b/yffi/cbindgen.toml
@@ -84,7 +84,7 @@ typedef struct YXmlTreeWalker {} YXmlTreeWalker;
 
 typedef struct YUndoManager {} YUndoManager;
 
-typedef struct RelativePosition {} RelativePosition;
+typedef struct StickyIndex {} StickyIndex;
 """
 
 trailer = """

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -26,7 +26,7 @@ use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use yrs::{
     uuid_v4, Array, ArrayRef, Assoc, DeleteSet, GetString, Map, MapRef, Observable, OffsetKind,
-    Options, Origin, PermaIndex, ReadTxn, Snapshot, StateVector, Store, SubdocsEvent,
+    Options, Origin, ReadTxn, Snapshot, StateVector, StickyIndex, Store, SubdocsEvent,
     SubdocsEventIter, SubscriptionId, Text, TextRef, Transact, TransactionCleanupEvent,
     UndoManager, Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragmentRef, XmlTextPrelim,
     XmlTextRef,
@@ -4804,37 +4804,37 @@ where
     }
 }
 
-/// A relative position is based on the Yjs model and is not affected by document changes.
-/// E.g. If you place a relative position before a certain character, it will always point to this character.
-/// If you place a relative position at the end of a type, it will always point to the end of the type.
+/// A sticky index is based on the Yjs model and is not affected by document changes.
+/// E.g. If you place a sticky index before a certain character, it will always point to this character.
+/// If you place a sticky index at the end of a type, it will always point to the end of the type.
 ///
 /// A numeric position is often unsuited for user selections, because it does not change when content is inserted
 /// before or after.
 ///
-/// ```Insert(0, 'x')('a.bc') = 'xa|bc'``` Where `.` is the relative position.
+/// ```Insert(0, 'x')('a.bc') = 'xa.bc'``` Where `.` is the sticky index position.
 ///
-/// Instances of `YRelativePosition` can be freed using `yperma_index_destroy`.
+/// Instances of `YStickyIndex` can be freed using `ysticky_index_destroy`.
 #[repr(transparent)]
-pub struct YPermaIndex(PermaIndex);
+pub struct YStickyIndex(StickyIndex);
 
-impl From<PermaIndex> for YPermaIndex {
+impl From<StickyIndex> for YStickyIndex {
     #[inline(always)]
-    fn from(value: PermaIndex) -> Self {
-        YPermaIndex(value)
+    fn from(value: StickyIndex) -> Self {
+        YStickyIndex(value)
     }
 }
 
-/// Releases resources allocated by `YRelativePosition` pointers.
+/// Releases resources allocated by `YStickyIndex` pointers.
 #[no_mangle]
-pub unsafe extern "C" fn yperma_index_destroy(pos: *mut YPermaIndex) {
+pub unsafe extern "C" fn ysticky_index_destroy(pos: *mut YStickyIndex) {
     drop(Box::from_raw(pos))
 }
 
-/// Returns association of current `YRelativePosition`.
+/// Returns association of current `YStickyIndex`.
 /// If association is **after** the referenced inserted character, returned number will be >= 0.
 /// If association is **before** the referenced inserted character, returned number will be < 0.
 #[no_mangle]
-pub unsafe extern "C" fn yperma_index_assoc(pos: *const YPermaIndex) -> c_int {
+pub unsafe extern "C" fn ysticky_index_assoc(pos: *const YStickyIndex) -> c_int {
     let pos = pos.as_ref().unwrap();
     match pos.0.assoc {
         Assoc::After => 0,
@@ -4842,19 +4842,19 @@ pub unsafe extern "C" fn yperma_index_assoc(pos: *const YPermaIndex) -> c_int {
     }
 }
 
-/// Retrieves a `YRelativePosition` corresponding to a given human-readable `index` pointing into
-/// the shared y-type `branch`. Unlike standard indexes relative position enables to track
+/// Retrieves a `YStickyIndex` corresponding to a given human-readable `index` pointing into
+/// the shared y-type `branch`. Unlike standard indexes sticky one enables to track
 /// the location inside of a shared y-types, even in the face of concurrent updates.
 ///
 /// If association is >= 0, the resulting position will point to location **after** the referenced index.
 /// If association is < 0, the resulting position will point to location **before** the referenced index.
 #[no_mangle]
-pub unsafe extern "C" fn yperma_index_from_index(
+pub unsafe extern "C" fn ysticky_index_from_index(
     branch: *const Branch,
     txn: *mut Transaction,
     index: c_int,
     assoc: c_int,
-) -> *mut YPermaIndex {
+) -> *mut YStickyIndex {
     assert!(!branch.is_null());
     assert!(!txn.is_null());
 
@@ -4868,21 +4868,21 @@ pub unsafe extern "C" fn yperma_index_from_index(
     };
 
     if let Some(txn) = txn.as_mut() {
-        if let Some(pos) = PermaIndex::at(txn, branch, index, assoc) {
-            Box::into_raw(Box::new(YPermaIndex(pos)))
+        if let Some(pos) = StickyIndex::at(txn, branch, index, assoc) {
+            Box::into_raw(Box::new(YStickyIndex(pos)))
         } else {
             null_mut()
         }
     } else {
-        panic!("yperma_index_from_index requires a read-write transaction");
+        panic!("ysticky_index_from_index requires a read-write transaction");
     }
 }
 
-/// Serializes `YRelativePosition` into binary representation. `len` parameter is updated with byte
+/// Serializes `YStickyIndex` into binary representation. `len` parameter is updated with byte
 /// length of the generated binary. Returned binary can be free'd using `ybinary_destroy`.  
 #[no_mangle]
-pub unsafe extern "C" fn yperma_index_encode(
-    pos: *const YPermaIndex,
+pub unsafe extern "C" fn ysticky_index_encode(
+    pos: *const YStickyIndex,
     len: *mut c_int,
 ) -> *mut c_uchar {
     let pos = pos.as_ref().unwrap();
@@ -4891,28 +4891,28 @@ pub unsafe extern "C" fn yperma_index_encode(
     Box::into_raw(binary) as *mut c_uchar
 }
 
-/// Deserializes `YRelativePosition` from the payload previously serialized using `yperma_index_encode`.
+/// Deserializes `YStickyIndex` from the payload previously serialized using `ysticky_index_encode`.
 #[no_mangle]
-pub unsafe extern "C" fn yperma_index_decode(
+pub unsafe extern "C" fn ysticky_index_decode(
     binary: *const c_uchar,
     len: c_int,
-) -> *mut YPermaIndex {
+) -> *mut YStickyIndex {
     let slice = std::slice::from_raw_parts(binary as *const u8, len as usize);
-    if let Ok(pos) = PermaIndex::decode_v1(slice) {
-        Box::into_raw(Box::new(YPermaIndex(pos)))
+    if let Ok(pos) = StickyIndex::decode_v1(slice) {
+        Box::into_raw(Box::new(YStickyIndex(pos)))
     } else {
         null_mut()
     }
 }
 
-/// Given `YRelativePosition` and transaction reference, if computes a human-readable index in a
+/// Given `YStickyIndex` and transaction reference, if computes a human-readable index in a
 /// context of the referenced shared y-type.
 ///
 /// `out_branch` is getting assigned with a corresponding shared y-type reference.
 /// `out_index` will be used to store computed human-readable index.
 #[no_mangle]
-pub unsafe extern "C" fn yperma_index_read(
-    pos: *const YPermaIndex,
+pub unsafe extern "C" fn ysticky_index_read(
+    pos: *const YStickyIndex,
     txn: *const Transaction,
     out_branch: *mut *mut Branch,
     out_index: *mut c_int,

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -1,5 +1,5 @@
 use crate::block::{Block, BlockPtr, Item, ItemContent, Prelim};
-use crate::moving::{Move, PermaIndex};
+use crate::moving::{Move, StickyIndex};
 use crate::transaction::{ReadTxn, TransactionMut};
 use crate::types::{BranchPtr, TypePtr, Value};
 use crate::{Assoc, ID};
@@ -496,7 +496,7 @@ impl BlockIter {
         block_ptr
     }
 
-    pub fn insert_move(&mut self, txn: &mut TransactionMut, start: PermaIndex, end: PermaIndex) {
+    pub fn insert_move(&mut self, txn: &mut TransactionMut, start: StickyIndex, end: StickyIndex) {
         self.insert_contents(txn, Move::new(start, end, -1));
     }
 

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -1,5 +1,5 @@
 use crate::block::{Block, BlockPtr, Item, ItemContent, Prelim};
-use crate::moving::{Move, RelativePosition};
+use crate::moving::{Move, PermaIndex};
 use crate::transaction::{ReadTxn, TransactionMut};
 use crate::types::{BranchPtr, TypePtr, Value};
 use crate::{Assoc, ID};
@@ -496,12 +496,7 @@ impl BlockIter {
         block_ptr
     }
 
-    pub fn insert_move(
-        &mut self,
-        txn: &mut TransactionMut,
-        start: RelativePosition,
-        end: RelativePosition,
-    ) {
+    pub fn insert_move(&mut self, txn: &mut TransactionMut, start: PermaIndex, end: PermaIndex) {
         self.insert_contents(txn, Move::new(start, end, -1));
     }
 

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -201,7 +201,7 @@
 //! assert_eq!(str.chars().nth(INDEX), Some('o'));
 //!
 //! // get a permanent index for cursor at index 1
-//! let pos = text2.perma_index(&mut txn2, INDEX as u32, Assoc::After).unwrap();
+//! let pos = text2.sticky_index(&mut txn2, INDEX as u32, Assoc::After).unwrap();
 //!
 //! // synchronize full state of doc1 -> doc2
 //! txn2.apply_update(Update::decode_v1(&txn1.encode_diff_v1(&StateVector::default())).unwrap());

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -181,7 +181,7 @@
 //! location, that will persist between concurrent updates being made:
 //!
 //! ```rust
-//! use yrs::{Assoc, Doc, GetString, ReadTxn, Indexable, StateVector, Text, Transact, Update};
+//! use yrs::{Assoc, Doc, GetString, ReadTxn, IndexedSequence, StateVector, Text, Transact, Update};
 //! use yrs::updates::decoder::Decode;
 //!
 //! let doc1 = Doc::with_client_id(1);
@@ -304,7 +304,7 @@ pub use crate::doc::{
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
 pub use crate::moving::Assoc;
-pub use crate::moving::Indexable;
+pub use crate::moving::IndexedSequence;
 pub use crate::moving::Offset;
 pub use crate::moving::PermaIndex;
 pub use crate::moving::PermaIndexContext;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -177,7 +177,7 @@
 //! them may shift the cursor position. However in such case the old index that we used (`1` in the
 //! example above) is no longer valid.
 //!
-//! To address these issues, we can make use of [PermaIndex] struct to save the permanent
+//! To address these issues, we can make use of [StickyIndex] struct to save the permanent
 //! location, that will persist between concurrent updates being made:
 //!
 //! ```rust
@@ -212,7 +212,7 @@
 //! assert_eq!(str.chars().nth(idx.index as usize), Some('o'));
 //! ```
 //!
-//! [PermaIndex] structure is serializable and can be persisted or passed over the network as
+//! [StickyIndex] structure is serializable and can be persisted or passed over the network as
 //! well, which may help with tracking and displaying the cursor location of other peers.
 //!
 //! # Other shared types
@@ -304,10 +304,10 @@ pub use crate::doc::{
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
 pub use crate::moving::Assoc;
+pub use crate::moving::IndexScope;
 pub use crate::moving::IndexedSequence;
 pub use crate::moving::Offset;
-pub use crate::moving::PermaIndex;
-pub use crate::moving::PermaIndexContext;
+pub use crate::moving::StickyIndex;
 pub use crate::observer::{Observer, Subscription, SubscriptionId};
 pub use crate::store::Store;
 pub use crate::transaction::Origin;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -177,11 +177,11 @@
 //! them may shift the cursor position. However in such case the old index that we used (`1` in the
 //! example above) is no longer valid.
 //!
-//! To address these issues, we can make use of [RelativePosition] struct to save the permanent
+//! To address these issues, we can make use of [PermaIndex] struct to save the permanent
 //! location, that will persist between concurrent updates being made:
 //!
 //! ```rust
-//! use yrs::{Assoc, Doc, GetString, ReadTxn, RelativeIndex, StateVector, Text, Transact, Update};
+//! use yrs::{Assoc, Doc, GetString, ReadTxn, Indexable, StateVector, Text, Transact, Update};
 //! use yrs::updates::decoder::Decode;
 //!
 //! let doc1 = Doc::with_client_id(1);
@@ -201,18 +201,18 @@
 //! assert_eq!(str.chars().nth(INDEX), Some('o'));
 //!
 //! // get a permanent index for cursor at index 1
-//! let pos = text2.position_at(&mut txn2, INDEX as u32, Assoc::After).unwrap();
+//! let pos = text2.perma_index(&mut txn2, INDEX as u32, Assoc::After).unwrap();
 //!
 //! // synchronize full state of doc1 -> doc2
 //! txn2.apply_update(Update::decode_v1(&txn1.encode_diff_v1(&StateVector::default())).unwrap());
 //!
 //! // restore the index from position saved previously
-//! let idx = pos.absolute(&txn2).unwrap();
+//! let idx = pos.get_offset(&txn2).unwrap();
 //! let str = text2.get_string(&txn2);
 //! assert_eq!(str.chars().nth(idx.index as usize), Some('o'));
 //! ```
 //!
-//! [RelativePosition] structure is serializable and can be persisted or passed over the network as
+//! [PermaIndex] structure is serializable and can be persisted or passed over the network as
 //! well, which may help with tracking and displaying the cursor location of other peers.
 //!
 //! # Other shared types
@@ -303,11 +303,11 @@ pub use crate::doc::{
 };
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
-pub use crate::moving::AbsolutePosition;
 pub use crate::moving::Assoc;
-pub use crate::moving::RelativeIndex;
-pub use crate::moving::RelativePosition;
-pub use crate::moving::RelativePositionContext;
+pub use crate::moving::Indexable;
+pub use crate::moving::Offset;
+pub use crate::moving::PermaIndex;
+pub use crate::moving::PermaIndexContext;
 pub use crate::observer::{Observer, Subscription, SubscriptionId};
 pub use crate::store::Store;
 pub use crate::transaction::Origin;

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -392,7 +392,7 @@ impl std::fmt::Display for Move {
 /// Example:
 ///
 /// ```rust
-/// use yrs::{Assoc, Doc, Indexable, Text, Transact};
+/// use yrs::{Assoc, Doc, IndexedSequence, Text, Transact};
 ///
 /// let doc = Doc::new();
 /// let txt = doc.get_or_insert_text("text");
@@ -451,7 +451,7 @@ impl PermaIndex {
     /// # Examples
     ///
     /// ```rust
-    /// use yrs::{Assoc, Doc, Indexable, Text, Transact};
+    /// use yrs::{Assoc, Doc, IndexedSequence, Text, Transact};
     ///
     /// let doc = Doc::new();
     /// let text = doc.get_or_insert_text("text");
@@ -749,7 +749,7 @@ impl Decode for Assoc {
 /// Trait used to retrieve a [PermaIndex] corresponding to a given human-readable index.
 /// Unlike standard indexes [PermaIndex] enables to track the location inside of a shared
 /// y-types, even in the face of concurrent updates.
-pub trait Indexable: AsRef<Branch> {
+pub trait IndexedSequence: AsRef<Branch> {
     /// Returns a [PermaIndex] equivalent to a human-readable `index`.
     /// Returns `None` if `index` is beyond the length of current sequence.
     fn perma_index(
@@ -789,7 +789,7 @@ mod test {
     use crate::moving::Assoc;
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::Encode;
-    use crate::{Doc, Indexable, PermaIndex, Text, TextRef, Transact};
+    use crate::{Doc, IndexedSequence, PermaIndex, Text, TextRef, Transact};
 
     fn check_relative_positions(text: &TextRef) {
         // test if all positions are encoded and restored correctly

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -400,7 +400,7 @@ impl std::fmt::Display for Move {
 /// txt.insert(&mut txn, 0, "abc"); // => 'abc'
 ///
 /// // create position tracker (marked as . in the comments)
-/// let pos = txt.perma_index(&mut txn, 2, Assoc::After).unwrap(); // => 'ab.c'
+/// let pos = txt.sticky_index(&mut txn, 2, Assoc::After).unwrap(); // => 'ab.c'
 ///
 /// // modify text
 /// txt.insert(&mut txn, 1, "def"); // => 'adefb.c'
@@ -462,7 +462,7 @@ impl StickyIndex {
     /// const INDEX: u32 = 4;
     ///
     /// // set perma index at position before letter 'o' => "hell.o world"
-    /// let pos = text.perma_index(&mut txn, INDEX, Assoc::After).unwrap();
+    /// let pos = text.sticky_index(&mut txn, INDEX, Assoc::After).unwrap();
     /// let off = pos.get_offset(&txn).unwrap();
     /// assert_eq!(off.index, INDEX);
     ///
@@ -752,7 +752,7 @@ impl Decode for Assoc {
 pub trait IndexedSequence: AsRef<Branch> {
     /// Returns a [StickyIndex] equivalent to a human-readable `index`.
     /// Returns `None` if `index` is beyond the length of current sequence.
-    fn perma_index(
+    fn sticky_index(
         &self,
         txn: &mut TransactionMut,
         index: u32,
@@ -798,7 +798,7 @@ mod test {
         for i in 0..len {
             // for all types of associations..
             for assoc in [Assoc::After, Assoc::Before] {
-                let rel_pos = text.perma_index(&mut txn, i, assoc).unwrap();
+                let rel_pos = text.sticky_index(&mut txn, i, assoc).unwrap();
                 let encoded = rel_pos.encode_v1();
                 let decoded = StickyIndex::decode_v1(&encoded).unwrap();
                 let abs_pos = decoded
@@ -890,8 +890,8 @@ mod test {
         txt.insert(&mut txn, 0, "2");
         txt.insert(&mut txn, 0, "1");
 
-        let rpos_right = txt.perma_index(&mut txn, 1, Assoc::After).unwrap();
-        let rpos_left = txt.perma_index(&mut txn, 1, Assoc::Before).unwrap();
+        let rpos_right = txt.sticky_index(&mut txn, 1, Assoc::After).unwrap();
+        let rpos_left = txt.sticky_index(&mut txn, 1, Assoc::Before).unwrap();
 
         txt.insert(&mut txn, 1, "x");
 

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -1,12 +1,12 @@
 use crate::block::{BlockPtr, EmbedPrelim, ItemContent, Prelim, Unused};
 use crate::block_iter::BlockIter;
-use crate::moving::RelativePosition;
+use crate::moving::PermaIndex;
 use crate::transaction::TransactionMut;
 use crate::types::{
     event_change_set, Branch, BranchPtr, Change, ChangeSet, EventHandler, Observers, Path, ToJson,
     Value, TYPE_REFS_ARRAY,
 };
-use crate::{Assoc, Observable, ReadTxn, RelativeIndex, ID};
+use crate::{Assoc, Indexable, Observable, ReadTxn, ID};
 use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -76,7 +76,7 @@ use std::sync::Arc;
 pub struct ArrayRef(BranchPtr);
 
 impl Array for ArrayRef {}
-impl RelativeIndex for ArrayRef {}
+impl Indexable for ArrayRef {}
 
 impl ToJson for ArrayRef {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {
@@ -244,7 +244,7 @@ pub trait Array: AsRef<Branch> {
             return;
         }
         let this = BranchPtr::from(self.as_ref());
-        let left = RelativePosition::from_type_index(txn, this, source, Assoc::After)
+        let left = PermaIndex::at(txn, this, source, Assoc::After)
             .expect("unbounded relative positions are not supported yet");
         let mut right = left.clone();
         right.assoc = Assoc::Before;
@@ -287,9 +287,9 @@ pub trait Array: AsRef<Branch> {
             return;
         }
         let this = BranchPtr::from(self.as_ref());
-        let left = RelativePosition::from_type_index(txn, this, start, assoc_start)
+        let left = PermaIndex::at(txn, this, start, assoc_start)
             .expect("unbounded relative positions are not supported yet");
-        let right = RelativePosition::from_type_index(txn, this, end + 1, assoc_end)
+        let right = PermaIndex::at(txn, this, end + 1, assoc_end)
             .expect("unbounded relative positions are not supported yet");
         let mut walker = BlockIter::new(this);
         if walker.try_forward(txn, target) {

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -1,6 +1,6 @@
 use crate::block::{BlockPtr, EmbedPrelim, ItemContent, Prelim, Unused};
 use crate::block_iter::BlockIter;
-use crate::moving::PermaIndex;
+use crate::moving::StickyIndex;
 use crate::transaction::TransactionMut;
 use crate::types::{
     event_change_set, Branch, BranchPtr, Change, ChangeSet, EventHandler, Observers, Path, ToJson,
@@ -237,22 +237,31 @@ pub trait Array: AsRef<Branch> {
         }
     }
 
-    /// Moves element found at `source` index into `target` index position.
+    /// Moves element found at `source` index into `target` index position. Both indexes refer to a
+    /// current state of the document.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if either `source` or `target` indexes are greater than current array's
+    /// length.
     fn move_to(&self, txn: &mut TransactionMut, source: u32, target: u32) {
         if source == target || source + 1 == target {
             // It doesn't make sense to move a range into the same range (it's basically a no-op).
             return;
         }
         let this = BranchPtr::from(self.as_ref());
-        let left = PermaIndex::at(txn, this, source, Assoc::After)
-            .expect("unbounded relative positions are not supported yet");
+        let left = StickyIndex::at(txn, this, source, Assoc::After)
+            .expect("`source` index parameter is beyond the range of an y-array");
         let mut right = left.clone();
         right.assoc = Assoc::Before;
         let mut walker = BlockIter::new(this);
         if walker.try_forward(txn, target) {
             walker.insert_move(txn, left, right);
         } else {
-            panic!("Index {} is outside of the range of an array", target);
+            panic!(
+                "`target` index parameter {} is outside of the range of an array",
+                target
+            );
         }
     }
 
@@ -273,6 +282,10 @@ pub trait Array: AsRef<Branch> {
     /// // move elements 2 and 3 after the 4
     /// array.move_range_to(&mut doc.transact_mut(), 1, Assoc::Before, 2, Assoc::After, 4);
     /// ```
+    /// # Panics
+    ///
+    /// This method panics if either `start`, `end` or `target` indexes are greater than current
+    /// array's length.
     fn move_range_to(
         &self,
         txn: &mut TransactionMut,
@@ -287,15 +300,18 @@ pub trait Array: AsRef<Branch> {
             return;
         }
         let this = BranchPtr::from(self.as_ref());
-        let left = PermaIndex::at(txn, this, start, assoc_start)
-            .expect("unbounded relative positions are not supported yet");
-        let right = PermaIndex::at(txn, this, end + 1, assoc_end)
-            .expect("unbounded relative positions are not supported yet");
+        let left = StickyIndex::at(txn, this, start, assoc_start)
+            .expect("`start` index parameter is beyond the range of an y-array");
+        let right = StickyIndex::at(txn, this, end + 1, assoc_end)
+            .expect("`end` index parameter is beyond the range of an y-array");
         let mut walker = BlockIter::new(this);
         if walker.try_forward(txn, target) {
             walker.insert_move(txn, left, right);
         } else {
-            panic!("Index {} is outside of the range of an array", target);
+            panic!(
+                "`target` index parameter {} is outside of the range of an array",
+                target
+            );
         }
     }
 

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -6,7 +6,7 @@ use crate::types::{
     event_change_set, Branch, BranchPtr, Change, ChangeSet, EventHandler, Observers, Path, ToJson,
     Value, TYPE_REFS_ARRAY,
 };
-use crate::{Assoc, Indexable, Observable, ReadTxn, ID};
+use crate::{Assoc, IndexedSequence, Observable, ReadTxn, ID};
 use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -76,7 +76,7 @@ use std::sync::Arc;
 pub struct ArrayRef(BranchPtr);
 
 impl Array for ArrayRef {}
-impl Indexable for ArrayRef {}
+impl IndexedSequence for ArrayRef {}
 
 impl ToJson for ArrayRef {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -40,7 +40,7 @@ use std::ops::{Deref, DerefMut};
 /// cursor positions in rich text documents with real-time collaborative capabilities. In such cases
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [TextRef], invalidating numeric index. For such cases you can take advantage of fact
-/// that [TextRef] implements [Indexable::perma_index] method that returns a
+/// that [TextRef] implements [IndexedSequence::perma_index] method that returns a
 /// [permanent index](PermaIndex) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///
@@ -94,7 +94,7 @@ use std::ops::{Deref, DerefMut};
 pub struct TextRef(BranchPtr);
 
 impl Text for TextRef {}
-impl Indexable for TextRef {}
+impl IndexedSequence for TextRef {}
 
 impl Into<XmlTextRef> for TextRef {
     fn into(self) -> XmlTextRef {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -40,8 +40,8 @@ use std::ops::{Deref, DerefMut};
 /// cursor positions in rich text documents with real-time collaborative capabilities. In such cases
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [TextRef], invalidating numeric index. For such cases you can take advantage of fact
-/// that [TextRef] implements [RelativeIndex::position_at] method that returns a
-/// [permanent index](RelativePosition) position that sticks to the same place even when concurrent
+/// that [TextRef] implements [Indexable::perma_index] method that returns a
+/// [permanent index](PermaIndex) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///
 /// # Example
@@ -94,7 +94,7 @@ use std::ops::{Deref, DerefMut};
 pub struct TextRef(BranchPtr);
 
 impl Text for TextRef {}
-impl RelativeIndex for TextRef {}
+impl Indexable for TextRef {}
 
 impl Into<XmlTextRef> for TextRef {
     fn into(self) -> XmlTextRef {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -40,7 +40,7 @@ use std::ops::{Deref, DerefMut};
 /// cursor positions in rich text documents with real-time collaborative capabilities. In such cases
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [TextRef], invalidating numeric index. For such cases you can take advantage of fact
-/// that [TextRef] implements [IndexedSequence::perma_index] method that returns a
+/// that [TextRef] implements [IndexedSequence::sticky_index] method that returns a
 /// [permanent index](StickyIndex) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -41,7 +41,7 @@ use std::ops::{Deref, DerefMut};
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [TextRef], invalidating numeric index. For such cases you can take advantage of fact
 /// that [TextRef] implements [IndexedSequence::perma_index] method that returns a
-/// [permanent index](PermaIndex) position that sticks to the same place even when concurrent
+/// [permanent index](StickyIndex) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///
 /// # Example

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -7,7 +7,7 @@ use crate::types::{
     EntryChange, EventHandler, MapRef, Observers, Path, ToJson, TypePtr, Value,
     TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_FRAGMENT, TYPE_REFS_XML_TEXT,
 };
-use crate::{ArrayRef, GetString, Map, Observable, ReadTxn, RelativeIndex, Text, TextRef, ID};
+use crate::{ArrayRef, GetString, Indexable, Map, Observable, ReadTxn, Text, TextRef, ID};
 use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -118,7 +118,7 @@ pub struct XmlElementRef(BranchPtr);
 
 impl Xml for XmlElementRef {}
 impl XmlFragment for XmlElementRef {}
-impl RelativeIndex for XmlElementRef {}
+impl Indexable for XmlElementRef {}
 
 impl Into<XmlFragmentRef> for XmlElementRef {
     fn into(self) -> XmlFragmentRef {
@@ -318,7 +318,7 @@ where
 /// cursor positions in rich text documents with real-time collaborative capabilities. In such cases
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [XmlTextRef], invalidating numeric index. For such cases you can take advantage of fact
-/// that [XmlTextRef] implements [RelativeIndex::position_at] method that returns a
+/// that [XmlTextRef] implements [Indexable::perma_index] method that returns a
 /// [permanent index](RelativePosition) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///
@@ -363,7 +363,7 @@ pub struct XmlTextRef(BranchPtr);
 
 impl Xml for XmlTextRef {}
 impl Text for XmlTextRef {}
-impl RelativeIndex for XmlTextRef {}
+impl Indexable for XmlTextRef {}
 
 impl Into<TextRef> for XmlTextRef {
     fn into(self) -> TextRef {
@@ -503,7 +503,7 @@ impl<T: Borrow<str>> Into<EmbedPrelim<XmlTextPrelim<T>>> for XmlTextPrelim<T> {
 pub struct XmlFragmentRef(BranchPtr);
 
 impl XmlFragment for XmlFragmentRef {}
-impl RelativeIndex for XmlFragmentRef {}
+impl Indexable for XmlFragmentRef {}
 
 impl XmlFragmentRef {
     pub fn parent(&self) -> Option<XmlNode> {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -320,7 +320,7 @@ where
 /// cursor positions in rich text documents with real-time collaborative capabilities. In such cases
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [XmlTextRef], invalidating numeric index. For such cases you can take advantage of fact
-/// that [XmlTextRef] implements [IndexedSequence::perma_index] method that returns a
+/// that [XmlTextRef] implements [IndexedSequence::sticky_index] method that returns a
 /// [permanent index](StickyIndex) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -7,7 +7,7 @@ use crate::types::{
     EntryChange, EventHandler, MapRef, Observers, Path, ToJson, TypePtr, Value,
     TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_FRAGMENT, TYPE_REFS_XML_TEXT,
 };
-use crate::{ArrayRef, GetString, Indexable, Map, Observable, ReadTxn, Text, TextRef, ID};
+use crate::{ArrayRef, GetString, IndexedSequence, Map, Observable, ReadTxn, Text, TextRef, ID};
 use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -118,7 +118,7 @@ pub struct XmlElementRef(BranchPtr);
 
 impl Xml for XmlElementRef {}
 impl XmlFragment for XmlElementRef {}
-impl Indexable for XmlElementRef {}
+impl IndexedSequence for XmlElementRef {}
 
 impl Into<XmlFragmentRef> for XmlElementRef {
     fn into(self) -> XmlFragmentRef {
@@ -318,7 +318,7 @@ where
 /// cursor positions in rich text documents with real-time collaborative capabilities. In such cases
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [XmlTextRef], invalidating numeric index. For such cases you can take advantage of fact
-/// that [XmlTextRef] implements [Indexable::perma_index] method that returns a
+/// that [XmlTextRef] implements [IndexedSequence::perma_index] method that returns a
 /// [permanent index](RelativePosition) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///
@@ -363,7 +363,7 @@ pub struct XmlTextRef(BranchPtr);
 
 impl Xml for XmlTextRef {}
 impl Text for XmlTextRef {}
-impl Indexable for XmlTextRef {}
+impl IndexedSequence for XmlTextRef {}
 
 impl Into<TextRef> for XmlTextRef {
     fn into(self) -> TextRef {
@@ -503,7 +503,7 @@ impl<T: Borrow<str>> Into<EmbedPrelim<XmlTextPrelim<T>>> for XmlTextPrelim<T> {
 pub struct XmlFragmentRef(BranchPtr);
 
 impl XmlFragment for XmlFragmentRef {}
-impl Indexable for XmlFragmentRef {}
+impl IndexedSequence for XmlFragmentRef {}
 
 impl XmlFragmentRef {
     pub fn parent(&self) -> Option<XmlNode> {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -7,7 +7,9 @@ use crate::types::{
     EntryChange, EventHandler, MapRef, Observers, Path, ToJson, TypePtr, Value,
     TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_FRAGMENT, TYPE_REFS_XML_TEXT,
 };
-use crate::{ArrayRef, GetString, IndexedSequence, Map, Observable, ReadTxn, Text, TextRef, ID};
+use crate::{
+    ArrayRef, GetString, IndexedSequence, Map, Observable, ReadTxn, StickyIndex, Text, TextRef, ID,
+};
 use lib0::any::Any;
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -319,7 +321,7 @@ where
 /// any concurrent update incoming and applied from the remote peer may change the order of elements
 /// in current [XmlTextRef], invalidating numeric index. For such cases you can take advantage of fact
 /// that [XmlTextRef] implements [IndexedSequence::perma_index] method that returns a
-/// [permanent index](RelativePosition) position that sticks to the same place even when concurrent
+/// [permanent index](StickyIndex) position that sticks to the same place even when concurrent
 /// updates are being made.
 ///
 /// # Example

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -334,13 +334,13 @@ impl Update {
                 }
 
                 if let ItemContent::Move(m) = &item.content {
-                    if let Some(start) = m.start.item() {
+                    if let Some(start) = m.start.id() {
                         if start.clock >= local_sv.get(&start.client) {
                             return Some(start.client);
                         }
                     }
                     if !m.is_collapsed() {
-                        if let Some(end) = m.end.item() {
+                        if let Some(end) = m.end.id() {
                             if end.clock >= local_sv.get(&end.client) {
                                 return Some(end.client);
                             }

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -26,13 +26,12 @@ use yrs::undo::{EventKind, UndoEventSubscription};
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use yrs::{
-    Array, ArrayRef, Assoc, DeleteSet, DestroySubscription, Doc, GetString, Map, MapRef,
-    Observable, Offset, OffsetKind, Options, Origin, PermaIndex, PermaIndexContext, ReadTxn,
-    Snapshot, StateVector, Store, SubdocsEvent, SubdocsEventIter, SubdocsSubscription,
-    Subscription, Text, TextRef, Transact, Transaction, TransactionCleanupEvent,
-    TransactionCleanupSubscription, TransactionMut, UndoManager, Update, UpdateSubscription, Xml,
-    XmlElementPrelim, XmlElementRef, XmlFragment, XmlFragmentRef, XmlNode, XmlTextPrelim,
-    XmlTextRef, ID,
+    Array, ArrayRef, Assoc, DeleteSet, DestroySubscription, Doc, GetString, IndexScope, Map,
+    MapRef, Observable, Offset, OffsetKind, Options, Origin, ReadTxn, Snapshot, StateVector,
+    StickyIndex, Store, SubdocsEvent, SubdocsEventIter, SubdocsSubscription, Subscription, Text,
+    TextRef, Transact, Transaction, TransactionCleanupEvent, TransactionCleanupSubscription,
+    TransactionMut, UndoManager, Update, UpdateSubscription, Xml, XmlElementPrelim, XmlElementRef,
+    XmlFragment, XmlFragmentRef, XmlNode, XmlTextPrelim, XmlTextRef, ID,
 };
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
@@ -3998,14 +3997,14 @@ impl<'a> Shared<'a> {
     }
 }
 
-/// Retrieves a relative position corresponding to a given human-readable `index` pointing into
-/// the shared `ytype`. Unlike standard indexes relative position enables to track
+/// Retrieves a sticky index corresponding to a given human-readable `index` pointing into
+/// the shared `ytype`. Unlike standard indexes sticky indexes enables to track
 /// the location inside of a shared y-types, even in the face of concurrent updates.
 ///
 /// If association is >= 0, the resulting position will point to location **after** the referenced index.
 /// If association is < 0, the resulting position will point to location **before** the referenced index.
-#[wasm_bindgen(catch, js_name=createRelativePositionFromTypeIndex)]
-pub fn create_relative_position_from_type_index(
+#[wasm_bindgen(catch, js_name=createStickyIndexFromType)]
+pub fn create_sticky_index_from_type(
     ytype: &JsValue,
     index: u32,
     assoc: i32,
@@ -4014,7 +4013,7 @@ pub fn create_relative_position_from_type_index(
     if let Ok(shared) = Shared::try_from(ytype) {
         if shared.is_prelim() {
             return Err(JsValue::from_str(
-                "cannot build relative position if shared type was not integrated",
+                "cannot build sticky index if shared type was not integrated",
             ));
         }
         let assoc = if assoc >= 0 {
@@ -4024,10 +4023,10 @@ pub fn create_relative_position_from_type_index(
         };
         if let Some(branch) = shared.branch() {
             let pos = if let Some(txn) = get_txn_mut(txn) {
-                PermaIndex::at(txn, branch, index, assoc)
+                StickyIndex::at(txn, branch, index, assoc)
             } else {
                 let mut txn = branch.transact_mut();
-                PermaIndex::at(&mut txn, branch, index, assoc)
+                StickyIndex::at(&mut txn, branch, index, assoc)
             };
             let result = if let Some(pos) = pos {
                 Ok(pos.into_js())
@@ -4040,14 +4039,11 @@ pub fn create_relative_position_from_type_index(
     Err(JsValue::from_str("shared type parameter is not indexable"))
 }
 
-/// Converts a relative position (see: `createRelativePositionFromTypeIndex`) into an object
+/// Converts a sticky index (see: `createStickyIndexFromType`) into an object
 /// containing human-readable index.
-#[wasm_bindgen(catch, js_name=createAbsolutePositionFromRelativePosition)]
-pub fn create_absolute_position_from_relative_position(
-    rpos: &JsValue,
-    doc: &YDoc,
-) -> Result<JsValue, JsValue> {
-    let pos = relative_position_from_js(rpos)?;
+#[wasm_bindgen(catch, js_name=createOffsetFromStickyIndex)]
+pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &YDoc) -> Result<JsValue, JsValue> {
+    let pos = sticky_index_from_js(rpos)?;
     let txn = doc.0.transact();
     if let Some(abs) = pos.get_offset(&txn) {
         Ok(abs.into_js())
@@ -4056,48 +4052,46 @@ pub fn create_absolute_position_from_relative_position(
     }
 }
 
-/// Serializes relative position created by `createRelativePositionFromTypeIndex` into a binary
+/// Serializes sticky index created by `createStickyIndexFromType` into a binary
 /// payload.
-#[wasm_bindgen(catch, js_name=encodeRelativePosition)]
-pub fn encode_relative_position(rpos: &JsValue) -> Result<Uint8Array, JsValue> {
-    if let Ok(pos) = relative_position_from_js(rpos) {
+#[wasm_bindgen(catch, js_name=encodeStickyIndex)]
+pub fn encode_sticky_index(rpos: &JsValue) -> Result<Uint8Array, JsValue> {
+    if let Ok(pos) = sticky_index_from_js(rpos) {
         let bytes = Uint8Array::from(pos.encode_v1().as_slice());
         Ok(bytes)
     } else {
-        Err(JsValue::from_str(
-            "passed parameter is not RelativePosition",
-        ))
+        Err(JsValue::from_str("passed parameter is not StickyIndex"))
     }
 }
 
-/// Deserializes relative position serialized previously by `encodeRelativePosition`.
-#[wasm_bindgen(catch, js_name=decodeRelativePosition)]
-pub fn decode_relative_position(bin: Uint8Array) -> Result<JsValue, JsValue> {
+/// Deserializes sticky index serialized previously by `encodeStickyIndex`.
+#[wasm_bindgen(catch, js_name=decodeStickyIndex)]
+pub fn decode_sticky_index(bin: Uint8Array) -> Result<JsValue, JsValue> {
     let data: Vec<u8> = bin.to_vec();
-    match PermaIndex::decode_v1(&data) {
+    match StickyIndex::decode_v1(&data) {
         Ok(value) => Ok(value.into_js()),
         Err(err) => Err(JsValue::from_str(&err.to_string())),
     }
 }
 
-fn relative_position_from_js(js: &JsValue) -> Result<PermaIndex, JsValue> {
+fn sticky_index_from_js(js: &JsValue) -> Result<StickyIndex, JsValue> {
     let value = Reflect::get(js, &JsValue::from_str("item"))?;
     let context = if value.is_undefined() || value.is_null() {
         let value = Reflect::get(js, &JsValue::from_str("tname"))?;
         if value.is_undefined() || value.is_null() {
             let value = Reflect::get(js, &JsValue::from_str("type"))?;
             let id = id_from_js(&value)?;
-            PermaIndexContext::Nested(id)
+            IndexScope::Nested(id)
         } else {
             if let Some(tname) = value.as_string() {
-                PermaIndexContext::Root(tname.into())
+                IndexScope::Root(tname.into())
             } else {
                 return Err(value);
             }
         }
     } else {
         let id = id_from_js(&value)?;
-        PermaIndexContext::Relative(id)
+        IndexScope::Relative(id)
     };
     let assoc = Reflect::get(js, &JsValue::from_str("assoc"))?;
     let assoc = if let Some(a) = assoc.as_f64() {
@@ -4110,7 +4104,7 @@ fn relative_position_from_js(js: &JsValue) -> Result<PermaIndex, JsValue> {
         return Err(assoc);
     };
 
-    Ok(PermaIndex::new(context, assoc))
+    Ok(StickyIndex::new(context, assoc))
 }
 
 fn id_from_js(js: &JsValue) -> Result<ID, JsValue> {
@@ -4143,18 +4137,18 @@ impl IntoJs for ID {
     }
 }
 
-impl IntoJs for PermaIndex {
+impl IntoJs for StickyIndex {
     fn into_js(self) -> JsValue {
         let js: JsValue = js_sys::Object::new().into();
 
-        match self.context() {
-            PermaIndexContext::Relative(id) => {
+        match self.scope() {
+            IndexScope::Relative(id) => {
                 Reflect::set(&js, &JsValue::from_str("item"), &id.into_js()).unwrap();
             }
-            PermaIndexContext::Nested(id) => {
+            IndexScope::Nested(id) => {
                 Reflect::set(&js, &JsValue::from_str("type"), &id.into_js()).unwrap();
             }
-            PermaIndexContext::Root(tname) => {
+            IndexScope::Root(tname) => {
                 Reflect::set(&js, &JsValue::from_str("tname"), &JsValue::from_str(&tname)).unwrap();
             }
         }


### PR DESCRIPTION
Renamed `RelativePosition` to `StickyIndex`.