### PR TITLE
add Result for Encode trait

### DIFF
--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -850,7 +850,10 @@ pub unsafe extern "C" fn ytransaction_state_vector_v1(
 
     let txn = txn.as_ref().unwrap();
     let state_vector = txn.state_vector();
-    let binary = state_vector.encode_v1().into_boxed_slice();
+    let binary = state_vector
+        .encode_v1()
+        .expect("failed to encode state vector using lib0 v1 encoding")
+        .into_boxed_slice();
 
     *len = binary.len() as u32;
     Box::into_raw(binary) as *mut c_char
@@ -894,7 +897,8 @@ pub unsafe extern "C" fn ytransaction_state_diff_v1(
     };
 
     let mut encoder = EncoderV1::new();
-    txn.encode_diff(&sv, &mut encoder);
+    txn.encode_diff(&sv, &mut encoder)
+        .expect("failed to encode transaction diff using lib0 v1 encoding");
     let binary = encoder.to_vec().into_boxed_slice();
     *len = binary.len() as u32;
     Box::into_raw(binary) as *mut c_char
@@ -938,7 +942,8 @@ pub unsafe extern "C" fn ytransaction_state_diff_v2(
     };
 
     let mut encoder = EncoderV2::new();
-    txn.encode_diff(&sv, &mut encoder);
+    txn.encode_diff(&sv, &mut encoder)
+        .expect("failed to encode diff using lib0 v2 encoding");
     let binary = encoder.to_vec().into_boxed_slice();
     *len = binary.len() as u32;
     Box::into_raw(binary) as *mut c_char
@@ -954,7 +959,11 @@ pub unsafe extern "C" fn ytransaction_snapshot(
 ) -> *mut c_char {
     assert!(!txn.is_null());
     let txn = txn.as_ref().unwrap();
-    let binary = txn.snapshot().encode_v1().into_boxed_slice();
+    let binary = txn
+        .snapshot()
+        .encode_v1()
+        .expect("failed to encode snapshot using lib0 v1 encoding")
+        .into_boxed_slice();
 
     *len = binary.len() as u32;
     Box::into_raw(binary) as *mut c_char
@@ -4949,7 +4958,13 @@ pub unsafe extern "C" fn ysticky_index_encode(
     len: *mut u32,
 ) -> *mut c_char {
     let pos = pos.as_ref().unwrap();
-    let binary = pos.0.encode_v1().into_boxed_slice();
+    let binary = pos
+        .0
+        .encode_v1()
+        .expect(
+            "YStickyIndex::encode_v1 failed. This is a bug, please report it to the developers.",
+        )
+        .into_boxed_slice();
     *len = binary.len() as u32;
     Box::into_raw(binary) as *mut c_char
 }

--- a/yrs/benches/benches.rs
+++ b/yrs/benches/benches.rs
@@ -241,11 +241,11 @@ where
                 for (o1, o2) in ops {
                     let mut txn1 = d1.transact_mut();
                     apply(&mut txn1, t1, o1);
-                    let u1 = txn1.encode_update_v1();
+                    let u1 = txn1.encode_update_v1().unwrap();
 
                     let mut txn2 = d2.transact_mut();
                     apply(&mut txn2, t2, o2);
-                    let u2 = txn2.encode_update_v1();
+                    let u2 = txn2.encode_update_v1().unwrap();
 
                     txn1.apply_update(Update::decode_v1(u2.as_slice()).unwrap());
                     txn2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
@@ -344,7 +344,7 @@ where
             let update = {
                 let mut txn = doc.transact_mut();
                 f(&map, &mut txn, i);
-                txn.encode_update_v1()
+                txn.encode_update_v1().unwrap()
             };
             (doc, update)
         })
@@ -391,7 +391,7 @@ fn b3_4(c: &mut Criterion, name: &str) {
             let update = {
                 let mut txn = doc.transact_mut();
                 array.insert(&mut txn, 0, i.to_string());
-                txn.encode_update_v1()
+                txn.encode_update_v1().unwrap()
             };
             (doc, update)
         })

--- a/yrs/src/alt.rs
+++ b/yrs/src/alt.rs
@@ -19,7 +19,7 @@ pub fn merge_updates_v1(updates: &[&[u8]]) -> Result<Vec<u8>, Error> {
         let parsed = Update::decode_v1(buf)?;
         merge.push(parsed);
     }
-    Ok(Update::merge_updates(merge).encode_v1())
+    Ok(Update::merge_updates(merge).encode_v1()?)
 }
 
 /// Merges a sequence of updates (encoded using lib0 v2 encoding) together, producing another
@@ -33,7 +33,7 @@ pub fn merge_updates_v2(updates: &[&[u8]]) -> Result<Vec<u8>, Error> {
         let update = Update::decode_v2(buf)?;
         merge.push(update);
     }
-    Ok(Update::merge_updates(merge).encode_v2())
+    Ok(Update::merge_updates(merge).encode_v2()?)
 }
 
 /// Decodes a input `update` (encoded using lib0 v1 encoding) and returns an encoded [StateVector]
