### PR TITLE
fixed issue with non utf-16 encoding on default y-wasm doc settings

### DIFF
--- a/tests-wasm/editing-traces.tests.js
+++ b/tests-wasm/editing-traces.tests.js
@@ -1,0 +1,75 @@
+import * as Y from 'ywasm'
+import * as t from 'lib0/testing'
+import * as fs from 'fs'
+import * as zlib from 'zlib'
+
+/**
+ * @param {t.TestCase} tc
+ * @param {String} filename
+ */
+const run = (tc, filename) => {
+    const { startContent, endContent, txns } = JSON.parse(
+        filename.endsWith('.gz')
+            ? zlib.gunzipSync(fs.readFileSync(filename))
+            : fs.readFileSync(filename, 'utf-8')
+    )
+    const doc = new Y.YDoc()
+    const text = doc.getText('text')
+    if (startContent && startContent !== '') {
+        text.push(startContent)
+    }
+    const start = performance.now()
+    for (const {patches} of txns) {
+        let txn = doc.writeTransaction()
+        for (const [pos, del, chunk] of patches) {
+            if (del !== 0) {
+                text.delete(pos, del, txn)
+            }
+            if (chunk && chunk !== '') {
+                text.insert(pos, chunk, null, txn)
+            }
+        }
+        txn.commit()
+        txn.free()
+    }
+    const end = performance.now()
+    console.log('execution time: ', (end-start), 'milliseconds')
+
+    const content = text.toString()
+    t.compareStrings(content, endContent)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testEditingTraceAutomerge = tc => {
+    run(tc, '../yrs/editing-traces/sequential_traces/automerge-paper.json.gz')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testEditingTraceFriendsForever = tc => {
+    run(tc, '../yrs/editing-traces/sequential_traces/friendsforever_flat.json.gz')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testEditingTraceRustCode = tc => {
+    run(tc, '../yrs/editing-traces/sequential_traces/rustcode.json.gz')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testEditingTraceSephBlog = tc => {
+    run(tc, '../yrs/editing-traces/sequential_traces/seph-blog1.json.gz')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testEditingTraceSvelteComponent = tc => {
+    run(tc, '../yrs/editing-traces/sequential_traces/sveltecomponent.json.gz')
+}

--- a/tests-wasm/index.js
+++ b/tests-wasm/index.js
@@ -5,6 +5,7 @@ import * as xml from './y-xml.tests.js'
 import * as doc from './y-doc.tests.js'
 import * as undo from './y-undo.tests.js'
 import * as stickyIndex from './sticky-index.tests.js'
+import * as editingTraces from './editing-traces.tests.js'
 
 import { runTests } from 'lib0/testing'
 import { isBrowser, isNode } from 'lib0/environment'
@@ -14,7 +15,7 @@ if (isBrowser) {
     log.createVConsole(document.body)
 }
 runTests({
-    array, text, map, xml, doc, undo, stickyIndex
+    array, text, map, xml, doc, undo, stickyIndex, editingTraces
 }).then(success => {
     /* istanbul ignore next */
     if (isNode) {

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -10,12 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42",
-        "ywasm": "file:../ywasm/pkg"
+        "ywasm": "file:../ywasm/pkg",
+        "zlib": "^1.0.5"
       }
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.16.0",
+      "version": "0.16.5",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {
@@ -45,6 +46,15 @@
     "node_modules/ywasm": {
       "resolved": "../ywasm/pkg",
       "link": true
+    },
+    "node_modules/zlib": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+      "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
     }
   },
   "dependencies": {
@@ -63,6 +73,11 @@
     },
     "ywasm": {
       "version": "file:../ywasm/pkg"
+    },
+    "zlib": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+      "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w=="
     }
   }
 }

--- a/tests-wasm/package.json
+++ b/tests-wasm/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "lib0": "^0.2.42",
-    "ywasm": "file:../ywasm/pkg"
+    "ywasm": "file:../ywasm/pkg",
+    "zlib": "^1.0.5"
   }
 }

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -421,9 +421,8 @@ impl YDoc {
 
 fn parse_options(js: &JsValue) -> Options {
     let mut options = Options::default();
+    options.offset_kind = OffsetKind::Utf16;
     if js.is_object() {
-        options.offset_kind = OffsetKind::Utf16;
-
         if let Some(client_id) = js_sys::Reflect::get(js, &JsValue::from_str("clientID"))
             .ok()
             .and_then(|v| v.as_f64())


### PR DESCRIPTION
This PR fixes an issue when non UTF-16 offset encoding was used if `new Y.Doc()` was used in y-wasm. We also extend Seph Gentle's editing-trace tests integrated in yrs last time onto y-wasm as well.