### PR TITLE
yffi: changed int types to use type definitions from stdint.h

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -451,7 +451,7 @@ typedef struct YStateVector {
    * has a corresponding client identifier attached, which can be found in `client_ids` field
    * under the same index.
    */
-  uint64_t *clocks;
+  uint32_t *clocks;
 } YStateVector;
 
 typedef struct YIdRange {
@@ -2272,7 +2272,7 @@ void yundo_manager_unobserve_popped(YUndoManager *mgr, uint32_t subscription_id)
  * Returns either 0 when `branch` is null or one of values: `Y_ARRAY`, `Y_TEXT`, `Y_MAP`,
  * `Y_XML_ELEM`, `Y_XML_TEXT`.
  */
-char ytype_kind(const Branch *branch);
+int8_t ytype_kind(const Branch *branch);
 
 /**
  * Releases resources allocated by `YRelativePosition` pointers.

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -292,7 +292,7 @@ typedef struct YOptions {
    * document state from snapshot, that didn't contain all of that clients updates that were sent
    * to other peers.
    */
-  unsigned long id;
+  uint64_t id;
   /**
    * A NULL-able globally unique Uuid v4 compatible null-terminated string identifier
    * of this document. If passed as NULL, a random Uuid will be generated instead.
@@ -311,21 +311,21 @@ typedef struct YOptions {
    * - `Y_ENCODING_UTF16`
    * - `Y_ENCODING_UTF32`
    */
-  int encoding;
+  uint8_t encoding;
   /**
    * Boolean flag used to determine if deleted blocks should be garbage collected or not
    * during the transaction commits. Setting this value to 0 means GC will be performed.
    */
-  int skip_gc;
+  uint8_t skip_gc;
   /**
    * Boolean flag used to determine if subdocument should be loaded automatically.
    * If this is a subdocument, remote peers will load the document as well automatically.
    */
-  int auto_load;
+  uint8_t auto_load;
   /**
    * Boolean flag used to determine whether the document should be synced by the provider now.
    */
-  int should_load;
+  uint8_t should_load;
 } YOptions;
 
 /**
@@ -351,11 +351,11 @@ typedef YDoc YDoc;
 typedef Branch Branch;
 
 typedef union YOutputContent {
-  char flag;
-  float num;
-  long long integer;
+  uint8_t flag;
+  double num;
+  int64_t integer;
   char *str;
-  unsigned char *buf;
+  char *buf;
   struct YOutput *array;
   struct YMapEntry *map;
   Branch *y_type;
@@ -399,7 +399,7 @@ typedef struct YOutput {
    *
    * For other types it's always equal to `1`.
    */
-  int len;
+  uint32_t len;
   /**
    * Union struct which contains a content corresponding to a provided `tag` field.
    */
@@ -439,24 +439,24 @@ typedef struct YStateVector {
   /**
    * Number of clients. It describes a length of both `client_ids` and `clocks` arrays.
    */
-  int entries_count;
+  uint32_t entries_count;
   /**
    * Array of unique client identifiers (length is given in `entries_count` field). Each client
    * ID has corresponding clock attached, which can be found in `clocks` field under the same
    * index.
    */
-  long long *client_ids;
+  uint64_t *client_ids;
   /**
    * Array of clocks (length is given in `entries_count` field) known for each client. Each clock
    * has a corresponding client identifier attached, which can be found in `client_ids` field
    * under the same index.
    */
-  int *clocks;
+  uint64_t *clocks;
 } YStateVector;
 
 typedef struct YIdRange {
-  int start;
-  int end;
+  uint32_t start;
+  uint32_t end;
 } YIdRange;
 
 /**
@@ -467,7 +467,7 @@ typedef struct YIdRangeSeq {
   /**
    * Number of ranges stored in this sequence.
    */
-  int len;
+  uint32_t len;
   /**
    * Array (length is stored in `len` field) or ranges. Each range is a pair of [start, end)
    * values, describing continuous collection of items produced by the same client, identified
@@ -485,13 +485,13 @@ typedef struct YDeleteSet {
   /**
    * Number of client identifier entries.
    */
-  int entries_count;
+  uint32_t entries_count;
   /**
    * Array of unique client identifiers (length is given in `entries_count` field). Each client
    * ID has corresponding sequence of ranges attached, which can be found in `ranges` field under
    * the same index.
    */
-  long long *client_ids;
+  uint64_t *client_ids;
   /**
    * Array of range sequences (length is given in `entries_count` field). Each sequence has
    * a corresponding client ID attached, which can be found in `client_ids` field under
@@ -520,9 +520,9 @@ typedef struct YAfterTransactionEvent {
 } YAfterTransactionEvent;
 
 typedef struct YSubdocsEvent {
-  int added_len;
-  int removed_len;
-  int loaded_len;
+  uint32_t added_len;
+  uint32_t removed_len;
+  uint32_t loaded_len;
   YDoc **added;
   YDoc **removed;
   YDoc **loaded;
@@ -541,11 +541,11 @@ typedef struct YMapInputData {
 } YMapInputData;
 
 typedef union YInputContent {
-  char flag;
-  float num;
-  long integer;
+  uint8_t flag;
+  double num;
+  int64_t integer;
   char *str;
-  unsigned char *buf;
+  char *buf;
   struct YInput *values;
   struct YMapInputData map;
   YDoc *doc;
@@ -587,7 +587,7 @@ typedef struct YInput {
    *
    * For other types it's always equal to `1`.
    */
-  int len;
+  uint32_t len;
   /**
    * Union struct which contains a content corresponding to a provided `tag` field.
    */