@@ -42,7 +42,7 @@ pub fn merge_updates_v2(updates: &[&[u8]]) -> Result<Vec<u8>, Error> {
 /// Returns an error whenever any of the input update couldn't be decoded.
 pub fn encode_state_vector_from_update_v1(update: &[u8]) -> Result<Vec<u8>, Error> {
     let update = Update::decode_v1(update)?;
-    Ok(update.state_vector().encode_v1())
+    Ok(update.state_vector().encode_v1()?)
 }
 
 /// Decodes a input `update` (encoded using lib0 v2 encoding) and returns an encoded [StateVector]
@@ -51,7 +51,7 @@ pub fn encode_state_vector_from_update_v1(update: &[u8]) -> Result<Vec<u8>, Erro
 /// Returns an error whenever any of the input update couldn't be decoded.
 pub fn encode_state_vector_from_update_v2(update: &[u8]) -> Result<Vec<u8>, Error> {
     let update = Update::decode_v2(update)?;
-    Ok(update.state_vector().encode_v2())
+    Ok(update.state_vector().encode_v2()?)
 }
 
 /// Givens an input `update` (encoded using lib0 v1 encoding) of document **A** and an encoded
@@ -63,7 +63,7 @@ pub fn diff_updates_v1(update: &[u8], state_vector: &[u8]) -> Result<Vec<u8>, Er
     let sv = StateVector::decode_v1(state_vector)?;
     let update = Update::decode_v1(update)?;
     let mut encoder = EncoderV1::new();
-    update.encode_diff(&sv, &mut encoder);
+    update.encode_diff(&sv, &mut encoder)?;
     // for delete set, don't decode/encode it - just copy the remaining part from the decoder
     let result = encoder.to_vec();
     Ok(result)
@@ -80,7 +80,7 @@ pub fn diff_updates_v2(update: &[u8], state_vector: &[u8]) -> Result<Vec<u8>, Er
     let mut decoder = DecoderV2::new(cursor)?;
     let update = Update::decode(&mut decoder)?;
     let mut encoder = EncoderV2::new();
-    update.encode_diff(&sv, &mut encoder);
+    update.encode_diff(&sv, &mut encoder)?;
     // for delete set, don't decode/encode it - just copy the remaining part from the decoder
     Ok(encoder.to_vec())
 }

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -131,12 +131,14 @@ impl Decode for StateVector {
 }
 
 impl Encode for StateVector {
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), Error> {
         encoder.write_var(self.len());
         for (&client, &clock) in self.iter() {
             encoder.write_var(client);
             encoder.write_var(clock);
         }
+
+        Ok(())
     }
 }
 
@@ -165,8 +167,8 @@ impl Snapshot {
 }
 
 impl Encode for Snapshot {
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
-        self.delete_set.encode(encoder);
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), Error> {
+        self.delete_set.encode(encoder)?;
         self.state_map.encode(encoder)
     }
 }

--- a/yrs/src/compatibility_tests.rs
+++ b/yrs/src/compatibility_tests.rs
@@ -302,7 +302,7 @@ fn state_vector() {
     let sv = StateVector::decode_v1(payload).unwrap();
     assert_eq!(sv, expected);
 
-    let serialized = sv.encode_v1();
+    let serialized = sv.encode_v1().unwrap();
     assert_eq!(serialized.as_slice(), payload);
 }
 
@@ -363,7 +363,7 @@ fn roundtrip_v1(payload: &[u8], expected: &Vec<BlockCarrier>) {
     assert_eq!(blocks, expected, "failed to decode V1");
 
     let store: Store = u.into();
-    let serialized = store.encode_v1();
+    let serialized = store.encode_v1().unwrap();
     assert_eq!(serialized, payload, "failed to encode V1");
 }
 
@@ -375,7 +375,7 @@ fn roundtrip_v2(payload: &[u8], expected: &Vec<BlockCarrier>) {
     assert_eq!(blocks, expected, "failed to decode V2");
 
     let store: Store = u.into();
-    let serialized = store.encode_v2();
+    let serialized = store.encode_v2().unwrap();
     assert_eq!(serialized, payload, "failed to encode V2");
 }
 
@@ -400,7 +400,9 @@ fn negative_zero_decoding_v2() {
     root.insert(&mut txn, "characters", ArrayPrelim::<_, Any>::from([]));
     let expected = root.to_json(&txn);
 
-    let buffer = txn.encode_state_as_update_v2(&StateVector::default());
+    let buffer = txn
+        .encode_state_as_update_v2(&StateVector::default())
+        .unwrap();
 
     let u = Update::decode_v2(&buffer).unwrap();
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -48,7 +48,7 @@ use thiserror::Error;
 /// // in order to exchange data with other documents we first need to create a state vector
 /// let remote_doc = Doc::new();
 /// let mut remote_txn = remote_doc.transact_mut();
-/// let state_vector = remote_txn.state_vector().encode_v1();
+/// let state_vector = remote_txn.state_vector().encode_v1().unwrap();
 ///
 /// // now compute a differential update based on remote document's state vector
 /// let update = txn.encode_diff_v1(&StateVector::decode_v1(&state_vector).unwrap()).unwrap();

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -51,7 +51,7 @@ use thiserror::Error;
 /// let state_vector = remote_txn.state_vector().encode_v1();
 ///
 /// // now compute a differential update based on remote document's state vector
-/// let update = txn.encode_diff_v1(&StateVector::decode_v1(&state_vector).unwrap());
+/// let update = txn.encode_diff_v1(&StateVector::decode_v1(&state_vector).unwrap()).unwrap();
 ///
 /// // both update and state vector are serializable, we can pass the over the wire
 /// // now apply update to a remote document
@@ -626,10 +626,11 @@ impl Default for Options {
 }
 
 impl Encode for Options {
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), Error> {
         let guid = self.guid.to_string();
         encoder.write_string(&guid);
-        encoder.write_any(&self.as_any())
+        encoder.write_any(&self.as_any());
+        Ok(())
     }
 }
 
