### PR TITLE
release v0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lib0"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "criterion",
  "proptest",
@@ -1022,7 +1022,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yffi"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "lib0",
  "rand 0.7.3",
@@ -1031,7 +1031,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "atomic_refcell",
  "criterion",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/lib0/Cargo.toml
+++ b/lib0/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "lib0"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 edition = "2018"
 license = "MIT"
-license-file = "../LICENSE"
 description = "Efficient binary encoding library for Yrs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "yffi"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
 license = "MIT"
-license-file = "../LICENSE"
 description = "Bindings for the Yrs native C foreign function interface"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -13,8 +12,8 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.16.0" }
-yrs = { path = "../yrs", version = "0.16.0" }
+lib0 = { path = "../lib0", version = "0.16.1" }
+yrs = { path = "../yrs", version = "0.16.1" }
 rand = "0.7.0"
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 name = "yrs"
-version = "0.16.0"
+version = "0.16.1"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
-license-file = "../LICENSE"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "yrs"]
 edition = "2018"
@@ -14,7 +13,7 @@ readme = "./README.md"
 [dependencies]
 thiserror = "1"
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }
-lib0 = { path = "../lib0", version = "0.16.0" }
+lib0 = { path = "../lib0", version = "0.16.1" }
 smallstr = { version = "0.2", features = ["union"]}
 smallvec = { version = "1.10", features = ["union", "const_generics", "const_new"]}
 atomic_refcell = "0.1"

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -394,9 +394,8 @@
 //!
 //! 1. Observers on updated shared types: [TextRef::observe], [ArrayRef::observe], [MapRef::observe],
 //!    [XmlTextRef::observe], [XmlFragmentRef::observe] and [XmlElementRef::observe].
-//! 2. Deep observers (special kind of observers that are bubbled up from nested shared types through
-//!    their parent collections hierarchy): [TextRef::observe_deep], [ArrayRef::observe_deep], [MapRef::observe_deep],
-//!    [XmlTextRef::observe_deep], [XmlFragmentRef::observe_deep] and [XmlElementRef::observe_deep].
+//! 2. [Deep observers](DeepObservable::observe_deep) (special kind of observers that are bubbled up
+//!    from nested shared types through their parent collections hierarchy).
 //! 3. After transaction callbacks: [Doc::observe_after_transaction].
 //! 4. After transaction cleanup callbacks (moment after all changes performed by transaction have
 //!    been compressed an integrated into document store): [Doc::observe_transaction_cleanup].

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "ywasm"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
 license = "MIT"
-license-file = "../LICENSE"
 description = "High performance implementation of the Yjs CRDT"
 homepage = "https://github.com/yjs/y-crdt/"
 repository = "https://github.com/yjs/y-crdt/"
@@ -18,8 +17,8 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-lib0 = { path = "../lib0", version = "0.16.0" }
-yrs = { path = "../yrs", version = "0.16.0" }
+lib0 = { path = "../lib0", version = "0.16.1" }
+yrs = { path = "../yrs", version = "0.16.1" }
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
- Fixed #253 : infinite loop in `Doc::to_json` when sub-documents are present
- Fixed #254 : lib0 v2 encoding of JSON-like structures (visible in formatting attributes decoding)