### PR TITLE
Add a documentation note defining lib0::Any

### DIFF
--- a/lib0/src/any.rs
+++ b/lib0/src/any.rs
@@ -5,6 +5,8 @@ use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::convert::TryInto;
 
+/// Any is an enum with a potentially associated value that is used to represent JSON values 
+/// and supports efficient encoding of those values.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Any {
     Null,


### PR DESCRIPTION
While I was digging around in the existing language bindings, I back-tracked to Any (since it features prominently) - and thought it might be helpful to have a small bit of detail in the docs about what it represents.