@@ -968,7 +969,9 @@ mod test {
         txt.insert(&mut t, 0, "1");
         txt.insert(&mut t, 0, "2");
 
-        let encoded = t.encode_state_as_update_v1(&StateVector::default());
+        let encoded = t
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         let expected = &[
             1, 3, 227, 214, 245, 198, 5, 0, 4, 1, 4, 116, 121, 112, 101, 1, 48, 68, 227, 214, 245,
             198, 5, 0, 1, 49, 68, 227, 214, 245, 198, 5, 1, 1, 50, 0,
@@ -994,14 +997,15 @@ mod test {
         let d2 = Doc::new();
         let txt = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
-        let sv = t2.state_vector().encode_v1();
+        let sv = t2.state_vector().encode_v1().unwrap();
 
         // create an update A->B based on B's state vector
         let mut encoder = EncoderV1::new();
         t1.encode_diff(
             &StateVector::decode_v1(sv.as_slice()).unwrap(),
             &mut encoder,
-        );
+        )
+        .unwrap();
         let binary = encoder.to_vec();
 
         // decode an update incoming from A and integrate it at B
@@ -1032,8 +1036,10 @@ mod test {
         {
             txt.insert(&mut txn, 0, "abc");
             let mut txn2 = doc2.transact_mut();
-            let sv = txn2.state_vector().encode_v1();
-            let u = txn.encode_diff_v1(&StateVector::decode_v1(sv.as_slice()).unwrap());
+            let sv = txn2.state_vector().encode_v1().unwrap();
+            let u = txn
+                .encode_diff_v1(&StateVector::decode_v1(sv.as_slice()).unwrap())
+                .unwrap();
             txn2.apply_update(Update::decode_v1(u.as_slice()).unwrap());
         }
         assert_eq!(counter.get(), 3); // update has been propagated
@@ -1043,8 +1049,10 @@ mod test {
         {
             txt.insert(&mut txn, 3, "de");
             let mut txn2 = doc2.transact_mut();
-            let sv = txn2.state_vector().encode_v1();
-            let u = txn.encode_diff_v1(&StateVector::decode_v1(sv.as_slice()).unwrap());
+            let sv = txn2.state_vector().encode_v1().unwrap();
+            let u = txn
+                .encode_diff_v1(&StateVector::decode_v1(sv.as_slice()).unwrap())
+                .unwrap();
             txn2.apply_update(Update::decode_v1(u.as_slice()).unwrap());
         }
         assert_eq!(counter.get(), 3); // since subscription has been dropped, update was not propagated
@@ -1139,10 +1147,11 @@ mod test {
 
         let d2 = Doc::new();
         let source_2 = d2.get_or_insert_text("source");
-        let state_2 = d2.transact().state_vector().encode_v1();
+        let state_2 = d2.transact().state_vector().encode_v1().unwrap();
         let update = d1
             .transact()
-            .encode_state_as_update_v1(&StateVector::decode_v1(&state_2).unwrap());
+            .encode_state_as_update_v1(&StateVector::decode_v1(&state_2).unwrap())
+            .unwrap();
         let update = Update::decode_v1(&update).unwrap();
         d2.transact_mut().apply_update(update);
 
@@ -1158,9 +1167,9 @@ mod test {
 
         let d3 = Doc::new();
         let source_3 = d3.get_or_insert_text("source");
-        let state_3 = d3.transact().state_vector().encode_v1();
+        let state_3 = d3.transact().state_vector().encode_v1().unwrap();
         let state_3 = StateVector::decode_v1(&state_3).unwrap();
-        let update = d1.transact().encode_state_as_update_v1(&state_3);
+        let update = d1.transact().encode_state_as_update_v1(&state_3).unwrap();
         let update = Update::decode_v1(&update).unwrap();
         d3.transact_mut().apply_update(update);
 
@@ -1219,7 +1228,8 @@ mod test {
         txt1.insert(&mut d1.transact_mut(), 0, "hello");
         let u = d1
             .transact()
-            .encode_state_as_update_v1(&StateVector::default());
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         let d2 = Doc::with_client_id(2);
         let txt2 = d2.get_or_insert_text("text");
@@ -1229,7 +1239,8 @@ mod test {
         txt1.insert(&mut d1.transact_mut(), 5, "world");
         let u = d1
             .transact()
-            .encode_state_as_update_v1(&StateVector::default());
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         d2.transact_mut()
             .apply_update(Update::decode_v1(&u).unwrap());
 
@@ -1607,7 +1618,7 @@ mod test {
             let mut t2 = d2.transact_mut();
             root.remove(&mut t2, 0);
             d1.transact_mut()
-                .apply_update(Update::decode_v1(&t2.encode_update_v1()).unwrap());
+                .apply_update(Update::decode_v1(&t2.encode_update_v1().unwrap()).unwrap());
         }
 
         {
@@ -1617,7 +1628,7 @@ mod test {
             a3.push_back(&mut t3, "B");
             // D1 got update which already removed a3, but this must not cause panic
             d1.transact_mut()
-                .apply_update(Update::decode_v1(&t3.encode_update_v1()).unwrap());
+                .apply_update(Update::decode_v1(&t3.encode_update_v1().unwrap()).unwrap());
         }
 
         exchange_updates(&[&d1, &d2, &d3]);
@@ -1728,7 +1739,8 @@ mod test {
 
         let data = doc
             .transact()
-            .encode_state_as_update_v1(&StateVector::default());
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         let doc2 = Doc::new();
         let event = Rc::new(Cell::new(None));
@@ -1835,7 +1847,8 @@ mod test {
         });
         let u = Update::decode_v1(
             &doc.transact()
-                .encode_state_as_update_v1(&StateVector::default()),
+                .encode_state_as_update_v1(&StateVector::default())
+                .unwrap(),
         );
         doc2.transact_mut().apply_update(u.unwrap());
         let doc_ref_3 = {
@@ -1918,7 +1931,8 @@ mod test {
         });
         let u = Update::decode_v1(
             &doc.transact()
-                .encode_state_as_update_v1(&StateVector::default()),
+                .encode_state_as_update_v1(&StateVector::default())
+                .unwrap(),
         );
         doc2.transact_mut().apply_update(u.unwrap());
         let subdoc_3 = {

--- a/yrs/src/event.rs
+++ b/yrs/src/event.rs
@@ -1,6 +1,7 @@
 use crate::doc::DocAddr;
 use crate::transaction::Subdocs;
 use crate::{DeleteSet, Doc, StateVector, TransactionMut};
+use lib0::error::Error;
 use std::collections::HashMap;
 
 /// An update event passed to a callback subscribed with [Doc::observe_update_v1]/[Doc::observe_update_v2].
@@ -11,15 +12,15 @@ pub struct UpdateEvent {
 }
 
 impl UpdateEvent {
-    pub(crate) fn new_v1(txn: &TransactionMut) -> Self {
-        UpdateEvent {
-            update: txn.encode_update_v1(),
-        }
+    pub(crate) fn new_v1(txn: &TransactionMut) -> Result<Self, Error> {
+        Ok(UpdateEvent {
+            update: txn.encode_update_v1()?,
+        })
     }
-    pub(crate) fn new_v2(txn: &TransactionMut) -> Self {
-        UpdateEvent {
-            update: txn.encode_update_v2(),
-        }
+    pub(crate) fn new_v2(txn: &TransactionMut) -> Result<Self, Error> {
+        Ok(UpdateEvent {
+            update: txn.encode_update_v2()?,
+        })
     }
 }
 

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -38,7 +38,7 @@
 //! let remote_timestamp = remote_doc.transact().state_vector().encode_v1();
 //!
 //! // get update with contents not observed by remote_doc
-//! let update = doc.transact().encode_diff_v1(&StateVector::decode_v1(&remote_timestamp).unwrap());
+//! let update = doc.transact().encode_diff_v1(&StateVector::decode_v1(&remote_timestamp).unwrap()).unwrap();
 //! // apply update on remote doc
 //! remote_doc.transact_mut().apply_update(Update::decode_v1(&update).unwrap());
 //!

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -35,7 +35,7 @@
 //! // synchronize state with remote replica
 //! let remote_doc = Doc::new();
 //! let remote_text = remote_doc.get_or_insert_text("article");
-//! let remote_timestamp = remote_doc.transact().state_vector().encode_v1();
+//! let remote_timestamp = remote_doc.transact().state_vector().encode_v1().unwrap();
 //!
 //! // get update with contents not observed by remote_doc
 //! let update = doc.transact().encode_diff_v1(&StateVector::decode_v1(&remote_timestamp).unwrap()).unwrap();
@@ -171,7 +171,7 @@
 //! assert_eq!(str.chars().nth(INDEX), Some('o'));
 //!
 //! // synchronize full state of doc1 -> doc2
-//! txn2.apply_update(Update::decode_v1(&txn1.encode_diff_v1(&StateVector::default())).unwrap());
+//! txn2.apply_update(Update::decode_v1(&txn1.encode_diff_v1(&StateVector::default()).unwrap()).unwrap());
 //!
 //! // Doc 2: cursor at index 1 no longer points to the same character
 //! let str = text2.get_string(&txn2);
@@ -209,7 +209,7 @@
 //! let pos = text2.sticky_index(&mut txn2, INDEX as u32, Assoc::After).unwrap();
 //!
 //! // synchronize full state of doc1 -> doc2
-//! txn2.apply_update(Update::decode_v1(&txn1.encode_diff_v1(&StateVector::default())).unwrap());
+//! txn2.apply_update(Update::decode_v1(&txn1.encode_diff_v1(&StateVector::default()).unwrap()).unwrap());
 //!
 //! // restore the index from position saved previously
 //! let idx = pos.get_offset(&txn2).unwrap();
@@ -255,7 +255,7 @@
 //! }
 //!
 //! // sync changes from remote to local
-//! let update = remote.transact().encode_state_as_update_v1(&local.transact().state_vector());
+//! let update = remote.transact().encode_state_as_update_v1(&local.transact().state_vector()).unwrap();
 //! local.transact_mut().apply_update(Update::decode_v1(&update).unwrap());
 //! assert_eq!(text1.get_string(&local.transact()), "hello worldeveryone"); // remote changes synced
 //!

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -22,8 +22,10 @@ pub fn exchange_updates(docs: &[&Doc]) {
                 let b = docs[j];
                 let mut tb = b.transact_mut_with(EXCHANGE_UPDATES_ORIGIN);
 
-                let sv = tb.state_vector().encode_v1();
-                let update = ta.encode_diff_v1(&StateVector::decode_v1(sv.as_slice()).unwrap());
+                let sv = tb.state_vector().encode_v1().unwrap();
+                let update = ta
+                    .encode_diff_v1(&StateVector::decode_v1(sv.as_slice()).unwrap())
+                    .unwrap();
                 tb.apply_update(Update::decode_v1(update.as_slice()).unwrap());
             }
         }
@@ -399,7 +401,7 @@ impl TestConnector {
         let txn = peer.doc.transact_mut();
 
         encoder.write_var(MSG_SYNC_STEP_1);
-        encoder.write_buf(txn.state_vector().encode_v1());
+        encoder.write_buf(txn.state_vector().encode_v1().unwrap());
     }
 
     fn write_step2<E: Encoder>(peer: &TestPeer, sv: &[u8], encoder: &mut E) {
@@ -407,7 +409,7 @@ impl TestConnector {
         let remote_sv = StateVector::decode_v1(sv).unwrap();
 
         encoder.write_var(MSG_SYNC_STEP_2);
-        encoder.write_buf(txn.encode_diff_v1(&remote_sv));
+        encoder.write_buf(txn.encode_diff_v1(&remote_sv).unwrap());
     }
 
     pub fn assert_final_state(mut self) {

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -580,7 +580,8 @@ mod test {
         a1.insert(&mut d1.transact_mut(), 0, "Hi");
         let update = d1
             .transact()
-            .encode_state_as_update_v1(&StateVector::default());
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         let a2 = d2.get_or_insert_array("array");
         let mut t2 = d2.transact_mut();
@@ -983,7 +984,7 @@ mod test {
 
             let sv = t2.state_vector();
             let mut encoder = EncoderV1::new();
-            t1.encode_diff(&sv, &mut encoder);
+            t1.encode_diff(&sv, &mut encoder).unwrap();
             t2.apply_update(Update::decode_v1(encoder.to_vec().as_slice()).unwrap());
         }
 

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -496,7 +496,9 @@ mod test {
 
         compare_all(&m1, &t1);
 
-        let update = t1.encode_state_as_update_v1(&StateVector::default());
+        let update = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         t2.apply_update(Update::decode_v1(update.as_slice()).unwrap());
 
         compare_all(&m2, &t2);
@@ -511,7 +513,9 @@ mod test {
         m1.insert(&mut t1, "stuff".to_owned(), "stuffy");
         m1.insert(&mut t1, "null".to_owned(), None as Option<String>);
 
-        let update = t1.encode_state_as_update_v1(&StateVector::default());
+        let update = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         let d2 = Doc::with_client_id(2);
         let m2 = d2.get_or_insert_map("map");
@@ -539,8 +543,12 @@ mod test {
         m1.insert(&mut t1, "stuff".to_owned(), "c0");
         m2.insert(&mut t2, "stuff".to_owned(), "c1");
 
-        let u1 = t1.encode_state_as_update_v1(&StateVector::default());
-        let u2 = t2.encode_state_as_update_v1(&StateVector::default());
+        let u1 = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
+        let u2 = t2
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         t1.apply_update(Update::decode_v1(u2.as_slice()).unwrap());
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
@@ -593,7 +601,9 @@ mod test {
         let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
-        let u1 = t1.encode_state_as_update_v1(&StateVector::default());
+        let u1 = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
 
         assert_eq!(m2.len(&t2), 0);
@@ -863,7 +873,7 @@ mod test {
 
             let sv = t2.state_vector();
             let mut encoder = EncoderV1::new();
-            t1.encode_diff(&sv, &mut encoder);
+            t1.encode_diff(&sv, &mut encoder).unwrap();
             t2.apply_update(Update::decode_v1(encoder.to_vec().as_slice()).unwrap());
         }
         assert_eq!(

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1410,11 +1410,15 @@ mod test {
 
         txt2.insert(&mut t2, 0, "world");
 
-        let d1_sv = t1.state_vector().encode_v1();
-        let d2_sv = t2.state_vector().encode_v1();
+        let d1_sv = t1.state_vector().encode_v1().unwrap();
+        let d2_sv = t2.state_vector().encode_v1().unwrap();
 
-        let u1 = t1.encode_diff_v1(&StateVector::decode_v1(&d2_sv).unwrap());
-        let u2 = t2.encode_diff_v1(&StateVector::decode_v1(&d1_sv).unwrap());
+        let u1 = t1
+            .encode_diff_v1(&StateVector::decode_v1(&d2_sv).unwrap())
+            .unwrap();
+        let u2 = t2
+            .encode_diff_v1(&StateVector::decode_v1(&d1_sv).unwrap())
+            .unwrap();
 
         t1.apply_update(Update::decode_v1(u2.as_slice()).unwrap());
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
@@ -1439,8 +1443,10 @@ mod test {
         let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
 
-        let d2_sv = t2.state_vector().encode_v1();
-        let u1 = t1.encode_diff_v1(&StateVector::decode_v1(&d2_sv).unwrap());
+        let d2_sv = t2.state_vector().encode_v1().unwrap();
+        let u1 = t1
+            .encode_diff_v1(&StateVector::decode_v1(&d2_sv).unwrap())
+            .unwrap();
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
 
         assert_eq!(txt2.get_string(&t2).as_str(), "I expect that");
@@ -1452,10 +1458,14 @@ mod test {
         txt1.insert(&mut t1, 1, " didn't");
         assert_eq!(txt1.get_string(&t1).as_str(), "I didn't expect that");
 
-        let d2_sv = t2.state_vector().encode_v1();
-        let d1_sv = t1.state_vector().encode_v1();
-        let u1 = t1.encode_diff_v1(&StateVector::decode_v1(&d2_sv.as_slice()).unwrap());
-        let u2 = t2.encode_diff_v1(&StateVector::decode_v1(&d1_sv.as_slice()).unwrap());
+        let d2_sv = t2.state_vector().encode_v1().unwrap();
+        let d1_sv = t1.state_vector().encode_v1().unwrap();
+        let u1 = t1
+            .encode_diff_v1(&StateVector::decode_v1(&d2_sv.as_slice()).unwrap())
+            .unwrap();
+        let u2 = t2
+            .encode_diff_v1(&StateVector::decode_v1(&d1_sv.as_slice()).unwrap())
+            .unwrap();
         t1.apply_update(Update::decode_v1(u2.as_slice()).unwrap());
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
 
@@ -1479,8 +1489,10 @@ mod test {
         let txt2 = d2.get_or_insert_text("test");
         let mut t2 = d2.transact_mut();
 
-        let d2_sv = t2.state_vector().encode_v1();
-        let u1 = t1.encode_diff_v1(&StateVector::decode_v1(&d2_sv.as_slice()).unwrap());
+        let d2_sv = t2.state_vector().encode_v1().unwrap();
+        let u1 = t1
+            .encode_diff_v1(&StateVector::decode_v1(&d2_sv.as_slice()).unwrap())
+            .unwrap();
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
 
         assert_eq!(txt2.get_string(&t2).as_str(), "aaa");
@@ -1492,10 +1504,14 @@ mod test {
         txt1.insert(&mut t1, 3, "aaa");
         assert_eq!(txt1.get_string(&t1).as_str(), "aaaaaa");
 
-        let d2_sv = t2.state_vector().encode_v1();
-        let d1_sv = t1.state_vector().encode_v1();
-        let u1 = t1.encode_diff_v1(&StateVector::decode_v1(&d2_sv.as_slice()).unwrap());
-        let u2 = t2.encode_diff_v1(&StateVector::decode_v1(&d1_sv.as_slice()).unwrap());
+        let d2_sv = t2.state_vector().encode_v1().unwrap();
+        let d1_sv = t1.state_vector().encode_v1().unwrap();
+        let u1 = t1
+            .encode_diff_v1(&StateVector::decode_v1(&d2_sv.as_slice()).unwrap())
+            .unwrap();
+        let u2 = t2
+            .encode_diff_v1(&StateVector::decode_v1(&d1_sv.as_slice()).unwrap())
+            .unwrap();
 
         t1.apply_update(Update::decode_v1(u2.as_slice()).unwrap());
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
@@ -1602,7 +1618,9 @@ mod test {
         txt1.insert(&mut t1, 0, "hello world");
         assert_eq!(txt1.get_string(&t1).as_str(), "hello world");
 
-        let u1 = t1.encode_state_as_update_v1(&StateVector::default());
+        let u1 = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         let d2 = Doc::with_client_id(2);
         let txt2 = d2.get_or_insert_text("test");
@@ -1620,10 +1638,14 @@ mod test {
         txt2.insert(&mut t2, 0, "H");
         assert_eq!(txt2.get_string(&t2).as_str(), "Hellod");
 
-        let sv1 = t1.state_vector().encode_v1();
-        let sv2 = t2.state_vector().encode_v1();
-        let u1 = t1.encode_diff_v1(&StateVector::decode_v1(&sv2.as_slice()).unwrap());
-        let u2 = t2.encode_diff_v1(&StateVector::decode_v1(&sv1.as_slice()).unwrap());
+        let sv1 = t1.state_vector().encode_v1().unwrap();
+        let sv2 = t2.state_vector().encode_v1().unwrap();
+        let u1 = t1
+            .encode_diff_v1(&StateVector::decode_v1(&sv2.as_slice()).unwrap())
+            .unwrap();
+        let u2 = t2
+            .encode_diff_v1(&StateVector::decode_v1(&sv1.as_slice()).unwrap())
+            .unwrap();
 
         t1.apply_update(Update::decode_v1(u2.as_slice()).unwrap());
         t2.apply_update(Update::decode_v1(u1.as_slice()).unwrap());
@@ -1744,7 +1766,7 @@ mod test {
 
             let sv = t2.state_vector();
             let mut encoder = EncoderV1::new();
-            t1.encode_diff(&sv, &mut encoder);
+            t1.encode_diff(&sv, &mut encoder).unwrap();
             t2.apply_update(Update::decode_v1(encoder.to_vec().as_slice()).unwrap());
         }
 
@@ -1875,7 +1897,7 @@ mod test {
         {
             let mut txn = d1.transact_mut();
             txt1.insert_with_attributes(&mut txn, 0, "abc", a.clone());
-            let update = txn.encode_update_v1();
+            let update = txn.encode_update_v1().unwrap();
             drop(txn);
 
             let expected = Some(vec![Delta::Inserted(
@@ -1902,7 +1924,7 @@ mod test {
         {
             let mut txn = d1.transact_mut();
             txt1.remove_range(&mut txn, 0, 1);
-            let update = txn.encode_update_v1();
+            let update = txn.encode_update_v1().unwrap();
             drop(txn);
 
             let expected = Some(vec![Delta::Deleted(1)]);
@@ -1926,7 +1948,7 @@ mod test {
         {
             let mut txn = d1.transact_mut();
             txt1.remove_range(&mut txn, 1, 1);
-            let update = txn.encode_update_v1();
+            let update = txn.encode_update_v1().unwrap();
             drop(txn);
 
             let expected = Some(vec![Delta::Retain(1, None), Delta::Deleted(1)]);
@@ -1950,7 +1972,7 @@ mod test {
         {
             let mut txn = d1.transact_mut();
             txt1.insert_with_attributes(&mut txn, 0, "z", a.clone());
-            let update = txn.encode_update_v1();
+            let update = txn.encode_update_v1().unwrap();
             drop(txn);
 
             let expected = Some(vec![Delta::Inserted("z".into(), Some(Box::new(a.clone())))]);
@@ -1974,7 +1996,7 @@ mod test {
         {
             let mut txn = d1.transact_mut();
             txt1.insert(&mut txn, 0, "y");
-            let update = txn.encode_update_v1();
+            let update = txn.encode_update_v1().unwrap();
             drop(txn);
 
             let expected = Some(vec![Delta::Inserted("y".into(), None)]);
@@ -2002,7 +2024,7 @@ mod test {
             let mut txn = d1.transact_mut();
             let b: Attrs = HashMap::from([("bold".into(), Any::Null)]);
             txt1.format(&mut txn, 0, 2, b.clone());
-            let update = txn.encode_update_v1();
+            let update = txn.encode_update_v1().unwrap();
             drop(txn);
 
             let expected = Some(vec![
@@ -2073,8 +2095,12 @@ mod test {
             let mut txn = d1.transact_mut();
             assert_eq!(txt1.diff(&mut txn, YChange::identity), expected);
 
-            let update_v1 = txn.encode_state_as_update_v1(&StateVector::default());
-            let update_v2 = txn.encode_state_as_update_v2(&StateVector::default());
+            let update_v1 = txn
+                .encode_state_as_update_v1(&StateVector::default())
+                .unwrap();
+            let update_v2 = txn
+                .encode_state_as_update_v2(&StateVector::default())
+                .unwrap();
             (update_v1, update_v2)
         };
 

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -1220,7 +1220,9 @@ mod test {
         let f = d2.get_or_insert_xml_fragment("xml");
         let mut t2 = d2.transact_mut();
         let xml2 = f.push_back(&mut t2, XmlElementPrelim::empty("div"));
-        let u = t1.encode_state_as_update_v1(&StateVector::default());
+        let u = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         t2.apply_update(Update::decode_v1(u.as_slice()).unwrap());
         assert_eq!(xml2.get_attribute(&t2, "height"), Some("10".to_string()));
     }
@@ -1313,7 +1315,9 @@ mod test {
         let expected = "hello<p></p>";
         assert_eq!(r1.get_string(&t1), expected);
 
-        let u1 = t1.encode_state_as_update_v1(&StateVector::default());
+        let u1 = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
 
         let d2 = Doc::with_client_id(2);
         let r2 = d2.get_or_insert_xml_fragment("root");
@@ -1347,7 +1351,9 @@ mod test {
             1, 3, 1, 0, 7, 1, 4, 114, 111, 111, 116, 6, 4, 0, 1, 0, 5, 104, 101, 108, 108, 111,
             135, 1, 0, 3, 1, 112, 0,
         ];
-        let u1 = t1.encode_state_as_update_v1(&StateVector::default());
+        let u1 = t1
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         assert_eq!(u1.as_slice(), expected);
     }
 
@@ -1460,7 +1466,7 @@ mod test {
             let mut t2 = d2.transact_mut();
             let sv = t2.state_vector();
             let mut encoder = EncoderV1::new();
-            t1.encode_diff(&sv, &mut encoder);
+            t1.encode_diff(&sv, &mut encoder).unwrap();
             t2.apply_update(Update::decode_v1(encoder.to_vec().as_slice()).unwrap());
         }
         assert_eq!(
@@ -1542,7 +1548,9 @@ mod test {
         txn.apply_update(update);
         assert_eq!(txt.get_string(&txn), "<i>hello </i><b><i>world</i></b>");
 
-        let actual = txn.encode_state_as_update_v1(&StateVector::default());
+        let actual = txn
+            .encode_state_as_update_v1(&StateVector::default())
+            .unwrap();
         assert_eq!(actual, data);
     }
 
@@ -1561,7 +1569,9 @@ mod test {
         txn.apply_update(update);
         assert_eq!(txt.get_string(&txn), "<i>hello </i><b><i>world</i></b>");
 
-        let actual = txn.encode_state_as_update_v2(&StateVector::default());
+        let actual = txn
+            .encode_state_as_update_v2(&StateVector::default())
+            .unwrap();
         assert_eq!(actual, data);
     }
 }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -1303,7 +1303,8 @@ mod test {
         fn send(src: &Doc, dst: &Doc) {
             let update = Update::decode_v1(
                 &src.transact()
-                    .encode_state_as_update_v1(&StateVector::default()),
+                    .encode_state_as_update_v1(&StateVector::default())
+                    .unwrap(),
             )
             .unwrap();
             dst.transact_mut().apply_update(update)

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -453,7 +453,11 @@ impl Update {
         }
     }
 
-    pub(crate) fn encode_diff<E: Encoder>(&self, remote_sv: &StateVector, encoder: &mut E) {
+    pub(crate) fn encode_diff<E: Encoder>(
+        &self,
+        remote_sv: &StateVector,
+        encoder: &mut E,
+    ) -> Result<(), Error> {
         let mut clients = HashMap::new();
         for (client, blocks) in self.blocks.clients.iter() {
             let remote_clock = remote_sv.get(client);
@@ -491,13 +495,14 @@ impl Update {
 
             let mut block = blocks[0];
             encoder.write_var(block.id().clock + offset);
-            block.encode_with_offset(encoder, *offset);
+            block.encode_with_offset(encoder, *offset)?;
             for i in 1..blocks.len() {
                 block = blocks[i];
-                block.encode_with_offset(encoder, 0);
+                block.encode_with_offset(encoder, 0)?;
             }
         }
-        self.delete_set.encode(encoder)
+        self.delete_set.encode(encoder)?;
+        Ok(())
     }
 
     pub fn merge_updates<T>(block_stores: T) -> Update
@@ -672,7 +677,7 @@ impl Update {
 
 impl Encode for Update {
     #[inline]
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), Error> {
         self.encode_diff(&StateVector::default(), encoder)
     }
 }
@@ -832,7 +837,11 @@ impl BlockCarrier {
             false
         }
     }
-    pub fn encode_with_offset<E: Encoder>(&self, encoder: &mut E, offset: u32) {
+    pub fn encode_with_offset<E: Encoder>(
+        &self,
+        encoder: &mut E,
+        offset: u32,
+    ) -> Result<(), Error> {
         match self {
             BlockCarrier::Block(x) => {
                 let slice = BlockSlice::new(x.into(), offset, x.len() - 1);
@@ -841,6 +850,7 @@ impl BlockCarrier {
             BlockCarrier::Skip(x) => {
                 encoder.write_info(BLOCK_SKIP_REF_NUMBER);
                 encoder.write_len(x.len - offset);
+                Ok(())
             }
         }
     }
@@ -860,14 +870,15 @@ impl From<Box<Block>> for BlockCarrier {
 }
 
 impl Encode for BlockCarrier {
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), Error> {
         match self {
-            BlockCarrier::Block(block) => block.encode(None, encoder),
+            BlockCarrier::Block(block) => block.encode(None, encoder)?,
             BlockCarrier::Skip(skip) => {
                 encoder.write_info(BLOCK_SKIP_REF_NUMBER);
                 encoder.write_len(skip.len)
             }
         }
+        Ok(())
     }
 }
 
@@ -1075,8 +1086,8 @@ mod test {
         txt2.insert(&mut t2, 0, "bbb");
         txt2.insert(&mut t2, 2, "bbb");
 
-        let binary1 = t1.encode_update_v1();
-        let binary2 = t2.encode_update_v1();
+        let binary1 = t1.encode_update_v1().unwrap();
+        let binary2 = t2.encode_update_v1().unwrap();
 
         t1.apply_update(Update::decode_v1(binary2.as_slice()).unwrap());
         t2.apply_update(Update::decode_v1(binary1.as_slice()).unwrap());
@@ -1108,7 +1119,7 @@ mod test {
         let mut tr = doc.transact_mut();
         txt.insert(&mut tr, 0, "aaa");
 
-        let binary = tr.encode_update_v1();
+        let binary = tr.encode_update_v1().unwrap();
         let u1 = decode_update(&binary);
         let u2 = decode_update(&binary);
         let u3 = decode_update(&binary);
@@ -1124,14 +1135,14 @@ mod test {
             let txt = doc.get_or_insert_text("test");
             let mut tr = doc.transact_mut();
             txt.insert(&mut tr, 0, "aaa");
-            tr.encode_update_v1()
+            tr.encode_update_v1().unwrap()
         };
         let binary2 = {
             let doc = Doc::with_client_id(2);
             let txt = doc.get_or_insert_text("test");
             let mut tr = doc.transact_mut();
             txt.insert(&mut tr, 0, "bbb");
-            tr.encode_update_v1()
+            tr.encode_update_v1().unwrap()
         };
 
         let u12 = Update::merge_updates(vec![decode_update(&binary1), decode_update(&binary2)]);

--- a/yrs/src/updates/encoder.rs
+++ b/yrs/src/updates/encoder.rs
@@ -2,25 +2,26 @@ use crate::block::ClientID;
 use crate::*;
 use lib0::any::Any;
 use lib0::encoding::Write;
+use lib0::error::Error;
 use lib0::number::Signed;
 use std::collections::HashMap;
 
 /// A trait that can be implemented by any other type in order to support lib0 encoding capability.
 pub trait Encode {
-    fn encode<E: Encoder>(&self, encoder: &mut E);
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), Error>;
 
     /// Helper function for encoding 1st version of lib0 encoding.
-    fn encode_v1(&self) -> Vec<u8> {
+    fn encode_v1(&self) -> Result<Vec<u8>, Error> {
         let mut encoder = EncoderV1::new();
-        self.encode(&mut encoder);
-        encoder.to_vec()
+        self.encode(&mut encoder)?;
+        Ok(encoder.to_vec())
     }
 
     /// Helper function for encoding 1st version of lib0 encoding.
-    fn encode_v2(&self) -> Vec<u8> {
+    fn encode_v2(&self) -> Result<Vec<u8>, Error> {
         let mut encoder = EncoderV2::new();
-        self.encode(&mut encoder);
-        encoder.to_vec()
+        self.encode(&mut encoder)?;
+        Ok(encoder.to_vec())
     }
 }
 

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -825,7 +825,9 @@ impl YTransaction {
     #[wasm_bindgen(method, js_name = stateVectorV1)]
     pub fn state_vector_v1(&self) -> Uint8Array {
         let sv = self.state_vector();
-        let payload = sv.encode_v1();
+        let payload = sv
+            .encode_v1()
+            .expect("failed to encode state vector using lib0 v1 encoding");
         Uint8Array::from(&payload[..payload.len()])
     }
 
@@ -869,7 +871,8 @@ impl YTransaction {
         } else {
             StateVector::default()
         };
-        self.encode_diff(&sv, &mut encoder);
+        self.encode_diff(&sv, &mut encoder)
+            .expect("failed to encode diff using lib0 v1 encoding");
         let payload = encoder.to_vec();
         Ok(Uint8Array::from(&payload[..payload.len()]))
     }
@@ -914,7 +917,8 @@ impl YTransaction {
         } else {
             StateVector::default()
         };
-        self.encode_diff(&sv, &mut encoder);
+        self.encode_diff(&sv, &mut encoder)
+            .expect("failed to encode diff using lib0 v2 encoding");
         let payload = encoder.to_vec();
         Ok(Uint8Array::from(&payload[..payload.len()]))
     }
@@ -1003,7 +1007,9 @@ impl YTransaction {
     pub fn encode_update(&mut self) -> Uint8Array {
         let out = match &self.0 {
             InnerTxn::ReadOnly(_) => vec![0u8, 0u8],
-            InnerTxn::ReadWrite(txn) => txn.encode_update_v1(),
+            InnerTxn::ReadWrite(txn) => txn
+                .encode_update_v1()
+                .expect("failed to encode update using lib0 v1 encoding"),
         };
         Uint8Array::from(&out[..out.len()])
     }
@@ -1012,7 +1018,9 @@ impl YTransaction {
     pub fn encode_update_v2(&mut self) -> Uint8Array {
         let out = match &self.0 {
             InnerTxn::ReadOnly(_) => vec![0u8, 0u8],
-            InnerTxn::ReadWrite(txn) => txn.encode_update_v2(),
+            InnerTxn::ReadWrite(txn) => txn
+                .encode_update_v2()
+                .expect("failed to encode update using lib0 v2 encoding"),
         };
         Uint8Array::from(&out[..out.len()])
     }
@@ -2138,12 +2146,18 @@ pub fn equal_snapshots(snap1: &YSnapshot, snap2: &YSnapshot) -> bool {
 
 #[wasm_bindgen(js_name = encodeSnapshotV1)]
 pub fn encode_snapshot_v1(snapshot: &YSnapshot) -> Vec<u8> {
-    snapshot.0.encode_v1()
+    snapshot
+        .0
+        .encode_v1()
+        .expect("failed to serialize snapshot using lib0 v1 encoding")
 }
 
 #[wasm_bindgen(js_name = encodeSnapshotV2)]
 pub fn encode_snapshot_v2(snapshot: &YSnapshot) -> Vec<u8> {
-    snapshot.0.encode_v2()
+    snapshot
+        .0
+        .encode_v2()
+        .expect("failed to serialize snapshot using lib0 v2 encoding")
 }
 
 #[wasm_bindgen(catch, js_name = decodeSnapshotV2)]
@@ -4057,7 +4071,11 @@ pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &YDoc) -> Result<JsV
 #[wasm_bindgen(catch, js_name=encodeStickyIndex)]
 pub fn encode_sticky_index(rpos: &JsValue) -> Result<Uint8Array, JsValue> {
     if let Ok(pos) = sticky_index_from_js(rpos) {
-        let bytes = Uint8Array::from(pos.encode_v1().as_slice());
+        let bytes = Uint8Array::from(
+            pos.encode_v1()
+                .expect("failed to serialize sticky index")
+                .as_slice(),
+        );
         Ok(bytes)
     } else {
         Err(JsValue::from_str("passed parameter is not StickyIndex"))


### PR DESCRIPTION
this pr aims to add `Result<(), lib0::error::Error>` return value to the `encode` function of `Encode` trait

this allows developers to safely handle errors when encountering erroneous data

after this pr is merged, I plan to modify the panic in yrs to a `YrsError` structure generated by thiserror in the next pr, which can make the error message clearer