@@ -674,7 +674,7 @@ typedef struct YEvent {
 
 typedef union YPathSegmentCase {
   const char *key;
-  int index;
+  uint32_t index;
 } YPathSegmentCase;
 
 /**
@@ -755,7 +755,7 @@ typedef struct YDelta {
    * Number of element affected by current type of a change. It can refer to a number of
    * inserted `values`, number of deleted element or a number of retained (unchanged) values.
    */
-  int len;
+  uint32_t len;
   /**
    * Used in case when current change is of `Y_EVENT_CHANGE_ADD` type. Contains a list (of
    * length stored in `len` field) of newly inserted values.
@@ -764,7 +764,7 @@ typedef struct YDelta {
   /**
    * A number of formatting attributes assigned to an edited area represented by this delta.
    */
-  int attributes_len;
+  uint32_t attributes_len;
   /**
    * A nullable pointer to a list of formatting attributes assigned to an edited area represented
    * by this delta.
@@ -806,7 +806,7 @@ typedef struct YEventChange {
    * Number of element affected by current type of a change. It can refer to a number of
    * inserted `values`, number of deleted element or a number of retained (unchanged) values.
    */
-  int len;
+  uint32_t len;
   /**
    * Used in case when current change is of `Y_EVENT_CHANGE_ADD` type. Contains a list (of
    * length stored in `len` field) of newly inserted values.
@@ -856,13 +856,13 @@ typedef struct YEventKeyChange {
 } YEventKeyChange;
 
 typedef struct YUndoManagerOptions {
-  int capture_timeout_millis;
+  uint32_t capture_timeout_millis;
 } YUndoManagerOptions;
 
 typedef struct YUndoEvent {
   char kind;
   const char *origin;
-  int origin_len;
+  uint32_t origin_len;
   struct YDeleteSet insertions;
   struct YDeleteSet deletions;
 } YUndoEvent;
@@ -913,7 +913,7 @@ void ystring_destroy(char *str);
  * therefore a size of memory to be released must be explicitly provided.
  * Yrs binaries don't use libc malloc, so calling `free()` on them will fault.
  */
-void ybinary_destroy(unsigned char *ptr, int len);
+void ybinary_destroy(char *ptr, uint32_t len);
 
 /**
  * Creates a new [Doc] instance with a randomized unique client identifier.
@@ -941,7 +941,7 @@ YDoc *ydoc_new_with_options(struct YOptions options);
 /**
  * Returns a unique client identifier of this [Doc] instance.
  */
-unsigned long ydoc_id(YDoc *doc);
+uint64_t ydoc_id(YDoc *doc);
 
 /**
  * Returns a unique document identifier of this [Doc] instance.
@@ -966,31 +966,27 @@ uint8_t ydoc_should_load(YDoc *doc);
  */
 uint8_t ydoc_auto_load(YDoc *doc);
 
-unsigned int ydoc_observe_updates_v1(YDoc *doc,
-                                     void *state,
-                                     void (*cb)(void*, int, const unsigned char*));
+uint32_t ydoc_observe_updates_v1(YDoc *doc, void *state, void (*cb)(void*, uint32_t, const char*));
 
-unsigned int ydoc_observe_updates_v2(YDoc *doc,
-                                     void *state,
-                                     void (*cb)(void*, int, const unsigned char*));
+uint32_t ydoc_observe_updates_v2(YDoc *doc, void *state, void (*cb)(void*, uint32_t, const char*));
 
-void ydoc_unobserve_updates_v1(YDoc *doc, unsigned int subscription_id);
+void ydoc_unobserve_updates_v1(YDoc *doc, uint32_t subscription_id);
 
-void ydoc_unobserve_updates_v2(YDoc *doc, unsigned int subscription_id);
+void ydoc_unobserve_updates_v2(YDoc *doc, uint32_t subscription_id);
 
-unsigned int ydoc_observe_after_transaction(YDoc *doc,
-                                            void *state,
-                                            void (*cb)(void*, struct YAfterTransactionEvent*));
+uint32_t ydoc_observe_after_transaction(YDoc *doc,
+                                        void *state,
+                                        void (*cb)(void*, struct YAfterTransactionEvent*));
 
-void ydoc_unobserve_after_transaction(YDoc *doc, unsigned int subscription_id);
+void ydoc_unobserve_after_transaction(YDoc *doc, uint32_t subscription_id);
 
-unsigned int ydoc_observe_subdocs(YDoc *doc, void *state, void (*cb)(void*, struct YSubdocsEvent*));
+uint32_t ydoc_observe_subdocs(YDoc *doc, void *state, void (*cb)(void*, struct YSubdocsEvent*));
 
-void ydoc_unobserve_subdocs(YDoc *doc, unsigned int subscription_id);
+void ydoc_unobserve_subdocs(YDoc *doc, uint32_t subscription_id);
 
-unsigned int ydoc_observe_clear(YDoc *doc, void *state, void (*cb)(void*, YDoc*));
+uint32_t ydoc_observe_clear(YDoc *doc, void *state, void (*cb)(void*, YDoc*));
 
-void ydoc_unobserve_clear(YDoc *doc, unsigned int subscription_id);
+void ydoc_unobserve_clear(YDoc *doc, uint32_t subscription_id);
 
 /**
  * Manually send a load request to a parent document of this subdoc.
@@ -1026,7 +1022,7 @@ YTransaction *ydoc_read_transaction(YDoc *doc);
  * Returns `NULL` if read-write transaction couldn't be created, i.e. when another transaction is
  * already opened.
  */
-YTransaction *ydoc_write_transaction(YDoc *doc, int origin_len, const char *origin);
+YTransaction *ydoc_write_transaction(YDoc *doc, uint32_t origin_len, const char *origin);
 
 /**
  * Starts a new read-write transaction on a given branches document. All other operations happen in
@@ -1051,7 +1047,7 @@ YTransaction *ybranch_read_transaction(Branch *branch);
 /**
  * Returns a list of subdocs existing within current document.
  */
-YDoc **ytransaction_subdocs(YTransaction *txn, int *len);
+YDoc **ytransaction_subdocs(YTransaction *txn, uint32_t *len);
 
 /**
  * Commit and dispose provided read-write transaction. This operation releases allocated resources,
@@ -1136,7 +1132,7 @@ Branch *yxmltext(YDoc *doc, const char *name);
  *
  * Once no longer needed, a returned binary can be disposed using [ybinary_destroy] function.
  */
-unsigned char *ytransaction_state_vector_v1(const YTransaction *txn, int *len);
+char *ytransaction_state_vector_v1(const YTransaction *txn, uint32_t *len);
 
 /**
  * Returns a delta difference between current state of a transaction's document and a state vector
@@ -1154,10 +1150,10 @@ unsigned char *ytransaction_state_vector_v1(const YTransaction *txn, int *len);
  *
  * Once no longer needed, a returned binary can be disposed using [ybinary_destroy] function.
  */
-unsigned char *ytransaction_state_diff_v1(const YTransaction *txn,
-                                          const unsigned char *sv,
-                                          int sv_len,
-                                          int *len);
+char *ytransaction_state_diff_v1(const YTransaction *txn,
+                                 const char *sv,
+                                 uint32_t sv_len,
+                                 uint32_t *len);
 
 /**
  * Returns a delta difference between current state of a transaction's document and a state vector
@@ -1175,17 +1171,17 @@ unsigned char *ytransaction_state_diff_v1(const YTransaction *txn,
  *
  * Once no longer needed, a returned binary can be disposed using [ybinary_destroy] function.
  */
-unsigned char *ytransaction_state_diff_v2(const YTransaction *txn,
-                                          const unsigned char *sv,
-                                          int sv_len,
-                                          int *len);
+char *ytransaction_state_diff_v2(const YTransaction *txn,
+                                 const char *sv,
+                                 uint32_t sv_len,
+                                 uint32_t *len);
 
 /**
  * Returns a snapshot descriptor of a current state of the document. This snapshot information
  * can be then used to encode document data at a particular point in time
  * (see: `ytransaction_encode_state_from_snapshot`).
  */
-unsigned char *ytransaction_snapshot(const YTransaction *txn, int *len);
+char *ytransaction_snapshot(const YTransaction *txn, uint32_t *len);
 
 /**
  * Encodes a state of the document at a point in time specified by the provided `snapshot`
@@ -1197,10 +1193,10 @@ unsigned char *ytransaction_snapshot(const YTransaction *txn, int *len);
  * This function requires document with a GC option flag turned off (otherwise "time travel" would
  * not be a safe operation). If this is not a case, the NULL pointer will be returned.
  */
-unsigned char *ytransaction_encode_state_from_snapshot_v1(const YTransaction *txn,
-                                                          const unsigned char *snapshot,
-                                                          int snapshot_len,
-                                                          int *len);
+char *ytransaction_encode_state_from_snapshot_v1(const YTransaction *txn,
+                                                 const char *snapshot,
+                                                 uint32_t snapshot_len,
+                                                 uint32_t *len);
 
 /**
  * Encodes a state of the document at a point in time specified by the provided `snapshot`
@@ -1212,24 +1208,24 @@ unsigned char *ytransaction_encode_state_from_snapshot_v1(const YTransaction *tx
  * This function requires document with a GC option flag turned off (otherwise "time travel" would
  * not be a safe operation). If this is not a case, the NULL pointer will be returned.
  */
-unsigned char *ytransaction_encode_state_from_snapshot_v2(const YTransaction *txn,
-                                                          const unsigned char *snapshot,
-                                                          int snapshot_len,
-                                                          int *len);
+char *ytransaction_encode_state_from_snapshot_v2(const YTransaction *txn,
+                                                 const char *snapshot,
+                                                 uint32_t snapshot_len,
+                                                 uint32_t *len);
 
 /**
  * Returns a null-terminated UTF-8 encoded string representation of an `update` binary payload,
  * encoded using lib0 v1 encoding.
  * Returns null if update couldn't be parsed into a lib0 v1 formatting.
  */
-char *yupdate_debug_v1(const unsigned char *update, int update_len);
+char *yupdate_debug_v1(const char *update, uint32_t update_len);
 
 /**
  * Returns a null-terminated UTF-8 encoded string representation of an `update` binary payload,
  * encoded using lib0 v2 encoding.
  * Returns null if update couldn't be parsed into a lib0 v2 formatting.
  */
-char *yupdate_debug_v2(const unsigned char *update, int update_len);
+char *yupdate_debug_v2(const char *update, uint32_t update_len);
 
 /**
  * Applies an diff update (generated by `ytransaction_state_diff_v1`) to a local transaction's
@@ -1246,9 +1242,9 @@ char *yupdate_debug_v2(const unsigned char *update, int update_len);
  * - `ERR_CODE_INVALID_JSON` (**5**): failure when trying to decode JSON content.
  * - `ERR_CODE_OTHER` (**6**): other error type than the one specified.
  */
-int ytransaction_apply(YTransaction *txn,
-                       const unsigned char *diff,
-                       int diff_len);
+uint8_t ytransaction_apply(YTransaction *txn,
+                           const char *diff,
+                           uint32_t diff_len);
 
 /**
  * Applies an diff update (generated by [ytransaction_state_diff_v2]) to a local transaction's
@@ -1265,14 +1261,14 @@ int ytransaction_apply(YTransaction *txn,
  * - `ERR_CODE_INVALID_JSON` (**5**): failure when trying to decode JSON content.
  * - `ERR_CODE_OTHER` (**6**): other error type than the one specified.
  */
-int ytransaction_apply_v2(YTransaction *txn,
-                          const unsigned char *diff,
-                          int diff_len);
+uint8_t ytransaction_apply_v2(YTransaction *txn,
+                              const char *diff,
+                              uint32_t diff_len);
 
 /**
  * Returns the length of the `YText` string content in bytes (without the null terminator character)
  */
-int ytext_len(const Branch *txt, const YTransaction *txn);
+uint32_t ytext_len(const Branch *txt, const YTransaction *txn);
 
 /**
  * Returns a null-terminated UTF-8 encoded string content of a current `YText` shared data type.
@@ -1295,7 +1291,7 @@ char *ytext_string(const Branch *txt, const YTransaction *txn);
  */
 void ytext_insert(const Branch *txt,
                   YTransaction *txn,
-                  int index,
+                  uint32_t index,
                   const char *value,
                   const struct YInput *attrs);
 
@@ -1305,8 +1301,8 @@ void ytext_insert(const Branch *txt,
  */
 void ytext_format(const Branch *txt,
                   YTransaction *txn,
-                  int index,
-                  int len,
+                  uint32_t index,
+                  uint32_t len,
                   const struct YInput *attrs);
 
 /**
@@ -1323,7 +1319,7 @@ void ytext_format(const Branch *txt,
  */
 void ytext_insert_embed(const Branch *txt,
                         YTransaction *txn,
-                        int index,
+                        uint32_t index,
                         const struct YInput *content,
                         const struct YInput *attrs);
 
@@ -1337,12 +1333,12 @@ void ytext_insert_embed(const Branch *txt,
  * A `length` must be lower or equal number of characters (counted as UTF chars depending on the
  * encoding configured by `YDoc`) from `index` position to the end of of the string.
  */
-void ytext_remove_range(const Branch *txt, YTransaction *txn, int index, int length);
+void ytext_remove_range(const Branch *txt, YTransaction *txn, uint32_t index, uint32_t length);
 
 /**
  * Returns a number of elements stored within current instance of `YArray`.
  */
-int yarray_len(const Branch *array);
+uint32_t yarray_len(const Branch *array);
 
 /**
  * Returns a pointer to a `YOutput` value stored at a given `index` of a current `YArray`.
@@ -1350,7 +1346,7 @@ int yarray_len(const Branch *array);
  *
  * A value returned should be eventually released using [youtput_destroy] function.
  */
-struct YOutput *yarray_get(const Branch *array, const YTransaction *txn, int index);
+struct YOutput *yarray_get(const Branch *array, const YTransaction *txn, uint32_t index);
 
 /**
  * Inserts a range of `items` into current `YArray`, starting at given `index`. An `items_len`
@@ -1366,18 +1362,18 @@ struct YOutput *yarray_get(const Branch *array, const YTransaction *txn, int ind
  */
 void yarray_insert_range(const Branch *array,
                          YTransaction *txn,
-                         int index,
+                         uint32_t index,
                          const struct YInput *items,
-                         int items_len);
+                         uint32_t items_len);
 
 /**
  * Removes a `len` of consecutive range of elements from current `array` instance, starting at
  * a given `index`. Range determined by `index` and `len` must fit into boundaries of an array,
  * otherwise it will panic at runtime.
  */
-void yarray_remove_range(const Branch *array, YTransaction *txn, int index, int len);
+void yarray_remove_range(const Branch *array, YTransaction *txn, uint32_t index, uint32_t len);
 
-void yarray_move(const Branch *array, YTransaction *txn, int source, int target);
+void yarray_move(const Branch *array, YTransaction *txn, uint32_t source, uint32_t target);
 
 /**
  * Returns an iterator, which can be used to traverse over all elements of an `array` (`array`'s
@@ -1426,7 +1422,7 @@ struct YMapEntry *ymap_iter_next(YMapIter *iter);
 /**
  * Returns a number of entries stored within a `map`.
  */
-int ymap_len(const Branch *map, const YTransaction *txn);
+uint32_t ymap_len(const Branch *map, const YTransaction *txn);
 
 /**
  * Inserts a new entry (specified as `key`-`value` pair) into a current `map`. If entry under such
@@ -1446,7 +1442,7 @@ void ymap_insert(const Branch *map, YTransaction *txn, const char *key, const st
  *
  * A `key` must be a null-terminated UTF-8 encoded string.
  */
-char ymap_remove(const Branch *map, YTransaction *txn, const char *key);
+uint8_t ymap_remove(const Branch *map, YTransaction *txn, const char *key);
 
 /**
  * Returns a value stored under the provided `key`, or a null pointer if no entry with such `key`
@@ -1571,7 +1567,7 @@ Branch *yxmlelem_parent(const Branch *xml);
  * Returns a number of child nodes (both `YXmlElement` and `YXmlText`) living under a current XML
  * element. This function doesn't count a recursive nodes, only direct children of a current node.
  */
-int yxmlelem_child_len(const Branch *xml, const YTransaction *txn);
+uint32_t yxmlelem_child_len(const Branch *xml, const YTransaction *txn);
 
 /**
  * Returns a first child node of a current `YXmlElement`, or null pointer if current XML node is
@@ -1613,7 +1609,10 @@ struct YOutput *yxmlelem_tree_walker_next(YXmlTreeWalker *iterator);
  * A `name` must be a null-terminated UTF-8 encoded string, which will be copied into current
  * document. Therefore `name` should be freed by the function caller.
  */
-Branch *yxmlelem_insert_elem(const Branch *xml, YTransaction *txn, int index, const char *name);
+Branch *yxmlelem_insert_elem(const Branch *xml,
+                             YTransaction *txn,
+                             uint32_t index,
+                             const char *name);
 
 /**
  * Inserts an `YXmlText` as a child of a current node at the given `index` and returns its
@@ -1622,14 +1621,14 @@ Branch *yxmlelem_insert_elem(const Branch *xml, YTransaction *txn, int index, co
  * An `index` value must be between 0 and (inclusive) length of a current XML element (use
  * [yxmlelem_child_len] function to determine its length).
  */
-Branch *yxmlelem_insert_text(const Branch *xml, YTransaction *txn, int index);
+Branch *yxmlelem_insert_text(const Branch *xml, YTransaction *txn, uint32_t index);
 
 /**
  * Removes a consecutive range of child elements (of specified length) from the current
  * `YXmlElement`, starting at the given `index`. Specified range must fit into boundaries of current
  * XML node children, otherwise this function will panic at runtime.
  */
-void yxmlelem_remove_range(const Branch *xml, YTransaction *txn, int index, int len);
+void yxmlelem_remove_range(const Branch *xml, YTransaction *txn, uint32_t index, uint32_t len);
 
 /**
  * Returns an XML child node (either a `YXmlElement` or `YXmlText`) stored at a given `index` of
@@ -1638,13 +1637,13 @@ void yxmlelem_remove_range(const Branch *xml, YTransaction *txn, int index, int 
  *
  * Returned value should be eventually released using [youtput_destroy].
  */
-const struct YOutput *yxmlelem_get(const Branch *xml, const YTransaction *txn, int index);
+const struct YOutput *yxmlelem_get(const Branch *xml, const YTransaction *txn, uint32_t index);
 
 /**
  * Returns the length of the `YXmlText` string content in bytes (without the null terminator
  * character)
  */
-int yxmltext_len(const Branch *txt, const YTransaction *txn);
+uint32_t yxmltext_len(const Branch *txt, const YTransaction *txn);
 
 /**
  * Returns a null-terminated UTF-8 encoded string content of a current `YXmlText` shared data type.
@@ -1667,7 +1666,7 @@ char *yxmltext_string(const Branch *txt, const YTransaction *txn);
  */
 void yxmltext_insert(const Branch *txt,
                      YTransaction *txn,
-                     int index,
+                     uint32_t index,
                      const char *str,
                      const struct YInput *attrs);
 
@@ -1685,7 +1684,7 @@ void yxmltext_insert(const Branch *txt,
  */
 void yxmltext_insert_embed(const Branch *txt,
                            YTransaction *txn,
-                           int index,
+                           uint32_t index,
                            const struct YInput *content,
                            const struct YInput *attrs);
 
@@ -1695,8 +1694,8 @@ void yxmltext_insert_embed(const Branch *txt,
  */
 void yxmltext_format(const Branch *txt,
                      YTransaction *txn,
-                     int index,
-                     int len,
+                     uint32_t index,
+                     uint32_t len,
                      const struct YInput *attrs);
 
 /**
@@ -1709,7 +1708,7 @@ void yxmltext_format(const Branch *txt,
  * A `length` must be lower or equal number of characters (counted as UTF chars depending on the
  * encoding configured by `YDoc`) from `index` position to the end of of the string.
  */
-void yxmltext_remove_range(const Branch *txt, YTransaction *txn, int idx, int len);
+void yxmltext_remove_range(const Branch *txt, YTransaction *txn, uint32_t idx, uint32_t len);
 
 /**
  * Inserts an XML attribute described using `attr_name` and `attr_value`. If another attribute with
@@ -1760,19 +1759,19 @@ struct YInput yinput_undefined(void);
  * Function constructor used to create JSON-like boolean `YInput` cell.
  * This function doesn't allocate any heap resources.
  */
-struct YInput yinput_bool(char flag);
+struct YInput yinput_bool(uint8_t flag);
 
 /**
  * Function constructor used to create JSON-like 64-bit floating point number `YInput` cell.
  * This function doesn't allocate any heap resources.
  */
-struct YInput yinput_float(float num);
+struct YInput yinput_float(double num);
 
 /**
  * Function constructor used to create JSON-like 64-bit signed integer `YInput` cell.
  * This function doesn't allocate any heap resources.
  */
-struct YInput yinput_long(long integer);
+struct YInput yinput_long(int64_t integer);
 
 /**
  * Function constructor used to create a string `YInput` cell. Provided parameter must be
@@ -1787,14 +1786,14 @@ struct YInput yinput_string(const char *str);
  * This function doesn't allocate any heap resources and doesn't release any on its own, therefore
  * its up to a caller to free resources once a structure is no longer needed.
  */
-struct YInput yinput_binary(const uint8_t *buf, int len);
+struct YInput yinput_binary(const char *buf, uint32_t len);
 
 /**
  * Function constructor used to create a JSON-like array `YInput` cell of other JSON-like values of
  * a given length. This function doesn't allocate any heap resources and doesn't release any on its
  * own, therefore its up to a caller to free resources once a structure is no longer needed.
  */
-struct YInput yinput_json_array(struct YInput *values, int len);
+struct YInput yinput_json_array(struct YInput *values, uint32_t len);
 
 /**
  * Function constructor used to create a JSON-like map `YInput` cell of other JSON-like key-value
@@ -1804,7 +1803,7 @@ struct YInput yinput_json_array(struct YInput *values, int len);
  * This function doesn't allocate any heap resources and doesn't release any on its own, therefore
  * its up to a caller to free resources once a structure is no longer needed.
  */
-struct YInput yinput_json_map(char **keys, struct YInput *values, int len);
+struct YInput yinput_json_map(char **keys, struct YInput *values, uint32_t len);
 
 /**
  * Function constructor used to create a nested `YArray` `YInput` cell prefilled with other
@@ -1812,7 +1811,7 @@ struct YInput yinput_json_map(char **keys, struct YInput *values, int len);
  * any on its own, therefore its up to a caller to free resources once a structure is no longer
  * needed.
  */
-struct YInput yinput_yarray(struct YInput *values, int len);
+struct YInput yinput_yarray(struct YInput *values, uint32_t len);
 
 /**
  * Function constructor used to create a nested `YMap` `YInput` cell prefilled with other key-value
@@ -1822,7 +1821,7 @@ struct YInput yinput_yarray(struct YInput *values, int len);
  * This function doesn't allocate any heap resources and doesn't release any on its own, therefore
  * its up to a caller to free resources once a structure is no longer needed.
  */
-struct YInput yinput_ymap(char **keys, struct YInput *values, int len);
+struct YInput yinput_ymap(char **keys, struct YInput *values, uint32_t len);
 
 /**
  * Function constructor used to create a nested `YText` `YInput` cell prefilled with a specified
@@ -1870,7 +1869,7 @@ YDoc *youtput_read_ydoc(const struct YOutput *val);
  * `1` for truthy case and `0` otherwise. Returns a null pointer in case when a value stored under
  * current `YOutput` cell is not of a boolean type.
  */
-const char *youtput_read_bool(const struct YOutput *val);
+const uint8_t *youtput_read_bool(const struct YOutput *val);
 
 /**
  * Attempts to read the value for a given `YOutput` pointer as a 64-bit floating point number.
@@ -1878,7 +1877,7 @@ const char *youtput_read_bool(const struct YOutput *val);
  * Returns a null pointer in case when a value stored under current `YOutput` cell
  * is not a floating point number.
  */
-const float *youtput_read_float(const struct YOutput *val);
+const double *youtput_read_float(const struct YOutput *val);
 
 /**
  * Attempts to read the value for a given `YOutput` pointer as a 64-bit signed integer.
@@ -1886,7 +1885,7 @@ const float *youtput_read_float(const struct YOutput *val);
  * Returns a null pointer in case when a value stored under current `YOutput` cell
  * is not a signed integer.
  */
-const long long *youtput_read_long(const struct YOutput *val);
+const int64_t *youtput_read_long(const struct YOutput *val);
 
 /**
  * Attempts to read the value for a given `YOutput` pointer as a null-terminated UTF-8 encoded
@@ -1906,7 +1905,7 @@ char *youtput_read_string(const struct YOutput *val);
  * is not a binary type. Underlying binary is released automatically as part of [youtput_destroy]
  * destructor.
  */
-const unsigned char *youtput_read_binary(const struct YOutput *val);
+const char *youtput_read_binary(const struct YOutput *val);
 
 /**
  * Attempts to read the value for a given `YOutput` pointer as a JSON-like array of `YOutput`
@@ -1979,9 +1978,7 @@ Branch *youtput_read_yxmltext(const struct YOutput *val);
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `ytext_unobserve` function.
  */
-unsigned int ytext_observe(const Branch *txt,
-                           void *state,
-                           void (*cb)(void*, const struct YTextEvent*));
+uint32_t ytext_observe(const Branch *txt, void *state, void (*cb)(void*, const struct YTextEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YMap` instance. Callbacks
@@ -1989,9 +1986,7 @@ unsigned int ytext_observe(const Branch *txt,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `ymap_unobserve` function.
  */
-unsigned int ymap_observe(const Branch *map,
-                          void *state,
-                          void (*cb)(void*, const struct YMapEvent*));
+uint32_t ymap_observe(const Branch *map, void *state, void (*cb)(void*, const struct YMapEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YArray` instance. Callbacks
@@ -1999,9 +1994,9 @@ unsigned int ymap_observe(const Branch *map,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yarray_unobserve` function.
  */
-unsigned int yarray_observe(const Branch *array,
-                            void *state,
-                            void (*cb)(void*, const struct YArrayEvent*));
+uint32_t yarray_observe(const Branch *array,
+                        void *state,
+                        void (*cb)(void*, const struct YArrayEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YXmlElement` instance.
@@ -2009,9 +2004,9 @@ unsigned int yarray_observe(const Branch *array,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yxmlelem_unobserve` function.
  */
-unsigned int yxmlelem_observe(const Branch *xml,
-                              void *state,
-                              void (*cb)(void*, const struct YXmlEvent*));
+uint32_t yxmlelem_observe(const Branch *xml,
+                          void *state,
+                          void (*cb)(void*, const struct YXmlEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YXmlText` instance. Callbacks
@@ -2019,9 +2014,9 @@ unsigned int yxmlelem_observe(const Branch *xml,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yxmltext_unobserve` function.
  */
-unsigned int yxmltext_observe(const Branch *xml,
-                              void *state,
-                              void (*cb)(void*, const struct YXmlTextEvent*));
+uint32_t yxmltext_observe(const Branch *xml,
+                          void *state,
+                          void (*cb)(void*, const struct YXmlTextEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this shared type instance as well
@@ -2031,45 +2026,45 @@ unsigned int yxmltext_observe(const Branch *xml,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yunobserve_deep` function.
  */
-unsigned int yobserve_deep(Branch *ytype,
-                           void *state,
-                           void (*cb)(void*, int, const struct YEvent*));
+uint32_t yobserve_deep(Branch *ytype,
+                       void *state,
+                       void (*cb)(void*, uint32_t, const struct YEvent*));
 
 /**
  * Releases a callback subscribed via `ytext_observe` function represented by passed
  * observer parameter.
  */
-void ytext_unobserve(const Branch *txt, unsigned int subscription_id);
+void ytext_unobserve(const Branch *txt, uint32_t subscription_id);
 
 /**
  * Releases a callback subscribed via `yarray_observe` function represented by passed
  * observer parameter.
  */
-void yarray_unobserve(const Branch *array, unsigned int subscription_id);
+void yarray_unobserve(const Branch *array, uint32_t subscription_id);
 
 /**
  * Releases a callback subscribed via `ymap_observe` function represented by passed
  * observer parameter.
  */
-void ymap_unobserve(const Branch *map, unsigned int subscription_id);
+void ymap_unobserve(const Branch *map, uint32_t subscription_id);
 
 /**
  * Releases a callback subscribed via `yxmlelem_observe` function represented by passed
  * observer parameter.
  */
-void yxmlelem_unobserve(const Branch *xml, unsigned int subscription_id);
+void yxmlelem_unobserve(const Branch *xml, uint32_t subscription_id);
 
 /**
  * Releases a callback subscribed via `yxmltext_observe` function represented by passed
  * observer parameter.
  */
-void yxmltext_unobserve(const Branch *xml, unsigned int subscription_id);
+void yxmltext_unobserve(const Branch *xml, uint32_t subscription_id);
 
 /**
  * Releases a callback subscribed via `yobserve_deep` function represented by passed
  * observer parameter.
  */
-void yunobserve_deep(Branch *ytype, unsigned int subscription_id);
+void yunobserve_deep(Branch *ytype, uint32_t subscription_id);
 
 /**
  * Returns a pointer to a shared collection, which triggered passed event `e`.
@@ -2104,7 +2099,7 @@ Branch *yxmltext_event_target(const struct YXmlTextEvent *e);
  *
  * Path returned this way should be eventually released using `ypath_destroy`.
  */
-struct YPathSegment *ytext_event_path(const struct YTextEvent *e, int *len);
+struct YPathSegment *ytext_event_path(const struct YTextEvent *e, uint32_t *len);
 
 /**
  * Returns a path from a root type down to a current shared collection (which can be obtained using
@@ -2114,7 +2109,7 @@ struct YPathSegment *ytext_event_path(const struct YTextEvent *e, int *len);
  *
  * Path returned this way should be eventually released using `ypath_destroy`.
  */
-struct YPathSegment *ymap_event_path(const struct YMapEvent *e, int *len);
+struct YPathSegment *ymap_event_path(const struct YMapEvent *e, uint32_t *len);
 
 /**
  * Returns a path from a root type down to a current shared collection (which can be obtained using
@@ -2124,7 +2119,7 @@ struct YPathSegment *ymap_event_path(const struct YMapEvent *e, int *len);
  *
  * Path returned this way should be eventually released using `ypath_destroy`.
  */
-struct YPathSegment *yxmlelem_event_path(const struct YXmlEvent *e, int *len);
+struct YPathSegment *yxmlelem_event_path(const struct YXmlEvent *e, uint32_t *len);
 
 /**
  * Returns a path from a root type down to a current shared collection (which can be obtained using
@@ -2134,7 +2129,7 @@ struct YPathSegment *yxmlelem_event_path(const struct YXmlEvent *e, int *len);
  *
  * Path returned this way should be eventually released using `ypath_destroy`.
  */
-struct YPathSegment *yxmltext_event_path(const struct YXmlTextEvent *e, int *len);
+struct YPathSegment *yxmltext_event_path(const struct YXmlTextEvent *e, uint32_t *len);
 
 /**
  * Returns a path from a root type down to a current shared collection (which can be obtained using
@@ -2144,13 +2139,13 @@ struct YPathSegment *yxmltext_event_path(const struct YXmlTextEvent *e, int *len
  *
  * Path returned this way should be eventually released using `ypath_destroy`.
  */
-struct YPathSegment *yarray_event_path(const struct YArrayEvent *e, int *len);
+struct YPathSegment *yarray_event_path(const struct YArrayEvent *e, uint32_t *len);
 
 /**
  * Releases allocated memory used by objects returned from path accessor functions of shared type
  * events.
  */
-void ypath_destroy(struct YPathSegment *path, int len);
+void ypath_destroy(struct YPathSegment *path, uint32_t len);
 
 /**
  * Returns a sequence of changes produced by sequence component of shared collections (such as
@@ -2160,7 +2155,7 @@ void ypath_destroy(struct YPathSegment *path, int len);
  * Delta returned from this function should eventually be released using `yevent_delta_destroy`
  * function.
  */
-struct YDelta *ytext_event_delta(const struct YTextEvent *e, int *len);
+struct YDelta *ytext_event_delta(const struct YTextEvent *e, uint32_t *len);
 
 /**
  * Returns a sequence of changes produced by sequence component of shared collections (such as
@@ -2170,7 +2165,7 @@ struct YDelta *ytext_event_delta(const struct YTextEvent *e, int *len);
  * Delta returned from this function should eventually be released using `yevent_delta_destroy`
  * function.
  */
-struct YDelta *yxmltext_event_delta(const struct YXmlTextEvent *e, int *len);
+struct YDelta *yxmltext_event_delta(const struct YXmlTextEvent *e, uint32_t *len);
 
 /**
  * Returns a sequence of changes produced by sequence component of shared collections (such as
@@ -2180,7 +2175,7 @@ struct YDelta *yxmltext_event_delta(const struct YXmlTextEvent *e, int *len);
  * Delta returned from this function should eventually be released using `yevent_delta_destroy`
  * function.
  */
-struct YEventChange *yarray_event_delta(const struct YArrayEvent *e, int *len);
+struct YEventChange *yarray_event_delta(const struct YArrayEvent *e, uint32_t *len);
 
 /**
  * Returns a sequence of changes produced by sequence component of shared collections (such as
@@ -2190,17 +2185,17 @@ struct YEventChange *yarray_event_delta(const struct YArrayEvent *e, int *len);
  * Delta returned from this function should eventually be released using `yevent_delta_destroy`
  * function.
  */
-struct YEventChange *yxmlelem_event_delta(const struct YXmlEvent *e, int *len);
+struct YEventChange *yxmlelem_event_delta(const struct YXmlEvent *e, uint32_t *len);
 
 /**
  * Releases memory allocated by the object returned from `yevent_delta` function.
  */
-void ytext_delta_destroy(struct YDelta *delta, int len);
+void ytext_delta_destroy(struct YDelta *delta, uint32_t len);
 
 /**
  * Releases memory allocated by the object returned from `yevent_delta` function.
  */
-void yevent_delta_destroy(struct YEventChange *delta, int len);
+void yevent_delta_destroy(struct YEventChange *delta, uint32_t len);
 
 /**
  * Returns a sequence of changes produced by map component of shared collections (such as
@@ -2210,7 +2205,7 @@ void yevent_delta_destroy(struct YEventChange *delta, int len);
  * Delta returned from this function should eventually be released using `yevent_keys_destroy`
  * function.
  */
-struct YEventKeyChange *ymap_event_keys(const struct YMapEvent *e, int *len);
+struct YEventKeyChange *ymap_event_keys(const struct YMapEvent *e, uint32_t *len);
 
 /**
  * Returns a sequence of changes produced by map component of shared collections.
@@ -2219,7 +2214,7 @@ struct YEventKeyChange *ymap_event_keys(const struct YMapEvent *e, int *len);
  * Delta returned from this function should eventually be released using `yevent_keys_destroy`
  * function.
  */
-struct YEventKeyChange *yxmlelem_event_keys(const struct YXmlEvent *e, int *len);
+struct YEventKeyChange *yxmlelem_event_keys(const struct YXmlEvent *e, uint32_t *len);
 
 /**
  * Returns a sequence of changes produced by map component of shared collections.
@@ -2228,13 +2223,13 @@ struct YEventKeyChange *yxmlelem_event_keys(const struct YXmlEvent *e, int *len)
  * Delta returned from this function should eventually be released using `yevent_keys_destroy`
  * function.
  */
-struct YEventKeyChange *yxmltext_event_keys(const struct YXmlTextEvent *e, int *len);
+struct YEventKeyChange *yxmltext_event_keys(const struct YXmlTextEvent *e, uint32_t *len);
 
 /**
  * Releases memory allocated by the object returned from `yxml_event_keys` and `ymap_event_keys`
  * functions.
  */
-void yevent_keys_destroy(struct YEventKeyChange *keys, int len);
+void yevent_keys_destroy(struct YEventKeyChange *keys, uint32_t len);
 
 YUndoManager *yundo_manager(const YDoc *doc,
                             const Branch *ytype,
@@ -2242,35 +2237,35 @@ YUndoManager *yundo_manager(const YDoc *doc,
 
 void yundo_manager_destroy(YUndoManager *mgr);
 
-void yundo_manager_add_origin(YUndoManager *mgr, int origin_len, const char *origin);
+void yundo_manager_add_origin(YUndoManager *mgr, uint32_t origin_len, const char *origin);
 
-void yundo_manager_remove_origin(YUndoManager *mgr, int origin_len, const char *origin);
+void yundo_manager_remove_origin(YUndoManager *mgr, uint32_t origin_len, const char *origin);
 
 void yundo_manager_add_scope(YUndoManager *mgr, const Branch *ytype);
 
-char yundo_manager_clear(YUndoManager *mgr);
+uint8_t yundo_manager_clear(YUndoManager *mgr);
 
 void yundo_manager_stop(YUndoManager *mgr);
 
-char yundo_manager_undo(YUndoManager *mgr);
+uint8_t yundo_manager_undo(YUndoManager *mgr);
 
-char yundo_manager_redo(YUndoManager *mgr);
+uint8_t yundo_manager_redo(YUndoManager *mgr);
 
-char yundo_manager_can_undo(YUndoManager *mgr);
+uint8_t yundo_manager_can_undo(YUndoManager *mgr);
 
-char yundo_manager_can_redo(YUndoManager *mgr);
+uint8_t yundo_manager_can_redo(YUndoManager *mgr);
 
-unsigned int yundo_manager_observe_added(YUndoManager *mgr,
-                                         void *state,
-                                         void (*cb)(void*, const struct YUndoEvent*));
+uint32_t yundo_manager_observe_added(YUndoManager *mgr,
+                                     void *state,
+                                     void (*cb)(void*, const struct YUndoEvent*));
 
-void yundo_manager_unobserve_added(YUndoManager *mgr, unsigned int subscription_id);
+void yundo_manager_unobserve_added(YUndoManager *mgr, uint32_t subscription_id);
 
-unsigned int yundo_manager_observe_popped(YUndoManager *mgr,
-                                          void *state,
-                                          void (*cb)(void*, const struct YUndoEvent*));
+uint32_t yundo_manager_observe_popped(YUndoManager *mgr,
+                                      void *state,
+                                      void (*cb)(void*, const struct YUndoEvent*));
 
-void yundo_manager_unobserve_popped(YUndoManager *mgr, unsigned int subscription_id);
+void yundo_manager_unobserve_popped(YUndoManager *mgr, uint32_t subscription_id);
 
 /**
  * Returns a value informing what kind of Yrs shared collection given `branch` represents.
@@ -2289,7 +2284,7 @@ void yrelative_position_destroy(YRelativePosition *pos);
  * If association is **after** the referenced inserted character, returned number will be >= 0.
  * If association is **before** the referenced inserted character, returned number will be < 0.
  */
-int yrelative_position_assoc(const YRelativePosition *pos);
+int8_t yrelative_position_assoc(const YRelativePosition *pos);
 
 /**
  * Retrieves a `YRelativePosition` corresponding to a given human-readable `index` pointing into
@@ -2301,20 +2296,20 @@ int yrelative_position_assoc(const YRelativePosition *pos);
  */
 YRelativePosition *yrelative_position_from_index(const Branch *branch,
                                                  YTransaction *txn,
-                                                 int index,
-                                                 int assoc);
+                                                 uint32_t index,
+                                                 int8_t assoc);
 
 /**
  * Serializes `YRelativePosition` into binary representation. `len` parameter is updated with byte
  * length of the generated binary. Returned binary can be free'd using `ybinary_destroy`.
  */
-unsigned char *yrelative_position_encode(const YRelativePosition *pos, int *len);
+char *yrelative_position_encode(const YRelativePosition *pos, uint32_t *len);
 
 /**
  * Deserializes `YRelativePosition` from the payload previously serialized using `yrelative_position_encode`.
  */
-YRelativePosition *yrelative_position_decode(const unsigned char *binary,
-                                             int len);
+YRelativePosition *yrelative_position_decode(const char *binary,
+                                             uint32_t len);
 
 /**
  * Given `YRelativePosition` and transaction reference, if computes a human-readable index in a
@@ -2326,6 +2321,6 @@ YRelativePosition *yrelative_position_decode(const unsigned char *binary,
 void yrelative_position_read(const YRelativePosition *pos,
                              const YTransaction *txn,
                              Branch **out_branch,
-                             int *out_index);
+                             uint32_t *out_index);
 
 #endif

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -8,7 +8,7 @@ extern "C" {
     #include "include/libyrs.h"
 };
 
-YDoc* ydoc_new_with_id(int id) {
+YDoc* ydoc_new_with_id(uint64_t id) {
     YOptions o = yoptions();
     o.encoding = Y_OFFSET_UTF16;
     o.id = id;
@@ -34,13 +34,13 @@ void exchange_updates(int len, ...) {
                 YDoc* d2 = docs[j];
 
                 YTransaction* t1 = ydoc_read_transaction(d1);
-                int sv1_len = 0;
-                unsigned char* sv1 = ytransaction_state_vector_v1(t1, &sv1_len);
+                uint32_t sv1_len = 0;
+                char* sv1 = ytransaction_state_vector_v1(t1, &sv1_len);
                 ytransaction_commit(t1);
 
                 YTransaction* t2 = ydoc_read_transaction(d2);
-                int u2_len = 0;
-                unsigned char* u2 = ytransaction_state_diff_v1(t2, sv1, sv1_len, &u2_len);
+                uint32_t u2_len = 0;
+                char* u2 = ytransaction_state_diff_v1(t2, sv1, sv1_len, &u2_len);
                 ytransaction_commit(t2);
                 ybinary_destroy(sv1, sv1_len);
 
@@ -70,17 +70,17 @@ TEST_CASE("Update exchange basic") {
     ytext_insert(txt2, t2, 0, "hello ", NULL);
 
     // exchange updates
-    int sv1_len = 0;
-    unsigned char* sv1 = ytransaction_state_vector_v1(t1, &sv1_len);
+    uint32_t sv1_len = 0;
+    char* sv1 = ytransaction_state_vector_v1(t1, &sv1_len);
 
-    int sv2_len = 0;
-    unsigned char* sv2 = ytransaction_state_vector_v1(t2, &sv2_len);
+    uint32_t sv2_len = 0;
+    char* sv2 = ytransaction_state_vector_v1(t2, &sv2_len);
 
-    int u1_len = 0;
-    unsigned char* u1 = ytransaction_state_diff_v1(t1, sv2, sv2_len, &u1_len);
+    uint32_t u1_len = 0;
+    char* u1 = ytransaction_state_diff_v1(t1, sv2, sv2_len, &u1_len);
 
-    int u2_len = 0;
-    unsigned char* u2 = ytransaction_state_diff_v1(t2, sv1, sv1_len, &u2_len);
+    uint32_t u2_len = 0;
+    char* u2 = ytransaction_state_diff_v1(t2, sv1, sv1_len, &u2_len);
 
     ybinary_destroy(sv1, sv1_len);
     ybinary_destroy(sv2, sv2_len);
@@ -392,7 +392,7 @@ TEST_CASE("YXmlElement basic") {
 }
 
 typedef struct YTextEventTest {
-    int delta_len;
+    uint32_t delta_len;
     YDelta* delta;
     Branch* target;
 } YEventTest;
@@ -424,7 +424,7 @@ TEST_CASE("YText observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YTextEventTest* t = ytext_event_test_new();
-    unsigned int sub = ytext_observe(txt, (void*)t, &ytext_test_observe);
+    uint32_t sub = ytext_observe(txt, (void*)t, &ytext_test_observe);
 
     // insert initial data to an empty YText
     ytext_insert(txt, txn, 0, "abcd", NULL);
@@ -482,7 +482,7 @@ TEST_CASE("YText insert embed") {
     YTransaction *txn = ydoc_write_transaction(doc, 0, NULL);
 
     YTextEventTest *t = ytext_event_test_new();
-    unsigned int sub = ytext_observe(txt, (void *) t, &ytext_test_observe);
+    uint32_t sub = ytext_observe(txt, (void *) t, &ytext_test_observe);
 
     char* _bold = (char*)"bold";
     YInput _true = yinput_bool(1);
@@ -536,7 +536,7 @@ TEST_CASE("YText insert embed") {
 }
 
 typedef struct YArrayEventTest {
-    int delta_len;
+    uint32_t delta_len;
     YEventChange* delta;
     Branch* target;
 } YArrayEventTest;
@@ -568,7 +568,7 @@ TEST_CASE("YArray observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YArrayEventTest* t = yarray_event_test_new();
-    unsigned int sub = yarray_observe(array, (void*)t, &yarray_test_observe);
+    uint32_t sub = yarray_observe(array, (void*)t, &yarray_test_observe);
 
     // insert initial data to an empty YArray
     YInput* i = (YInput*)malloc(4 * sizeof(YInput));
@@ -638,7 +638,7 @@ TEST_CASE("YArray observe") {
 }
 
 typedef struct YMapEventTest {
-    int keys_len;
+    uint32_t keys_len;
     YEventKeyChange * keys;
     Branch* target;
 } YMapEventTest;
@@ -670,7 +670,7 @@ TEST_CASE("YMap observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YMapEventTest* t = ymap_event_test_new();
-    unsigned int sub = ymap_observe(map, (void*)t, &ymap_test_observe);
+    uint32_t sub = ymap_observe(map, (void*)t, &ymap_test_observe);
 
     // insert initial data to an empty YMap
     YInput i1 = yinput_string("value1");
@@ -749,8 +749,8 @@ TEST_CASE("YMap observe") {
 }
 
 typedef struct YXmlTextEventTest {
-    int delta_len;
-    int keys_len;
+    uint32_t delta_len;
+    uint32_t keys_len;
     YDelta* delta;
     Branch* target;
     YEventKeyChange *keys;
@@ -788,7 +788,7 @@ TEST_CASE("YXmlText observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YXmlTextEventTest* t = yxmltext_event_test_new();
-    unsigned int sub = yxmltext_observe(txt, (void*)t, &yxmltext_test_observe);
+    uint32_t sub = yxmltext_observe(txt, (void*)t, &yxmltext_test_observe);
 
     // insert initial data to an empty YText
     yxmltext_insert(txt, txn, 0, "abcd", NULL);
@@ -842,9 +842,9 @@ TEST_CASE("YXmlText observe") {
 
 typedef struct YXmlEventTest {
     Branch* target;
-    int keys_len;
+    uint32_t keys_len;
+    uint32_t delta_len;
     YEventKeyChange * keys;
-    int delta_len;
     YEventChange* delta;
 } YXmlEventTest;
 
@@ -882,7 +882,7 @@ TEST_CASE("YXmlElement observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YXmlEventTest* t = yxml_event_test_new();
-    unsigned int sub = yxmlelem_observe(xml, (void*)t, &yxml_test_observe);
+    uint32_t sub = yxmlelem_observe(xml, (void*)t, &yxml_test_observe);
 
     // insert initial attributes
     yxmlelem_insert_attr(xml, txn, "attr1", "value1");
@@ -1001,8 +1001,8 @@ TEST_CASE("YXmlElement observe") {
 
 typedef struct YDeepObserveTest {
     YPathSegment* path[4];
-    int path_lens[4];
-    int count;
+    uint32_t path_lens[4];
+    uint32_t count;
 } YDeepObserveTest;
 
 YDeepObserveTest* new_ydeepobserve_test() {
@@ -1020,14 +1020,14 @@ void ydeepobserve_test_clean(YDeepObserveTest* test) {
     test->count = 0;
 }
 
-void ydeepobserve_test(void* state, int event_count, const YEvent* events) {
+void ydeepobserve_test(void* state, uint32_t event_count, const YEvent* events) {
     YDeepObserveTest* test = (YDeepObserveTest*)state;
     // cleanup previous state
     ydeepobserve_test_clean(test);
 
     for (int i = 0; i < event_count; i++) {
         YEvent e = events[i];
-        int path_len = 0;
+        uint32_t path_len = 0;
         switch (e.tag) {
             case Y_ARRAY: {
                 YArrayEvent nested = e.content.array;
@@ -1055,7 +1055,7 @@ TEST_CASE("YArray deep observe") {
     ytransaction_commit(txn);
 
     YDeepObserveTest* state = new_ydeepobserve_test();
-    unsigned int subscription_id = yobserve_deep(array, (void *) state, ydeepobserve_test);
+    uint32_t subscription_id = yobserve_deep(array, (void *) state, ydeepobserve_test);
 
     txn = ydoc_write_transaction(doc, 0, NULL);
     YInput input = yinput_ymap(NULL, NULL, 0);
@@ -1094,7 +1094,7 @@ TEST_CASE("YMap deep observe") {
     ytransaction_commit(txn);
 
     YDeepObserveTest* state = new_ydeepobserve_test();
-    unsigned int subscription_id = yobserve_deep(map, (void *) state, ydeepobserve_test);
+    uint32_t subscription_id = yobserve_deep(map, (void *) state, ydeepobserve_test);
 
     /* map.set(txn, 'map', new Y.YMap()) */
     txn = ydoc_write_transaction(doc, 0, NULL);
@@ -1151,10 +1151,10 @@ TEST_CASE("YMap deep observe") {
 }
 
 typedef struct {
-    int len;
-    unsigned char* update;
-    int incoming_len;
-    unsigned char* incoming_update;
+    uint32_t len;
+    uint32_t incoming_len;
+    char* update;
+    char* incoming_update;
 } ObserveUpdatesTest;
 
 void reset_observe_updates(ObserveUpdatesTest* t) {
@@ -1171,12 +1171,12 @@ void reset_observe_updates(ObserveUpdatesTest* t) {
     }
 }
 
-void observe_updates(void* state, int len, const unsigned char* bytes) {
+void observe_updates(void* state, uint32_t len, const char* bytes) {
     ObserveUpdatesTest* t = (ObserveUpdatesTest*)state;
     t->incoming_len = len;
-    void* buf = malloc(sizeof(unsigned char*) * len);
+    void* buf = malloc(sizeof(char*) * len);
     memcpy(buf, (void*)bytes, (size_t)len);
-    t->incoming_update = (unsigned char*)buf;
+    t->incoming_update = (char*)buf;
 }
 
 TEST_CASE("YDoc observe updates V1") {
@@ -1192,7 +1192,7 @@ TEST_CASE("YDoc observe updates V1") {
 
     YDoc *doc2 = ydoc_new_with_id(2);
     Branch *txt2 = ytext(doc2, "test");
-    unsigned int subscription_id = ydoc_observe_updates_v1(doc2, t, observe_updates);
+    uint32_t subscription_id = ydoc_observe_updates_v1(doc2, t, observe_updates);
     txn = ydoc_write_transaction(doc2, 0, NULL);
     ytransaction_apply(txn, t->update, t->len);
     ytransaction_commit(txn);
@@ -1234,7 +1234,7 @@ TEST_CASE("YDoc observe updates V2") {
 
     YDoc *doc2 = ydoc_new_with_id(2);
     Branch *txt2 = ytext(doc2, "test");
-    unsigned int subscription_id = ydoc_observe_updates_v2(doc2, t, observe_updates);
+    uint32_t subscription_id = ydoc_observe_updates_v2(doc2, t, observe_updates);
     txn = ydoc_write_transaction(doc2, 0, NULL);
     ytransaction_apply_v2(txn, t->update, t->len);
     ytransaction_commit(txn);
@@ -1327,7 +1327,7 @@ void observe_after_transaction(void* state, YAfterTransactionEvent* e) {
 }
 
 TEST_CASE("YDoc observe after transaction") {
-    long long CLIENT_ID = 1;
+    uint64_t CLIENT_ID = 1;
     AfterTransactionTest t;
     t.calls = 0;
     t.delete_set.entries_count = 0;
@@ -1335,12 +1335,12 @@ TEST_CASE("YDoc observe after transaction") {
 
     t.after_state.entries_count = 1;
     t.after_state.client_ids = &CLIENT_ID;
-    int CLOCK = 11;
+    uint64_t CLOCK = 11;
     t.after_state.clocks = &CLOCK;
 
     YDoc *doc1 = ydoc_new_with_id(CLIENT_ID);
     Branch *txt1 = ytext(doc1, "test");
-    unsigned int subscription_id = ydoc_observe_after_transaction(doc1, &t, observe_after_transaction);
+    uint32_t subscription_id = ydoc_observe_after_transaction(doc1, &t, observe_after_transaction);
 
     YTransaction *txn = ydoc_write_transaction(doc1, 0, NULL);
     ytext_insert(txt1, txn, 0, "hello world", NULL);
@@ -1391,13 +1391,13 @@ TEST_CASE("YDoc snapshots") {
 
     ytext_insert(txt, txn, 0, "hello", NULL);
 
-    int snapshot_len = 0;
-    unsigned char* snapshot = ytransaction_snapshot(txn, &snapshot_len);
+    uint32_t snapshot_len = 0;
+    char* snapshot = ytransaction_snapshot(txn, &snapshot_len);
 
     ytext_insert(txt, txn, 5, " world", NULL);
 
-    int update_len = 0;
-    unsigned char* update = ytransaction_encode_state_from_snapshot_v1(txn, snapshot, snapshot_len, &update_len);
+    uint32_t update_len = 0;
+    char* update = ytransaction_encode_state_from_snapshot_v1(txn, snapshot, snapshot_len, &update_len);
 
     ytransaction_commit(txn);
     ydoc_destroy(doc);
@@ -1457,7 +1457,7 @@ TEST_CASE("YDoc observe subdocs") {
     YDoc *doc1 = ydoc_new_with_id(1);
     SubdocsTest t;
     memset(t.total, '\0', 20);
-    unsigned int subscription_id = ydoc_observe_subdocs(doc1, &t, observe_subdocs);
+    uint32_t subscription_id = ydoc_observe_subdocs(doc1, &t, observe_subdocs);
     Branch* subdocs = ymap(doc1, "mysubdocs");
 
     YOptions options = yoptions();
@@ -1552,7 +1552,7 @@ TEST_CASE("YDoc observe subdocs") {
 
 
     txn = ydoc_read_transaction(doc1);
-    int subdoc_count = 0;
+    uint32_t subdoc_count = 0;
     YDoc** subdoc_refs = ytransaction_subdocs(txn, &subdoc_count);
     concat_guids(t.total, subdoc_count, subdoc_refs);
     ytransaction_commit(txn);
@@ -1562,8 +1562,8 @@ TEST_CASE("YDoc observe subdocs") {
     memset(t.total, '\0', 20);
 
     txn = ydoc_read_transaction(doc1);
-    int update_len = 0;
-    unsigned char* update = ytransaction_state_diff_v1(txn, NULL, 0, &update_len);
+    uint32_t update_len = 0;
+    char* update = ytransaction_state_diff_v1(txn, NULL, 0, &update_len);
     ytransaction_commit(txn);
     ydoc_unobserve_subdocs(doc1, subscription_id);
 
@@ -1742,12 +1742,12 @@ TEST_CASE("Relative position") {
         for (int assoc = -1; assoc <= 0; ++assoc) {
 
             YRelativePosition* pos = yrelative_position_from_index(txt, txn, i, assoc);
-            int bin_len = 0;
-            unsigned char* bin = yrelative_position_encode(pos, &bin_len);
+            uint32_t bin_len = 0;
+            char* bin = yrelative_position_encode(pos, &bin_len);
             YRelativePosition* pos2 = yrelative_position_decode(bin, bin_len);
 
             Branch* actual_branch;
-            int actual_index;
+            uint32_t actual_index;
 
             yrelative_position_read(pos2, txn, &actual_branch, &actual_index);
 

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1335,7 +1335,7 @@ TEST_CASE("YDoc observe after transaction") {
 
     t.after_state.entries_count = 1;
     t.after_state.client_ids = &CLIENT_ID;
-    uint64_t CLOCK = 11;
+    uint32_t CLOCK = 11;
     t.after_state.clocks = &CLOCK;
 
     YDoc *doc1 = ydoc_new_with_id(CLIENT_ID);

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -4370,7 +4370,7 @@ impl YUndoEvent {
 /// Returns either 0 when `branch` is null or one of values: `Y_ARRAY`, `Y_TEXT`, `Y_MAP`,
 /// `Y_XML_ELEM`, `Y_XML_TEXT`.
 #[no_mangle]
-pub unsafe extern "C" fn ytype_kind(branch: *const Branch) -> c_char {
+pub unsafe extern "C" fn ytype_kind(branch: *const Branch) -> i8 {
     if let Some(branch) = branch.as_ref() {
         match branch.type_ref() {
             TYPE_REFS_ARRAY => Y_ARRAY,

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1,10 +1,9 @@
 use lib0::any::Any;
 use lib0::error::Error;
 use std::collections::HashMap;
-use std::ffi::{c_void, CStr, CString};
+use std::ffi::{c_char, c_void, CStr, CString};
 use std::mem::{forget, ManuallyDrop, MaybeUninit};
 use std::ops::Deref;
-use std::os::raw::{c_char, c_float, c_int, c_long, c_longlong, c_uchar, c_uint, c_ulong};
 use std::ptr::{null, null_mut};
 use std::rc::Rc;
 use yrs::block::{ClientID, ItemContent, Prelim, Unused};
@@ -83,22 +82,22 @@ pub const Y_XML_FRAG: i8 = 6;
 pub const Y_DOC: i8 = 7;
 
 /// Flag used to mark a truthy boolean numbers.
-pub const Y_TRUE: c_char = 1;
+pub const Y_TRUE: u8 = 1;
 
 /// Flag used to mark a falsy boolean numbers.
-pub const Y_FALSE: c_char = 0;
+pub const Y_FALSE: u8 = 0;
 
 /// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
 /// the byte number of UTF8-encoded string.
-pub const Y_OFFSET_BYTES: c_int = 0;
+pub const Y_OFFSET_BYTES: u8 = 0;
 
 /// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
 /// UTF-16 chars of encoded string.
-pub const Y_OFFSET_UTF16: c_int = 1;
+pub const Y_OFFSET_UTF16: u8 = 1;
 
 /// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
 /// by UTF-32 chars of encoded string.
-pub const Y_OFFSET_UTF32: c_int = 2;
+pub const Y_OFFSET_UTF32: u8 = 2;
 
 /* pub types below are used by cbindgen for c header generation */
 
@@ -246,7 +245,7 @@ pub struct YOptions {
     /// unrecoverable document state corruption. The same thing may happen if the client restored
     /// document state from snapshot, that didn't contain all of that clients updates that were sent
     /// to other peers.
-    pub id: c_ulong,
+    pub id: u64,
 
     /// A NULL-able globally unique Uuid v4 compatible null-terminated string identifier
     /// of this document. If passed as NULL, a random Uuid will be generated instead.
@@ -262,18 +261,18 @@ pub struct YOptions {
     /// - `Y_ENCODING_BYTES`
     /// - `Y_ENCODING_UTF16`
     /// - `Y_ENCODING_UTF32`
-    pub encoding: c_int,
+    pub encoding: u8,
 
     /// Boolean flag used to determine if deleted blocks should be garbage collected or not
     /// during the transaction commits. Setting this value to 0 means GC will be performed.
-    pub skip_gc: c_int,
+    pub skip_gc: u8,
 
     /// Boolean flag used to determine if subdocument should be loaded automatically.
     /// If this is a subdocument, remote peers will load the document as well automatically.
-    pub auto_load: c_int,
+    pub auto_load: u8,
 
     /// Boolean flag used to determine whether the document should be synced by the provider now.
-    pub should_load: c_int,
+    pub should_load: u8,
 }
 
 impl Into<Options> for YOptions {
@@ -313,7 +312,7 @@ impl Into<Options> for YOptions {
 impl From<Options> for YOptions {
     fn from(o: Options) -> Self {
         YOptions {
-            id: o.client_id as c_ulong,
+            id: o.client_id,
             guid: CString::new(o.guid.as_ref()).unwrap().into_raw(),
             collection_id: if let Some(collection_id) = o.collection_id {
                 CString::new(collection_id).unwrap().into_raw()
@@ -376,7 +375,7 @@ pub unsafe extern "C" fn ystring_destroy(str: *mut c_char) {
 /// therefore a size of memory to be released must be explicitly provided.
 /// Yrs binaries don't use libc malloc, so calling `free()` on them will fault.
 #[no_mangle]
-pub unsafe extern "C" fn ybinary_destroy(ptr: *mut c_uchar, len: c_int) {
+pub unsafe extern "C" fn ybinary_destroy(ptr: *mut c_char, len: u32) {
     if !ptr.is_null() {
         drop(Vec::from_raw_parts(ptr, len as usize, len as usize));
     }
@@ -411,9 +410,9 @@ pub extern "C" fn ydoc_new_with_options(options: YOptions) -> *mut Doc {
 
 /// Returns a unique client identifier of this [Doc] instance.
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_id(doc: *mut Doc) -> c_ulong {
+pub unsafe extern "C" fn ydoc_id(doc: *mut Doc) -> u64 {
     let doc = doc.as_ref().unwrap();
-    doc.client_id() as c_ulong
+    doc.client_id()
 }
 
 /// Returns a unique document identifier of this [Doc] instance.
@@ -456,46 +455,46 @@ pub unsafe extern "C" fn ydoc_auto_load(doc: *mut Doc) -> u8 {
 pub unsafe extern "C" fn ydoc_observe_updates_v1(
     doc: *mut Doc,
     state: *mut c_void,
-    cb: extern "C" fn(*mut c_void, c_int, *const c_uchar),
-) -> c_uint {
+    cb: extern "C" fn(*mut c_void, u32, *const c_char),
+) -> u32 {
     let doc = doc.as_ref().unwrap();
     let observer = doc
         .observe_update_v1(move |_, e| {
             let bytes = &e.update;
-            let len = bytes.len();
-            cb(state, len as c_int, bytes.as_ptr() as *const c_uchar)
+            let len = bytes.len() as u32;
+            cb(state, len, bytes.as_ptr() as *const c_char)
         })
         .unwrap();
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn ydoc_observe_updates_v2(
     doc: *mut Doc,
     state: *mut c_void,
-    cb: extern "C" fn(*mut c_void, c_int, *const c_uchar),
-) -> c_uint {
+    cb: extern "C" fn(*mut c_void, u32, *const c_char),
+) -> u32 {
     let doc = doc.as_ref().unwrap();
     let observer = doc
         .observe_update_v2(move |_, e| {
             let bytes = &e.update;
-            let len = bytes.len();
-            cb(state, len as c_int, bytes.as_ptr() as *const c_uchar)
+            let len = bytes.len() as u32;
+            cb(state, len, bytes.as_ptr() as *const c_char)
         })
         .unwrap();
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_updates_v1(doc: *mut Doc, subscription_id: c_uint) {
+pub unsafe extern "C" fn ydoc_unobserve_updates_v1(doc: *mut Doc, subscription_id: u32) {
     let doc = doc.as_ref().unwrap();
     doc.unobserve_update_v1(subscription_id as SubscriptionId);
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_updates_v2(doc: *mut Doc, subscription_id: c_uint) {
+pub unsafe extern "C" fn ydoc_unobserve_updates_v2(doc: *mut Doc, subscription_id: u32) {
     let doc = doc.as_ref().unwrap();
     doc.unobserve_update_v2(subscription_id as SubscriptionId);
 }
@@ -505,7 +504,7 @@ pub unsafe extern "C" fn ydoc_observe_after_transaction(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *mut YAfterTransactionEvent),
-) -> c_uint {
+) -> u32 {
     let doc = doc.as_ref().unwrap();
     let observer = doc
         .observe_transaction_cleanup(move |_, e| {
@@ -514,11 +513,11 @@ pub unsafe extern "C" fn ydoc_observe_after_transaction(
         })
         .unwrap();
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_after_transaction(doc: *mut Doc, subscription_id: c_uint) {
+pub unsafe extern "C" fn ydoc_unobserve_after_transaction(doc: *mut Doc, subscription_id: u32) {
     let doc = doc.as_ref().unwrap();
     doc.unobserve_transaction_cleanup(subscription_id as SubscriptionId);
 }
@@ -528,7 +527,7 @@ pub unsafe extern "C" fn ydoc_observe_subdocs(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *mut YSubdocsEvent),
-) -> c_uint {
+) -> u32 {
     let doc = doc.as_mut().unwrap();
     let observer = doc
         .observe_subdocs(move |_, e| {
@@ -537,11 +536,11 @@ pub unsafe extern "C" fn ydoc_observe_subdocs(
         })
         .unwrap();
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_subdocs(doc: *mut Doc, subscription_id: c_uint) {
+pub unsafe extern "C" fn ydoc_unobserve_subdocs(doc: *mut Doc, subscription_id: u32) {
     let doc = doc.as_ref().unwrap();
     doc.unobserve_subdocs(subscription_id as SubscriptionId);
 }
@@ -551,17 +550,17 @@ pub unsafe extern "C" fn ydoc_observe_clear(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *mut Doc),
-) -> c_uint {
+) -> u32 {
     let doc = doc.as_mut().unwrap();
     let observer = doc
         .observe_destroy(move |_, e| cb(state, e as *const Doc as *mut _))
         .unwrap();
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_clear(doc: *mut Doc, subscription_id: c_uint) {
+pub unsafe extern "C" fn ydoc_unobserve_clear(doc: *mut Doc, subscription_id: u32) {
     let doc = doc.as_ref().unwrap();
     doc.unobserve_destroy(subscription_id as SubscriptionId);
 }
@@ -623,7 +622,7 @@ pub unsafe extern "C" fn ydoc_read_transaction(doc: *mut Doc) -> *mut Transactio
 #[no_mangle]
 pub unsafe extern "C" fn ydoc_write_transaction(
     doc: *mut Doc,
-    origin_len: c_int,
+    origin_len: u32,
     origin: *const c_char,
 ) -> *mut Transaction {
     assert!(!doc.is_null());
@@ -685,7 +684,7 @@ pub unsafe extern "C" fn ybranch_read_transaction(branch: *mut Branch) -> *mut T
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_subdocs(
     txn: *mut Transaction,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut *mut Doc {
     let txn = txn.as_ref().unwrap();
     let subdocs: Vec<_> = txn
@@ -693,7 +692,7 @@ pub unsafe extern "C" fn ytransaction_subdocs(
         .map(|doc| doc as *const Doc as *mut Doc)
         .collect();
     let out = subdocs.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -845,16 +844,16 @@ pub unsafe extern "C" fn yxmltext(doc: *mut Doc, name: *const c_char) -> *mut Br
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_state_vector_v1(
     txn: *const Transaction,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    len: *mut u32,
+) -> *mut c_char {
     assert!(!txn.is_null());
 
     let txn = txn.as_ref().unwrap();
     let state_vector = txn.state_vector();
     let binary = state_vector.encode_v1().into_boxed_slice();
 
-    *len = binary.len() as c_int;
-    Box::into_raw(binary) as *mut c_uchar
+    *len = binary.len() as u32;
+    Box::into_raw(binary) as *mut c_char
 }
 
 /// Returns a delta difference between current state of a transaction's document and a state vector
@@ -874,10 +873,10 @@ pub unsafe extern "C" fn ytransaction_state_vector_v1(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_state_diff_v1(
     txn: *const Transaction,
-    sv: *const c_uchar,
-    sv_len: c_int,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    sv: *const c_char,
+    sv_len: u32,
+    len: *mut u32,
+) -> *mut c_char {
     assert!(!txn.is_null());
 
     let txn = txn.as_ref().unwrap();
@@ -897,8 +896,8 @@ pub unsafe extern "C" fn ytransaction_state_diff_v1(
     let mut encoder = EncoderV1::new();
     txn.encode_diff(&sv, &mut encoder);
     let binary = encoder.to_vec().into_boxed_slice();
-    *len = binary.len() as c_int;
-    Box::into_raw(binary) as *mut c_uchar
+    *len = binary.len() as u32;
+    Box::into_raw(binary) as *mut c_char
 }
 
 /// Returns a delta difference between current state of a transaction's document and a state vector
@@ -918,10 +917,10 @@ pub unsafe extern "C" fn ytransaction_state_diff_v1(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_state_diff_v2(
     txn: *const Transaction,
-    sv: *const c_uchar,
-    sv_len: c_int,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    sv: *const c_char,
+    sv_len: u32,
+    len: *mut u32,
+) -> *mut c_char {
     assert!(!txn.is_null());
 
     let txn = txn.as_ref().unwrap();
@@ -941,8 +940,8 @@ pub unsafe extern "C" fn ytransaction_state_diff_v2(
     let mut encoder = EncoderV2::new();
     txn.encode_diff(&sv, &mut encoder);
     let binary = encoder.to_vec().into_boxed_slice();
-    *len = binary.len() as c_int;
-    Box::into_raw(binary) as *mut c_uchar
+    *len = binary.len() as u32;
+    Box::into_raw(binary) as *mut c_char
 }
 
 /// Returns a snapshot descriptor of a current state of the document. This snapshot information
@@ -951,14 +950,14 @@ pub unsafe extern "C" fn ytransaction_state_diff_v2(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_snapshot(
     txn: *const Transaction,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    len: *mut u32,
+) -> *mut c_char {
     assert!(!txn.is_null());
     let txn = txn.as_ref().unwrap();
     let binary = txn.snapshot().encode_v1().into_boxed_slice();
 
-    *len = binary.len() as c_int;
-    Box::into_raw(binary) as *mut c_uchar
+    *len = binary.len() as u32;
+    Box::into_raw(binary) as *mut c_char
 }
 
 /// Encodes a state of the document at a point in time specified by the provided `snapshot`
@@ -972,10 +971,10 @@ pub unsafe extern "C" fn ytransaction_snapshot(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_encode_state_from_snapshot_v1(
     txn: *const Transaction,
-    snapshot: *const c_uchar,
-    snapshot_len: c_int,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    snapshot: *const c_char,
+    snapshot_len: u32,
+    len: *mut u32,
+) -> *mut c_char {
     assert!(!txn.is_null());
     let txn = txn.as_ref().unwrap();
     let snapshot = {
@@ -988,8 +987,8 @@ pub unsafe extern "C" fn ytransaction_encode_state_from_snapshot_v1(
         Err(_) => null_mut(),
         Ok(_) => {
             let binary = encoder.to_vec().into_boxed_slice();
-            *len = binary.len() as c_int;
-            Box::into_raw(binary) as *mut c_uchar
+            *len = binary.len() as u32;
+            Box::into_raw(binary) as *mut c_char
         }
     }
 }
@@ -1005,10 +1004,10 @@ pub unsafe extern "C" fn ytransaction_encode_state_from_snapshot_v1(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_encode_state_from_snapshot_v2(
     txn: *const Transaction,
-    snapshot: *const c_uchar,
-    snapshot_len: c_int,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    snapshot: *const c_char,
+    snapshot_len: u32,
+    len: *mut u32,
+) -> *mut c_char {
     assert!(!txn.is_null());
     let txn = txn.as_ref().unwrap();
     let snapshot = {
@@ -1021,8 +1020,8 @@ pub unsafe extern "C" fn ytransaction_encode_state_from_snapshot_v2(
         Err(_) => null_mut(),
         Ok(_) => {
             let binary = encoder.to_vec().into_boxed_slice();
-            *len = binary.len() as c_int;
-            Box::into_raw(binary) as *mut c_uchar
+            *len = binary.len() as u32;
+            Box::into_raw(binary) as *mut c_char
         }
     }
 }
@@ -1031,10 +1030,7 @@ pub unsafe extern "C" fn ytransaction_encode_state_from_snapshot_v2(
 /// encoded using lib0 v1 encoding.
 /// Returns null if update couldn't be parsed into a lib0 v1 formatting.
 #[no_mangle]
-pub unsafe extern "C" fn yupdate_debug_v1(
-    update: *const c_uchar,
-    update_len: c_int,
-) -> *mut c_char {
+pub unsafe extern "C" fn yupdate_debug_v1(update: *const c_char, update_len: u32) -> *mut c_char {
     assert!(!update.is_null());
 
     let data = std::slice::from_raw_parts(update as *const u8, update_len as usize);
@@ -1050,10 +1046,7 @@ pub unsafe extern "C" fn yupdate_debug_v1(
 /// encoded using lib0 v2 encoding.
 /// Returns null if update couldn't be parsed into a lib0 v2 formatting.
 #[no_mangle]
-pub unsafe extern "C" fn yupdate_debug_v2(
-    update: *const c_uchar,
-    update_len: c_int,
-) -> *mut c_char {
+pub unsafe extern "C" fn yupdate_debug_v2(update: *const c_char, update_len: u32) -> *mut c_char {
     assert!(!update.is_null());
 
     let data = std::slice::from_raw_parts(update as *const u8, update_len as usize);
@@ -1081,9 +1074,9 @@ pub unsafe extern "C" fn yupdate_debug_v2(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_apply(
     txn: *mut Transaction,
-    diff: *const c_uchar,
-    diff_len: c_int,
-) -> c_int {
+    diff: *const c_char,
+    diff_len: u32,
+) -> u8 {
     assert!(!txn.is_null());
     assert!(!diff.is_null());
 
@@ -1118,9 +1111,9 @@ pub unsafe extern "C" fn ytransaction_apply(
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_apply_v2(
     txn: *mut Transaction,
-    diff: *const c_uchar,
-    diff_len: c_int,
-) -> c_int {
+    diff: *const c_char,
+    diff_len: u32,
+) -> u8 {
     assert!(!txn.is_null());
     assert!(!diff.is_null());
 
@@ -1139,24 +1132,24 @@ pub unsafe extern "C" fn ytransaction_apply_v2(
 }
 
 /// Error code: couldn't read data from input stream.
-pub const ERR_CODE_IO: c_int = 1;
+pub const ERR_CODE_IO: u8 = 1;
 
 /// Error code: decoded variable integer outside of the expected integer size bounds.
-pub const ERR_CODE_VAR_INT: c_int = 2;
+pub const ERR_CODE_VAR_INT: u8 = 2;
 
 /// Error code: end of stream found when more data was expected.
-pub const ERR_CODE_EOS: c_int = 3;
+pub const ERR_CODE_EOS: u8 = 3;
 
 /// Error code: decoded enum tag value was not among known cases.
-pub const ERR_CODE_UNEXPECTED_VALUE: c_int = 4;
+pub const ERR_CODE_UNEXPECTED_VALUE: u8 = 4;
 
 /// Error code: failure when trying to decode JSON content.
-pub const ERR_CODE_INVALID_JSON: c_int = 5;
+pub const ERR_CODE_INVALID_JSON: u8 = 5;
 
 /// Error code: other error type than the one specified.
-pub const ERR_CODE_OTHER: c_int = 6;
+pub const ERR_CODE_OTHER: u8 = 6;
 
-fn err_code(e: Error) -> c_int {
+fn err_code(e: Error) -> u8 {
     match e {
         Error::IO(_) => ERR_CODE_IO,
         Error::VarIntSizeExceeded(_) => ERR_CODE_VAR_INT,
@@ -1169,11 +1162,11 @@ fn err_code(e: Error) -> c_int {
 
 /// Returns the length of the `YText` string content in bytes (without the null terminator character)
 #[no_mangle]
-pub unsafe extern "C" fn ytext_len(txt: *const Branch, txn: *const Transaction) -> c_int {
+pub unsafe extern "C" fn ytext_len(txt: *const Branch, txn: *const Transaction) -> u32 {
     assert!(!txt.is_null());
     let txn = txn.as_ref().unwrap();
     let txt = TextRef::from_raw_branch(txt);
-    txt.len(txn) as c_int
+    txt.len(txn)
 }
 
 /// Returns a null-terminated UTF-8 encoded string content of a current `YText` shared data type.
@@ -1203,7 +1196,7 @@ pub unsafe extern "C" fn ytext_string(txt: *const Branch, txn: *const Transactio
 pub unsafe extern "C" fn ytext_insert(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
     value: *const c_char,
     attrs: *const YInput,
 ) {
@@ -1235,8 +1228,8 @@ pub unsafe extern "C" fn ytext_insert(
 pub unsafe extern "C" fn ytext_format(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
-    len: c_int,
+    index: u32,
+    len: u32,
     attrs: *const YInput,
 ) {
     assert!(!txt.is_null());
@@ -1271,7 +1264,7 @@ pub unsafe extern "C" fn ytext_format(
 pub unsafe extern "C" fn ytext_insert_embed(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
     content: *const YInput,
     attrs: *const YInput,
 ) {
@@ -1318,8 +1311,8 @@ fn map_attrs(attrs: Any) -> Option<Attrs> {
 pub unsafe extern "C" fn ytext_remove_range(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
-    length: c_int,
+    index: u32,
+    length: u32,
 ) {
     assert!(!txt.is_null());
     assert!(!txn.is_null());
@@ -1334,11 +1327,11 @@ pub unsafe extern "C" fn ytext_remove_range(
 
 /// Returns a number of elements stored within current instance of `YArray`.
 #[no_mangle]
-pub unsafe extern "C" fn yarray_len(array: *const Branch) -> c_int {
+pub unsafe extern "C" fn yarray_len(array: *const Branch) -> u32 {
     assert!(!array.is_null());
 
     let array = array.as_ref().unwrap();
-    array.len() as c_int
+    array.len() as u32
 }
 
 /// Returns a pointer to a `YOutput` value stored at a given `index` of a current `YArray`.
@@ -1349,7 +1342,7 @@ pub unsafe extern "C" fn yarray_len(array: *const Branch) -> c_int {
 pub unsafe extern "C" fn yarray_get(
     array: *const Branch,
     txn: *const Transaction,
-    index: c_int,
+    index: u32,
 ) -> *mut YOutput {
     assert!(!array.is_null());
 
@@ -1377,9 +1370,9 @@ pub unsafe extern "C" fn yarray_get(
 pub unsafe extern "C" fn yarray_insert_range(
     array: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
     items: *const YInput,
-    items_len: c_int,
+    items_len: u32,
 ) {
     assert!(!array.is_null());
     assert!(!txn.is_null());
@@ -1430,8 +1423,8 @@ pub unsafe extern "C" fn yarray_insert_range(
 pub unsafe extern "C" fn yarray_remove_range(
     array: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
-    len: c_int,
+    index: u32,
+    len: u32,
 ) {
     assert!(!array.is_null());
     assert!(!txn.is_null());
@@ -1449,8 +1442,8 @@ pub unsafe extern "C" fn yarray_remove_range(
 pub unsafe extern "C" fn yarray_move(
     array: *const Branch,
     txn: *mut Transaction,
-    source: c_int,
-    target: c_int,
+    source: u32,
+    target: u32,
 ) {
     assert!(!array.is_null());
     assert!(!txn.is_null());
@@ -1547,13 +1540,13 @@ pub unsafe extern "C" fn ymap_iter_next(iter: *mut MapIter) -> *mut YMapEntry {
 
 /// Returns a number of entries stored within a `map`.
 #[no_mangle]
-pub unsafe extern "C" fn ymap_len(map: *const Branch, txn: *const Transaction) -> c_int {
+pub unsafe extern "C" fn ymap_len(map: *const Branch, txn: *const Transaction) -> u32 {
     assert!(!map.is_null());
 
     let txn = txn.as_ref().unwrap();
     let map = MapRef::from_raw_branch(map);
 
-    map.len(txn) as c_int
+    map.len(txn) as u32
 }
 
 /// Inserts a new entry (specified as `key`-`value` pair) into a current `map`. If entry under such
@@ -1597,7 +1590,7 @@ pub unsafe extern "C" fn ymap_remove(
     map: *const Branch,
     txn: *mut Transaction,
     key: *const c_char,
-) -> c_char {
+) -> u8 {
     assert!(!map.is_null());
     assert!(!txn.is_null());
     assert!(!key.is_null());
@@ -1912,14 +1905,14 @@ pub unsafe extern "C" fn yxmlelem_parent(xml: *const Branch) -> *mut Branch {
 /// Returns a number of child nodes (both `YXmlElement` and `YXmlText`) living under a current XML
 /// element. This function doesn't count a recursive nodes, only direct children of a current node.
 #[no_mangle]
-pub unsafe extern "C" fn yxmlelem_child_len(xml: *const Branch, txn: *const Transaction) -> c_int {
+pub unsafe extern "C" fn yxmlelem_child_len(xml: *const Branch, txn: *const Transaction) -> u32 {
     assert!(!xml.is_null());
     assert!(!txn.is_null());
 
     let txn = txn.as_ref().unwrap();
     let xml = XmlElementRef::from_raw_branch(xml);
 
-    xml.len(txn) as c_int
+    xml.len(txn) as u32
 }
 
 /// Returns a first child node of a current `YXmlElement`, or null pointer if current XML node is
@@ -2002,7 +1995,7 @@ pub unsafe extern "C" fn yxmlelem_tree_walker_next(iterator: *mut TreeWalker) ->
 pub unsafe extern "C" fn yxmlelem_insert_elem(
     xml: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
     name: *const c_char,
 ) -> *mut Branch {
     assert!(!xml.is_null());
@@ -2029,7 +2022,7 @@ pub unsafe extern "C" fn yxmlelem_insert_elem(
 pub unsafe extern "C" fn yxmlelem_insert_text(
     xml: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
 ) -> *mut Branch {
     assert!(!xml.is_null());
     assert!(!txn.is_null());
@@ -2050,8 +2043,8 @@ pub unsafe extern "C" fn yxmlelem_insert_text(
 pub unsafe extern "C" fn yxmlelem_remove_range(
     xml: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
-    len: c_int,
+    index: u32,
+    len: u32,
 ) {
     assert!(!xml.is_null());
     assert!(!txn.is_null());
@@ -2074,7 +2067,7 @@ pub unsafe extern "C" fn yxmlelem_remove_range(
 pub unsafe extern "C" fn yxmlelem_get(
     xml: *const Branch,
     txn: *const Transaction,
-    index: c_int,
+    index: u32,
 ) -> *const YOutput {
     assert!(!xml.is_null());
     assert!(!txn.is_null());
@@ -2096,14 +2089,14 @@ pub unsafe extern "C" fn yxmlelem_get(
 /// Returns the length of the `YXmlText` string content in bytes (without the null terminator
 /// character)
 #[no_mangle]
-pub unsafe extern "C" fn yxmltext_len(txt: *const Branch, txn: *const Transaction) -> c_int {
+pub unsafe extern "C" fn yxmltext_len(txt: *const Branch, txn: *const Transaction) -> u32 {
     assert!(!txt.is_null());
     assert!(!txn.is_null());
 
     let txn = txn.as_ref().unwrap();
     let txt = XmlTextRef::from_raw_branch(txt);
 
-    txt.len(txn) as c_int
+    txt.len(txn) as u32
 }
 
 /// Returns a null-terminated UTF-8 encoded string content of a current `YXmlText` shared data type.
@@ -2138,7 +2131,7 @@ pub unsafe extern "C" fn yxmltext_string(
 pub unsafe extern "C" fn yxmltext_insert(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
     str: *const c_char,
     attrs: *const YInput,
 ) {
@@ -2178,7 +2171,7 @@ pub unsafe extern "C" fn yxmltext_insert(
 pub unsafe extern "C" fn yxmltext_insert_embed(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
+    index: u32,
     content: *const YInput,
     attrs: *const YInput,
 ) {
@@ -2210,8 +2203,8 @@ pub unsafe extern "C" fn yxmltext_insert_embed(
 pub unsafe extern "C" fn yxmltext_format(
     txt: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
-    len: c_int,
+    index: u32,
+    len: u32,
     attrs: *const YInput,
 ) {
     assert!(!txt.is_null());
@@ -2244,8 +2237,8 @@ pub unsafe extern "C" fn yxmltext_format(
 pub unsafe extern "C" fn yxmltext_remove_range(
     txt: *const Branch,
     txn: *mut Transaction,
-    idx: c_int,
-    len: c_int,
+    idx: u32,
+    len: u32,
 ) {
     assert!(!txt.is_null());
     assert!(!txn.is_null());
@@ -2368,7 +2361,7 @@ pub struct YInput {
     /// elements.
     ///
     /// For other types it's always equal to `1`.
-    pub len: c_int,
+    pub len: u32,
 
     /// Union struct which contains a content corresponding to a provided `tag` field.
     value: YInputContent,
@@ -2433,11 +2426,11 @@ impl YInput {
 
 #[repr(C)]
 union YInputContent {
-    flag: c_char,
-    num: c_float,
-    integer: c_long,
+    flag: u8,
+    num: f64,
+    integer: i64,
     str: *mut c_char,
-    buf: *mut c_uchar,
+    buf: *mut c_char,
     values: *mut YInput,
     map: ManuallyDrop<YMapInputData>,
     doc: *mut Doc,
@@ -2562,7 +2555,7 @@ pub struct YOutput {
     /// For [Y_JSON_ARR], [Y_JSON_MAP] it describes a number of passed elements.
     ///
     /// For other types it's always equal to `1`.
-    pub len: c_int,
+    pub len: u32,
 
     /// Union struct which contains a content corresponding to a provided `tag` field.
     value: YOutputContent,
@@ -2705,26 +2698,24 @@ impl From<Any> for YOutput {
                 Any::BigInt(v) => YOutput {
                     tag: Y_JSON_INT,
                     len: 1,
-                    value: YOutputContent {
-                        integer: v as c_longlong,
-                    },
+                    value: YOutputContent { integer: v },
                 },
                 Any::String(v) => YOutput {
                     tag: Y_JSON_STR,
-                    len: v.len() as c_int,
+                    len: v.len() as u32,
                     value: YOutputContent {
                         str: CString::new(v.as_ref()).unwrap().into_raw(),
                     },
                 },
                 Any::Buffer(v) => YOutput {
                     tag: Y_JSON_BUF,
-                    len: v.len() as c_int,
+                    len: v.len() as u32,
                     value: YOutputContent {
                         buf: Box::into_raw(v.clone()) as *mut _,
                     },
                 },
                 Any::Array(v) => {
-                    let len = v.len() as c_int;
+                    let len = v.len() as u32;
                     let v = Vec::from(v);
                     let mut array: Vec<_> = v.into_iter().map(|v| YOutput::from(v)).collect();
                     array.shrink_to_fit();
@@ -2737,7 +2728,7 @@ impl From<Any> for YOutput {
                     }
                 }
                 Any::Map(v) => {
-                    let len = v.len() as c_int;
+                    let len = v.len() as u32;
                     let v = *v;
                     let mut array: Vec<_> = v
                         .into_iter()
@@ -2843,11 +2834,11 @@ impl From<Doc> for YOutput {
 
 #[repr(C)]
 union YOutputContent {
-    flag: c_char,
-    num: c_float,
-    integer: c_longlong,
+    flag: u8,
+    num: f64,
+    integer: i64,
     str: *mut c_char,
-    buf: *mut c_uchar,
+    buf: *mut c_char,
     array: *mut YOutput,
     map: *mut YMapEntry,
     y_type: *mut Branch,
@@ -2887,7 +2878,7 @@ pub unsafe extern "C" fn yinput_undefined() -> YInput {
 /// Function constructor used to create JSON-like boolean `YInput` cell.
 /// This function doesn't allocate any heap resources.
 #[no_mangle]
-pub unsafe extern "C" fn yinput_bool(flag: c_char) -> YInput {
+pub unsafe extern "C" fn yinput_bool(flag: u8) -> YInput {
     YInput {
         tag: Y_JSON_BOOL,
         len: 1,
@@ -2898,7 +2889,7 @@ pub unsafe extern "C" fn yinput_bool(flag: c_char) -> YInput {
 /// Function constructor used to create JSON-like 64-bit floating point number `YInput` cell.
 /// This function doesn't allocate any heap resources.
 #[no_mangle]
-pub unsafe extern "C" fn yinput_float(num: c_float) -> YInput {
+pub unsafe extern "C" fn yinput_float(num: f64) -> YInput {
     YInput {
         tag: Y_JSON_NUM,
         len: 1,
@@ -2909,7 +2900,7 @@ pub unsafe extern "C" fn yinput_float(num: c_float) -> YInput {
 /// Function constructor used to create JSON-like 64-bit signed integer `YInput` cell.
 /// This function doesn't allocate any heap resources.
 #[no_mangle]
-pub unsafe extern "C" fn yinput_long(integer: c_long) -> YInput {
+pub unsafe extern "C" fn yinput_long(integer: i64) -> YInput {
     YInput {
         tag: Y_JSON_INT,
         len: 1,
@@ -2936,12 +2927,12 @@ pub unsafe extern "C" fn yinput_string(str: *const c_char) -> YInput {
 /// This function doesn't allocate any heap resources and doesn't release any on its own, therefore
 /// its up to a caller to free resources once a structure is no longer needed.
 #[no_mangle]
-pub unsafe extern "C" fn yinput_binary(buf: *const u8, len: c_int) -> YInput {
+pub unsafe extern "C" fn yinput_binary(buf: *const c_char, len: u32) -> YInput {
     YInput {
         tag: Y_JSON_BUF,
         len,
         value: YInputContent {
-            buf: buf as *mut u8,
+            buf: buf as *mut c_char,
         },
     }
 }
@@ -2950,7 +2941,7 @@ pub unsafe extern "C" fn yinput_binary(buf: *const u8, len: c_int) -> YInput {
 /// a given length. This function doesn't allocate any heap resources and doesn't release any on its
 /// own, therefore its up to a caller to free resources once a structure is no longer needed.
 #[no_mangle]
-pub unsafe extern "C" fn yinput_json_array(values: *mut YInput, len: c_int) -> YInput {
+pub unsafe extern "C" fn yinput_json_array(values: *mut YInput, len: u32) -> YInput {
     YInput {
         tag: Y_JSON_ARR,
         len,
@@ -2968,7 +2959,7 @@ pub unsafe extern "C" fn yinput_json_array(values: *mut YInput, len: c_int) -> Y
 pub unsafe extern "C" fn yinput_json_map(
     keys: *mut *mut c_char,
     values: *mut YInput,
-    len: c_int,
+    len: u32,
 ) -> YInput {
     YInput {
         tag: Y_JSON_MAP,
@@ -2984,7 +2975,7 @@ pub unsafe extern "C" fn yinput_json_map(
 /// any on its own, therefore its up to a caller to free resources once a structure is no longer
 /// needed.
 #[no_mangle]
-pub unsafe extern "C" fn yinput_yarray(values: *mut YInput, len: c_int) -> YInput {
+pub unsafe extern "C" fn yinput_yarray(values: *mut YInput, len: u32) -> YInput {
     YInput {
         tag: Y_ARRAY,
         len,
@@ -3002,7 +2993,7 @@ pub unsafe extern "C" fn yinput_yarray(values: *mut YInput, len: c_int) -> YInpu
 pub unsafe extern "C" fn yinput_ymap(
     keys: *mut *mut c_char,
     values: *mut YInput,
-    len: c_int,
+    len: u32,
 ) -> YInput {
     YInput {
         tag: Y_MAP,
@@ -3084,7 +3075,7 @@ pub unsafe extern "C" fn youtput_read_ydoc(val: *const YOutput) -> *mut Doc {
 /// `1` for truthy case and `0` otherwise. Returns a null pointer in case when a value stored under
 /// current `YOutput` cell is not of a boolean type.
 #[no_mangle]
-pub unsafe extern "C" fn youtput_read_bool(val: *const YOutput) -> *const c_char {
+pub unsafe extern "C" fn youtput_read_bool(val: *const YOutput) -> *const u8 {
     let v = val.as_ref().unwrap();
     if v.tag == Y_JSON_BOOL {
         &v.value.flag
@@ -3098,7 +3089,7 @@ pub unsafe extern "C" fn youtput_read_bool(val: *const YOutput) -> *const c_char
 /// Returns a null pointer in case when a value stored under current `YOutput` cell
 /// is not a floating point number.
 #[no_mangle]
-pub unsafe extern "C" fn youtput_read_float(val: *const YOutput) -> *const c_float {
+pub unsafe extern "C" fn youtput_read_float(val: *const YOutput) -> *const f64 {
     let v = val.as_ref().unwrap();
     if v.tag == Y_JSON_NUM {
         &v.value.num
@@ -3112,7 +3103,7 @@ pub unsafe extern "C" fn youtput_read_float(val: *const YOutput) -> *const c_flo
 /// Returns a null pointer in case when a value stored under current `YOutput` cell
 /// is not a signed integer.
 #[no_mangle]
-pub unsafe extern "C" fn youtput_read_long(val: *const YOutput) -> *const c_longlong {
+pub unsafe extern "C" fn youtput_read_long(val: *const YOutput) -> *const i64 {
     let v = val.as_ref().unwrap();
     if v.tag == Y_JSON_INT {
         &v.value.integer
@@ -3144,7 +3135,7 @@ pub unsafe extern "C" fn youtput_read_string(val: *const YOutput) -> *mut c_char
 /// is not a binary type. Underlying binary is released automatically as part of [youtput_destroy]
 /// destructor.
 #[no_mangle]
-pub unsafe extern "C" fn youtput_read_binary(val: *const YOutput) -> *const c_uchar {
+pub unsafe extern "C" fn youtput_read_binary(val: *const YOutput) -> *const c_char {
     let v = val.as_ref().unwrap();
     if v.tag == Y_JSON_BUF {
         v.value.buf
@@ -3269,7 +3260,7 @@ pub unsafe extern "C" fn ytext_observe(
     txt: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YTextEvent),
-) -> c_uint {
+) -> u32 {
     assert!(!txt.is_null());
 
     let mut txt = TextRef::from_raw_branch(txt);
@@ -3278,7 +3269,7 @@ pub unsafe extern "C" fn ytext_observe(
         cb(state, &e as *const YTextEvent);
     });
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YMap` instance. Callbacks
@@ -3290,7 +3281,7 @@ pub unsafe extern "C" fn ymap_observe(
     map: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YMapEvent),
-) -> c_uint {
+) -> u32 {
     assert!(!map.is_null());
 
     let mut map = MapRef::from_raw_branch(map);
@@ -3299,7 +3290,7 @@ pub unsafe extern "C" fn ymap_observe(
         cb(state, &e as *const YMapEvent);
     });
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YArray` instance. Callbacks
@@ -3311,7 +3302,7 @@ pub unsafe extern "C" fn yarray_observe(
     array: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YArrayEvent),
-) -> c_uint {
+) -> u32 {
     assert!(!array.is_null());
 
     let mut array = ArrayRef::from_raw_branch(array);
@@ -3320,7 +3311,7 @@ pub unsafe extern "C" fn yarray_observe(
         cb(state, &e as *const YArrayEvent);
     });
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YXmlElement` instance.
@@ -3332,7 +3323,7 @@ pub unsafe extern "C" fn yxmlelem_observe(
     xml: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YXmlEvent),
-) -> c_uint {
+) -> u32 {
     assert!(!xml.is_null());
 
     let mut xml = XmlElementRef::from_raw_branch(xml);
@@ -3341,7 +3332,7 @@ pub unsafe extern "C" fn yxmlelem_observe(
         cb(state, &e as *const YXmlEvent);
     });
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YXmlText` instance. Callbacks
@@ -3353,7 +3344,7 @@ pub unsafe extern "C" fn yxmltext_observe(
     xml: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YXmlTextEvent),
-) -> c_uint {
+) -> u32 {
     assert!(!xml.is_null());
 
     let mut xml = XmlTextRef::from_raw_branch(xml);
@@ -3362,7 +3353,7 @@ pub unsafe extern "C" fn yxmltext_observe(
         cb(state, &e as *const YXmlTextEvent);
     });
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 /// Subscribes a given callback function `cb` to changes made by this shared type instance as well
@@ -3375,18 +3366,18 @@ pub unsafe extern "C" fn yxmltext_observe(
 pub unsafe extern "C" fn yobserve_deep(
     ytype: *mut Branch,
     state: *mut c_void,
-    cb: extern "C" fn(*mut c_void, c_int, *const YEvent),
-) -> c_uint {
+    cb: extern "C" fn(*mut c_void, u32, *const YEvent),
+) -> u32 {
     assert!(!ytype.is_null());
 
     let branch = ytype.as_mut().unwrap();
     let observer = branch.observe_deep(move |txn, events| {
         let events: Vec<_> = events.iter().map(|e| YEvent::new(txn, e)).collect();
-        let len = events.len() as c_int;
+        let len = events.len() as u32;
         cb(state, len, events.as_ptr());
     });
     let subscription_id: u32 = observer.into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 /// Event generated for callbacks subscribed using `ydoc_observe_after_transaction`. It contains
@@ -3413,9 +3404,9 @@ impl YAfterTransactionEvent {
 
 #[repr(C)]
 pub struct YSubdocsEvent {
-    added_len: c_int,
-    removed_len: c_int,
-    loaded_len: c_int,
+    added_len: u32,
+    removed_len: u32,
+    loaded_len: u32,
     added: *mut *mut Doc,
     removed: *mut *mut Doc,
     loaded: *mut *mut Doc,
@@ -3436,9 +3427,9 @@ impl YSubdocsEvent {
         let loaded = e.loaded();
 
         YSubdocsEvent {
-            added_len: added.len() as c_int,
-            removed_len: removed.len() as c_int,
-            loaded_len: loaded.len() as c_int,
+            added_len: added.len() as u32,
+            removed_len: removed.len() as u32,
+            loaded_len: loaded.len() as u32,
             added: into_ptr(added),
             removed: into_ptr(removed),
             loaded: into_ptr(loaded),
@@ -3448,7 +3439,7 @@ impl YSubdocsEvent {
 
 impl Drop for YSubdocsEvent {
     fn drop(&mut self) {
-        fn release(len: c_int, buf: *mut *mut Doc) {
+        fn release(len: u32, buf: *mut *mut Doc) {
             unsafe {
                 let docs = Vec::from_raw_parts(buf, len as usize, len as usize);
                 for d in docs {
@@ -3468,25 +3459,25 @@ impl Drop for YSubdocsEvent {
 #[repr(C)]
 pub struct YStateVector {
     /// Number of clients. It describes a length of both `client_ids` and `clocks` arrays.
-    pub entries_count: c_int,
+    pub entries_count: u32,
     /// Array of unique client identifiers (length is given in `entries_count` field). Each client
     /// ID has corresponding clock attached, which can be found in `clocks` field under the same
     /// index.
-    pub client_ids: *mut c_longlong,
+    pub client_ids: *mut u64,
     /// Array of clocks (length is given in `entries_count` field) known for each client. Each clock
     /// has a corresponding client identifier attached, which can be found in `client_ids` field
     /// under the same index.
-    pub clocks: *mut c_int,
+    pub clocks: *mut u32,
 }
 
 impl YStateVector {
     unsafe fn new(sv: &StateVector) -> Self {
-        let entries_count = sv.len() as c_int;
+        let entries_count = sv.len() as u32;
         let mut client_ids = Vec::with_capacity(sv.len());
         let mut clocks = Vec::with_capacity(sv.len());
         for (&client, &clock) in sv.iter() {
-            client_ids.push(client as c_longlong);
-            clocks.push(clock as c_int);
+            client_ids.push(client as u64);
+            clocks.push(clock as u32);
         }
 
         YStateVector {
@@ -3511,11 +3502,11 @@ impl Drop for YStateVector {
 #[repr(C)]
 pub struct YDeleteSet {
     /// Number of client identifier entries.
-    pub entries_count: c_int,
+    pub entries_count: u32,
     /// Array of unique client identifiers (length is given in `entries_count` field). Each client
     /// ID has corresponding sequence of ranges attached, which can be found in `ranges` field under
     /// the same index.
-    pub client_ids: *mut c_longlong,
+    pub client_ids: *mut u64,
     /// Array of range sequences (length is given in `entries_count` field). Each sequence has
     /// a corresponding client ID attached, which can be found in `client_ids` field under
     /// the same index.
@@ -3529,22 +3520,22 @@ impl YDeleteSet {
         let mut ranges = Vec::with_capacity(len);
 
         for (&client, range) in ds.iter() {
-            client_ids.push(client as c_longlong);
+            client_ids.push(client);
             let seq: Vec<_> = range
                 .iter()
                 .map(|r| YIdRange {
-                    start: r.start as c_int,
-                    end: r.end as c_int,
+                    start: r.start as u32,
+                    end: r.end as u32,
                 })
                 .collect();
             ranges.push(YIdRangeSeq {
-                len: seq.len() as c_int,
+                len: seq.len() as u32,
                 seq: Box::into_raw(seq.into_boxed_slice()) as *mut _,
             })
         }
 
         YDeleteSet {
-            entries_count: len as c_int,
+            entries_count: len as u32,
             client_ids: Box::into_raw(client_ids.into_boxed_slice()) as *mut _,
             ranges: Box::into_raw(ranges.into_boxed_slice()) as *mut _,
         }
@@ -3564,7 +3555,7 @@ impl Drop for YDeleteSet {
 #[repr(C)]
 pub struct YIdRangeSeq {
     /// Number of ranges stored in this sequence.
-    pub len: c_int,
+    pub len: u32,
     /// Array (length is stored in `len` field) or ranges. Each range is a pair of [start, end)
     /// values, describing continuous collection of items produced by the same client, identified
     /// by clock values, that this range refers to.
@@ -3580,8 +3571,8 @@ impl Drop for YIdRangeSeq {
 
 #[repr(C)]
 pub struct YIdRange {
-    pub start: c_int,
-    pub end: c_int,
+    pub start: u32,
+    pub end: u32,
 }
 
 #[repr(C)]
@@ -3810,7 +3801,7 @@ impl Deref for YXmlTextEvent {
 /// Releases a callback subscribed via `ytext_observe` function represented by passed
 /// observer parameter.
 #[no_mangle]
-pub unsafe extern "C" fn ytext_unobserve(txt: *const Branch, subscription_id: c_uint) {
+pub unsafe extern "C" fn ytext_unobserve(txt: *const Branch, subscription_id: u32) {
     let txt = TextRef::from_raw_branch(txt);
     txt.unobserve(subscription_id as SubscriptionId);
 }
@@ -3818,7 +3809,7 @@ pub unsafe extern "C" fn ytext_unobserve(txt: *const Branch, subscription_id: c_
 /// Releases a callback subscribed via `yarray_observe` function represented by passed
 /// observer parameter.
 #[no_mangle]
-pub unsafe extern "C" fn yarray_unobserve(array: *const Branch, subscription_id: c_uint) {
+pub unsafe extern "C" fn yarray_unobserve(array: *const Branch, subscription_id: u32) {
     let txt = ArrayRef::from_raw_branch(array);
     txt.unobserve(subscription_id as SubscriptionId);
 }
@@ -3826,7 +3817,7 @@ pub unsafe extern "C" fn yarray_unobserve(array: *const Branch, subscription_id:
 /// Releases a callback subscribed via `ymap_observe` function represented by passed
 /// observer parameter.
 #[no_mangle]
-pub unsafe extern "C" fn ymap_unobserve(map: *const Branch, subscription_id: c_uint) {
+pub unsafe extern "C" fn ymap_unobserve(map: *const Branch, subscription_id: u32) {
     let map = MapRef::from_raw_branch(map);
     map.unobserve(subscription_id as SubscriptionId);
 }
@@ -3834,7 +3825,7 @@ pub unsafe extern "C" fn ymap_unobserve(map: *const Branch, subscription_id: c_u
 /// Releases a callback subscribed via `yxmlelem_observe` function represented by passed
 /// observer parameter.
 #[no_mangle]
-pub unsafe extern "C" fn yxmlelem_unobserve(xml: *const Branch, subscription_id: c_uint) {
+pub unsafe extern "C" fn yxmlelem_unobserve(xml: *const Branch, subscription_id: u32) {
     let xml = XmlElementRef::from_raw_branch(xml);
     xml.unobserve(subscription_id as SubscriptionId);
 }
@@ -3842,7 +3833,7 @@ pub unsafe extern "C" fn yxmlelem_unobserve(xml: *const Branch, subscription_id:
 /// Releases a callback subscribed via `yxmltext_observe` function represented by passed
 /// observer parameter.
 #[no_mangle]
-pub unsafe extern "C" fn yxmltext_unobserve(xml: *const Branch, subscription_id: c_uint) {
+pub unsafe extern "C" fn yxmltext_unobserve(xml: *const Branch, subscription_id: u32) {
     let xml = XmlTextRef::from_raw_branch(xml);
     xml.unobserve(subscription_id as SubscriptionId);
 }
@@ -3850,7 +3841,7 @@ pub unsafe extern "C" fn yxmltext_unobserve(xml: *const Branch, subscription_id:
 /// Releases a callback subscribed via `yobserve_deep` function represented by passed
 /// observer parameter.
 #[no_mangle]
-pub unsafe extern "C" fn yunobserve_deep(ytype: *mut Branch, subscription_id: c_uint) {
+pub unsafe extern "C" fn yunobserve_deep(ytype: *mut Branch, subscription_id: u32) {
     assert!(!ytype.is_null());
     let branch = ytype.as_mut().unwrap();
     branch.unobserve_deep(subscription_id as SubscriptionId);
@@ -3905,13 +3896,13 @@ pub unsafe extern "C" fn yxmltext_event_target(e: *const YXmlTextEvent) -> *mut 
 #[no_mangle]
 pub unsafe extern "C" fn ytext_event_path(
     e: *const YTextEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YPathSegment {
     assert!(!e.is_null());
     let e = &*e;
     let path: Vec<_> = e.path().into_iter().map(YPathSegment::from).collect();
     let out = path.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -3922,15 +3913,12 @@ pub unsafe extern "C" fn ytext_event_path(
 ///
 /// Path returned this way should be eventually released using `ypath_destroy`.
 #[no_mangle]
-pub unsafe extern "C" fn ymap_event_path(
-    e: *const YMapEvent,
-    len: *mut c_int,
-) -> *mut YPathSegment {
+pub unsafe extern "C" fn ymap_event_path(e: *const YMapEvent, len: *mut u32) -> *mut YPathSegment {
     assert!(!e.is_null());
     let e = &*e;
     let path: Vec<_> = e.path().into_iter().map(YPathSegment::from).collect();
     let out = path.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -3943,13 +3931,13 @@ pub unsafe extern "C" fn ymap_event_path(
 #[no_mangle]
 pub unsafe extern "C" fn yxmlelem_event_path(
     e: *const YXmlEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YPathSegment {
     assert!(!e.is_null());
     let e = &*e;
     let path: Vec<_> = e.path().into_iter().map(YPathSegment::from).collect();
     let out = path.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -3962,13 +3950,13 @@ pub unsafe extern "C" fn yxmlelem_event_path(
 #[no_mangle]
 pub unsafe extern "C" fn yxmltext_event_path(
     e: *const YXmlTextEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YPathSegment {
     assert!(!e.is_null());
     let e = &*e;
     let path: Vec<_> = e.path().into_iter().map(YPathSegment::from).collect();
     let out = path.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -3981,20 +3969,20 @@ pub unsafe extern "C" fn yxmltext_event_path(
 #[no_mangle]
 pub unsafe extern "C" fn yarray_event_path(
     e: *const YArrayEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YPathSegment {
     assert!(!e.is_null());
     let e = &*e;
     let path: Vec<_> = e.path().into_iter().map(YPathSegment::from).collect();
     let out = path.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
 /// Releases allocated memory used by objects returned from path accessor functions of shared type
 /// events.
 #[no_mangle]
-pub unsafe extern "C" fn ypath_destroy(path: *mut YPathSegment, len: c_int) {
+pub unsafe extern "C" fn ypath_destroy(path: *mut YPathSegment, len: u32) {
     if !path.is_null() {
         drop(Vec::from_raw_parts(path, len as usize, len as usize));
     }
@@ -4007,13 +3995,13 @@ pub unsafe extern "C" fn ypath_destroy(path: *mut YPathSegment, len: c_int) {
 /// Delta returned from this function should eventually be released using `yevent_delta_destroy`
 /// function.
 #[no_mangle]
-pub unsafe extern "C" fn ytext_event_delta(e: *const YTextEvent, len: *mut c_int) -> *mut YDelta {
+pub unsafe extern "C" fn ytext_event_delta(e: *const YTextEvent, len: *mut u32) -> *mut YDelta {
     assert!(!e.is_null());
     let e = &*e;
     let delta: Vec<_> = e.delta(e.txn()).into_iter().map(YDelta::from).collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -4026,14 +4014,14 @@ pub unsafe extern "C" fn ytext_event_delta(e: *const YTextEvent, len: *mut c_int
 #[no_mangle]
 pub unsafe extern "C" fn yxmltext_event_delta(
     e: *const YXmlTextEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YDelta {
     assert!(!e.is_null());
     let e = &*e;
     let delta: Vec<_> = e.delta(e.txn()).into_iter().map(YDelta::from).collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -4046,7 +4034,7 @@ pub unsafe extern "C" fn yxmltext_event_delta(
 #[no_mangle]
 pub unsafe extern "C" fn yarray_event_delta(
     e: *const YArrayEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YEventChange {
     assert!(!e.is_null());
     let e = &*e;
@@ -4057,7 +4045,7 @@ pub unsafe extern "C" fn yarray_event_delta(
         .collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -4070,7 +4058,7 @@ pub unsafe extern "C" fn yarray_event_delta(
 #[no_mangle]
 pub unsafe extern "C" fn yxmlelem_event_delta(
     e: *const YXmlEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YEventChange {
     assert!(!e.is_null());
     let e = &*e;
@@ -4081,13 +4069,13 @@ pub unsafe extern "C" fn yxmlelem_event_delta(
         .collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
 /// Releases memory allocated by the object returned from `yevent_delta` function.
 #[no_mangle]
-pub unsafe extern "C" fn ytext_delta_destroy(delta: *mut YDelta, len: c_int) {
+pub unsafe extern "C" fn ytext_delta_destroy(delta: *mut YDelta, len: u32) {
     if !delta.is_null() {
         let delta = Vec::from_raw_parts(delta, len as usize, len as usize);
         drop(delta);
@@ -4096,7 +4084,7 @@ pub unsafe extern "C" fn ytext_delta_destroy(delta: *mut YDelta, len: c_int) {
 
 /// Releases memory allocated by the object returned from `yevent_delta` function.
 #[no_mangle]
-pub unsafe extern "C" fn yevent_delta_destroy(delta: *mut YEventChange, len: c_int) {
+pub unsafe extern "C" fn yevent_delta_destroy(delta: *mut YEventChange, len: u32) {
     if !delta.is_null() {
         let delta = Vec::from_raw_parts(delta, len as usize, len as usize);
         drop(delta);
@@ -4112,7 +4100,7 @@ pub unsafe extern "C" fn yevent_delta_destroy(delta: *mut YEventChange, len: c_i
 #[no_mangle]
 pub unsafe extern "C" fn ymap_event_keys(
     e: *const YMapEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YEventKeyChange {
     assert!(!e.is_null());
     let e = &*e;
@@ -4123,7 +4111,7 @@ pub unsafe extern "C" fn ymap_event_keys(
         .collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -4135,7 +4123,7 @@ pub unsafe extern "C" fn ymap_event_keys(
 #[no_mangle]
 pub unsafe extern "C" fn yxmlelem_event_keys(
     e: *const YXmlEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YEventKeyChange {
     assert!(!e.is_null());
     let e = &*e;
@@ -4146,7 +4134,7 @@ pub unsafe extern "C" fn yxmlelem_event_keys(
         .collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
@@ -4158,7 +4146,7 @@ pub unsafe extern "C" fn yxmlelem_event_keys(
 #[no_mangle]
 pub unsafe extern "C" fn yxmltext_event_keys(
     e: *const YXmlTextEvent,
-    len: *mut c_int,
+    len: *mut u32,
 ) -> *mut YEventKeyChange {
     assert!(!e.is_null());
     let e = &*e;
@@ -4169,14 +4157,14 @@ pub unsafe extern "C" fn yxmltext_event_keys(
         .collect();
 
     let out = delta.into_boxed_slice();
-    *len = out.len() as c_int;
+    *len = out.len() as u32;
     Box::into_raw(out) as *mut _
 }
 
 /// Releases memory allocated by the object returned from `yxml_event_keys` and `ymap_event_keys`
 /// functions.
 #[no_mangle]
-pub unsafe extern "C" fn yevent_keys_destroy(keys: *mut YEventKeyChange, len: c_int) {
+pub unsafe extern "C" fn yevent_keys_destroy(keys: *mut YEventKeyChange, len: u32) {
     if !keys.is_null() {
         drop(Vec::from_raw_parts(keys, len as usize, len as usize));
     }
@@ -4184,7 +4172,7 @@ pub unsafe extern "C" fn yevent_keys_destroy(keys: *mut YEventKeyChange, len: c_
 
 #[repr(C)]
 pub struct YUndoManagerOptions {
-    pub capture_timeout_millis: c_int,
+    pub capture_timeout_millis: u32,
 }
 
 #[no_mangle]
@@ -4214,7 +4202,7 @@ pub unsafe extern "C" fn yundo_manager_destroy(mgr: *mut UndoManager) {
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_add_origin(
     mgr: *mut UndoManager,
-    origin_len: c_int,
+    origin_len: u32,
     origin: *const c_char,
 ) {
     let mgr = mgr.as_mut().unwrap();
@@ -4225,7 +4213,7 @@ pub unsafe extern "C" fn yundo_manager_add_origin(
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_remove_origin(
     mgr: *mut UndoManager,
-    origin_len: c_int,
+    origin_len: u32,
     origin: *const c_char,
 ) {
     let mgr = mgr.as_mut().unwrap();
@@ -4241,7 +4229,7 @@ pub unsafe extern "C" fn yundo_manager_add_scope(mgr: *mut UndoManager, ytype: *
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_clear(mgr: *mut UndoManager) -> c_char {
+pub unsafe extern "C" fn yundo_manager_clear(mgr: *mut UndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     match mgr.clear() {
         Ok(_) => Y_TRUE,
@@ -4256,7 +4244,7 @@ pub unsafe extern "C" fn yundo_manager_stop(mgr: *mut UndoManager) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut UndoManager) -> c_char {
+pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut UndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     match mgr.undo() {
         Ok(_) => Y_TRUE,
@@ -4265,7 +4253,7 @@ pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut UndoManager) -> c_char {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_redo(mgr: *mut UndoManager) -> c_char {
+pub unsafe extern "C" fn yundo_manager_redo(mgr: *mut UndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     match mgr.redo() {
         Ok(_) => Y_TRUE,
@@ -4274,7 +4262,7 @@ pub unsafe extern "C" fn yundo_manager_redo(mgr: *mut UndoManager) -> c_char {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_can_undo(mgr: *mut UndoManager) -> c_char {
+pub unsafe extern "C" fn yundo_manager_can_undo(mgr: *mut UndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     if mgr.can_undo() {
         Y_TRUE
@@ -4284,7 +4272,7 @@ pub unsafe extern "C" fn yundo_manager_can_undo(mgr: *mut UndoManager) -> c_char
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_can_redo(mgr: *mut UndoManager) -> c_char {
+pub unsafe extern "C" fn yundo_manager_can_redo(mgr: *mut UndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     if mgr.can_redo() {
         Y_TRUE
@@ -4298,7 +4286,7 @@ pub unsafe extern "C" fn yundo_manager_observe_added(
     mgr: *mut UndoManager,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YUndoEvent),
-) -> c_uint {
+) -> u32 {
     let mgr = mgr.as_mut().unwrap();
     let subscription_id: SubscriptionId = mgr
         .observe_item_added(move |_, e| {
@@ -4306,13 +4294,13 @@ pub unsafe extern "C" fn yundo_manager_observe_added(
             cb(state, &event as *const YUndoEvent);
         })
         .into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_unobserve_added(
     mgr: *mut UndoManager,
-    subscription_id: c_uint,
+    subscription_id: u32,
 ) {
     let mgr = mgr.as_mut().unwrap();
     mgr.unobserve_item_added(subscription_id as SubscriptionId);
@@ -4323,7 +4311,7 @@ pub unsafe extern "C" fn yundo_manager_observe_popped(
     mgr: *mut UndoManager,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YUndoEvent),
-) -> c_uint {
+) -> u32 {
     let mgr = mgr.as_mut().unwrap();
     let subscription_id: SubscriptionId = mgr
         .observe_item_popped(move |_, e| {
@@ -4331,13 +4319,13 @@ pub unsafe extern "C" fn yundo_manager_observe_popped(
             cb(state, &event as *const YUndoEvent);
         })
         .into();
-    subscription_id as c_uint
+    subscription_id
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_unobserve_popped(
     mgr: *mut UndoManager,
-    subscription_id: c_uint,
+    subscription_id: u32,
 ) {
     let mgr = mgr.as_mut().unwrap();
     mgr.unobserve_item_popped(subscription_id as SubscriptionId);
@@ -4350,7 +4338,7 @@ pub const Y_KIND_REDO: c_char = 1;
 pub struct YUndoEvent {
     pub kind: c_char,
     pub origin: *const c_char,
-    pub origin_len: c_int,
+    pub origin_len: u32,
     pub insertions: YDeleteSet,
     pub deletions: YDeleteSet,
 }
@@ -4359,7 +4347,7 @@ impl YUndoEvent {
     unsafe fn new(e: &yrs::undo::Event) -> Self {
         let (origin, origin_len) = if let Some(origin) = e.origin.as_ref() {
             let bytes = origin.as_ref();
-            let origin_len = bytes.len() as c_int;
+            let origin_len = bytes.len() as u32;
             let origin = bytes.as_ptr() as *const c_char;
             (origin, origin_len)
         } else {
@@ -4441,7 +4429,7 @@ impl From<PathSegment> for YPathSegment {
             PathSegment::Index(index) => YPathSegment {
                 tag: Y_EVENT_PATH_INDEX,
                 value: YPathSegmentCase {
-                    index: index as c_int,
+                    index: index as u32,
                 },
             },
         }
@@ -4461,7 +4449,7 @@ impl Drop for YPathSegment {
 #[repr(C)]
 pub union YPathSegmentCase {
     pub key: *const c_char,
-    pub index: c_int,
+    pub index: u32,
 }
 
 /// Tag used to identify `YEventChange` (see: `yevent_delta` function) case, when a new element
@@ -4506,7 +4494,7 @@ pub struct YEventChange {
 
     /// Number of element affected by current type of a change. It can refer to a number of
     /// inserted `values`, number of deleted element or a number of retained (unchanged) values.  
-    pub len: c_int,
+    pub len: u32,
 
     /// Used in case when current change is of `Y_EVENT_CHANGE_ADD` type. Contains a list (of
     /// length stored in `len` field) of newly inserted values.
@@ -4521,7 +4509,7 @@ impl<'a> From<&'a Change> for YEventChange {
                     .into_iter()
                     .map(|v| YOutput::from(v.clone()))
                     .collect();
-                let len = out.len() as c_int;
+                let len = out.len() as u32;
                 let out = out.into_boxed_slice();
                 let values = Box::into_raw(out) as *mut _;
 
@@ -4533,12 +4521,12 @@ impl<'a> From<&'a Change> for YEventChange {
             }
             Change::Removed(len) => YEventChange {
                 tag: Y_EVENT_CHANGE_DELETE,
-                len: *len as c_int,
+                len: *len as u32,
                 values: null(),
             },
             Change::Retain(len) => YEventChange {
                 tag: Y_EVENT_CHANGE_RETAIN,
-                len: *len as c_int,
+                len: *len as u32,
                 values: null(),
             },
         }
@@ -4590,14 +4578,14 @@ pub struct YDelta {
 
     /// Number of element affected by current type of a change. It can refer to a number of
     /// inserted `values`, number of deleted element or a number of retained (unchanged) values.  
-    pub len: c_int,
+    pub len: u32,
 
     /// Used in case when current change is of `Y_EVENT_CHANGE_ADD` type. Contains a list (of
     /// length stored in `len` field) of newly inserted values.
     pub insert: *mut YOutput,
 
     /// A number of formatting attributes assigned to an edited area represented by this delta.
-    pub attributes_len: c_int,
+    pub attributes_len: u32,
 
     /// A nullable pointer to a list of formatting attributes assigned to an edited area represented
     /// by this delta.
@@ -4608,7 +4596,7 @@ impl YDelta {
     fn insert(value: &Value, attrs: &Option<Box<Attrs>>) -> Self {
         let insert = Box::into_raw(Box::new(YOutput::from(value.clone())));
         let (attributes_len, attributes) = if let Some(attrs) = attrs {
-            let len = attrs.len() as c_int;
+            let len = attrs.len() as u32;
             let attrs: Vec<_> = attrs.iter().map(|(k, v)| YDeltaAttr::new(k, v)).collect();
             let attrs = Box::into_raw(attrs.into_boxed_slice()) as *mut _;
             (len, attrs)
@@ -4627,7 +4615,7 @@ impl YDelta {
 
     fn retain(len: u32, attrs: &Option<Box<Attrs>>) -> Self {
         let (attributes_len, attributes) = if let Some(attrs) = attrs {
-            let len = attrs.len() as c_int;
+            let len = attrs.len() as u32;
             let attrs: Vec<_> = attrs.iter().map(|(k, v)| YDeltaAttr::new(k, v)).collect();
             let attrs = Box::into_raw(attrs.into_boxed_slice()) as *mut _;
             (len, attrs)
@@ -4636,7 +4624,7 @@ impl YDelta {
         };
         YDelta {
             tag: Y_EVENT_CHANGE_RETAIN,
-            len: len as c_int,
+            len: len as u32,
             insert: null_mut(),
             attributes_len,
             attributes,
@@ -4646,7 +4634,7 @@ impl YDelta {
     fn delete(len: u32) -> Self {
         YDelta {
             tag: Y_EVENT_CHANGE_DELETE,
-            len: len as c_int,
+            len: len as u32,
             insert: null_mut(),
             attributes_len: 0,
             attributes: null_mut(),
@@ -4834,7 +4822,7 @@ pub unsafe extern "C" fn yrelative_position_destroy(pos: *mut YRelativePosition)
 /// If association is **after** the referenced inserted character, returned number will be >= 0.
 /// If association is **before** the referenced inserted character, returned number will be < 0.
 #[no_mangle]
-pub unsafe extern "C" fn yrelative_position_assoc(pos: *const YRelativePosition) -> c_int {
+pub unsafe extern "C" fn yrelative_position_assoc(pos: *const YRelativePosition) -> i8 {
     let pos = pos.as_ref().unwrap();
     match pos.0.assoc {
         Assoc::After => 0,
@@ -4852,8 +4840,8 @@ pub unsafe extern "C" fn yrelative_position_assoc(pos: *const YRelativePosition)
 pub unsafe extern "C" fn yrelative_position_from_index(
     branch: *const Branch,
     txn: *mut Transaction,
-    index: c_int,
-    assoc: c_int,
+    index: u32,
+    assoc: i8,
 ) -> *mut YRelativePosition {
     assert!(!branch.is_null());
     assert!(!txn.is_null());
@@ -4883,19 +4871,19 @@ pub unsafe extern "C" fn yrelative_position_from_index(
 #[no_mangle]
 pub unsafe extern "C" fn yrelative_position_encode(
     pos: *const YRelativePosition,
-    len: *mut c_int,
-) -> *mut c_uchar {
+    len: *mut u32,
+) -> *mut c_char {
     let pos = pos.as_ref().unwrap();
     let binary = pos.0.encode_v1().into_boxed_slice();
-    *len = binary.len() as c_int;
-    Box::into_raw(binary) as *mut c_uchar
+    *len = binary.len() as u32;
+    Box::into_raw(binary) as *mut c_char
 }
 
 /// Deserializes `YRelativePosition` from the payload previously serialized using `yrelative_position_encode`.
 #[no_mangle]
 pub unsafe extern "C" fn yrelative_position_decode(
-    binary: *const c_uchar,
-    len: c_int,
+    binary: *const c_char,
+    len: u32,
 ) -> *mut YRelativePosition {
     let slice = std::slice::from_raw_parts(binary as *const u8, len as usize);
     if let Ok(pos) = RelativePosition::decode_v1(slice) {
@@ -4915,14 +4903,14 @@ pub unsafe extern "C" fn yrelative_position_read(
     pos: *const YRelativePosition,
     txn: *const Transaction,
     out_branch: *mut *mut Branch,
-    out_index: *mut c_int,
+    out_index: *mut u32,
 ) {
     let pos = pos.as_ref().unwrap();
     let txn = txn.as_ref().unwrap();
 
     if let Some(abs) = pos.0.absolute(txn) {
         *out_branch = abs.branch.as_ref() as *const Branch as *mut Branch;
-        *out_index = abs.index as c_int;
+        *out_index = abs.index as u32;
     }
 }
 


### PR DESCRIPTION
Related to #246

In general from cross-platform C point of view standard definitions like char, int etc. are not guaranteed to be the same across different platforms. Hence the definitions like `uint8_t`, `uint32_t` etc.

This PR changes libyrs.h header to make use to these universal type definitions.