### PR TITLE
Optimize block lookups?

### DIFF
--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -154,7 +154,7 @@ impl Store {
         encoder.write_var(diff.len());
         for (client, clock) in diff {
             let blocks = self.blocks.get(&client).unwrap();
-            let clock = clock.min(blocks.last_id());
+            let clock = clock.min(blocks.last_clock());
             let last_idx = blocks.find_pivot(clock - 1).unwrap();
             // write # encoded structs
             encoder.write_var(last_idx + 1);
@@ -277,6 +277,7 @@ impl Store {
         } else {
             let mut i = blocks.find_pivot(id.clock).unwrap();
             if let Some(new) = slice.as_ptr().splice(slice.start(), OffsetKind::Utf16) {
+                blocks.fix_offset(i, &slice.as_ptr());
                 blocks.insert(i + 1, new);
                 i += 1;
                 //todo: txn merge blocks insert?
@@ -296,6 +297,7 @@ impl Store {
                 blocks.find_pivot(last_id.clock).unwrap()
             };
             let new = ptr.splice(slice.len(), OffsetKind::Utf16).unwrap();
+            blocks.fix_offset(i, &ptr);
             blocks.insert(i + 1, new);
             //todo: txn merge blocks insert?
         }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -154,7 +154,7 @@ impl Store {
         encoder.write_var(diff.len());
         for (client, clock) in diff {
             let blocks = self.blocks.get(&client).unwrap();
-            let clock = clock.min(blocks.last().last_id().clock);
+            let clock = clock.min(blocks.last_id());
             let last_idx = blocks.find_pivot(clock - 1).unwrap();
             // write # encoded structs
             encoder.write_var(last_idx + 1);


### PR DESCRIPTION
This is simple optimization of block-by-id lookups by introducing an intermediary array that stores clock ranges for each block list of a given client. This way binary search by ID (clock) uses only a continuous array of u32 rather than jumping over the memory to recollect block id and length. That was the theory that we wanted to check as such change doesn't significantly change the code base.

Performance benchmarks against current main:
```
[B1.1] Append N characters/6000
                        time:   [13.151 ms 13.186 ms 13.215 ms]
                        change: [-2.3469% -1.5423% -0.7662%] (p = 0.00 < 0.05)
                        Change within noise threshold.

[B1.2] Insert string of length N/1
                        time:   [6.7260 µs 6.7639 µs 6.7848 µs]
                        change: [-0.7276% +10.854% +20.092%] (p = 0.06 > 0.05)
                        No change in performance detected.

[B1.3] Prepend N characters/6000
                        time:   [4.7641 ms 4.8114 ms 4.8299 ms]
                        change: [-2.1385% -0.3210% +1.4274%] (p = 0.73 > 0.05)
                        No change in performance detected.

[B1.4] Insert N characters at random positions/6000
                        time:   [80.118 ms 80.160 ms 80.230 ms]
                        change: [-0.6076% -0.3143% +0.0099%] (p = 0.07 > 0.05)
                        No change in performance detected.

[B1.5] Insert N words at random positions/6000
                        time:   [22.516 ms 22.645 ms 22.820 ms]
                        change: [-1.8838% -1.2119% -0.4552%] (p = 0.01 < 0.05)
                        Change within noise threshold.

[B1.7] Insert/Delete strings at random positions/6000
                        time:   [78.024 ms 81.203 ms 82.944 ms]
                        change: [-5.9846% -0.7946% +4.3953%] (p = 0.78 > 0.05)
                        No change in performance detected.

[B1.8] Append N numbers/6000
                        time:   [5.7772 ms 5.8363 ms 5.8694 ms]
                        change: [-2.0206% -1.1578% -0.2484%] (p = 0.03 < 0.05)
                        Change within noise threshold.

[B1.9] Insert Array of N numbers/1
                        time:   [67.828 µs 71.480 µs 73.598 µs]
                        change: [-11.764% +0.5268% +14.176%] (p = 0.94 > 0.05)
                        No change in performance detected.
[B1.10] Prepend N numbers/6000
                        time:   [5.0876 ms 5.1280 ms 5.1728 ms]
                        change: [-0.2341% +0.4025% +1.0612%] (p = 0.29 > 0.05)
                        No change in performance detected.

Benchmarking [B1.11] Insert N numbers at random positions/6000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.8s or enable flat sampling.
                        change: [-0.8480% -0.3599% +0.1466%] (p = 0.19 > 0.05)
                        No change in performance detected.

[B2.1] Concurrently insert string of length N at index 0/6000
                        time:   [35.905 µs 40.246 µs 42.171 µs]
                        change: [+1.2762% +12.258% +23.258%] (p = 0.06 > 0.05)
                        No change in performance detected.

[B2.2] Concurrently insert N characters at random positions/6000
                        time:   [215.32 ms 215.55 ms 215.81 ms]
                        change: [-1.6555% -1.4741% -1.2773%] (p = 0.00 < 0.05)
                        Performance has improved.

[B2.3] Concurrently insert N words at random positions/6000
                        time:   [400.55 ms 401.30 ms 402.08 ms]
                        change: [-0.9406% -0.4273% +0.0479%] (p = 0.13 > 0.05)
                        No change in performance detected.

[B2.4] Concurrently insert & delete/6000
                        time:   [228.50 ms 228.96 ms 229.46 ms]
                        change: [-0.1197% +0.1481% +0.4254%] (p = 0.33 > 0.05)
                        No change in performance detected.

[B3.1] 20√N clients concurrently set number in Map/1540
                        time:   [83.977 ms 84.090 ms 84.312 ms]
                        change: [-10.994% -10.706% -10.456%] (p = 0.00 < 0.05)
                        Performance has improved.

[B3.2] 20√N clients concurrently set Object in Map/1540
                        time:   [88.645 ms 88.697 ms 88.766 ms]
                        change: [-4.9698% -4.5797% -4.2980%] (p = 0.00 < 0.05)
                        Performance has improved.

[B3.3] 20√N clients concurrently set String in Map/1540
                        time:   [74.535 ms 74.654 ms 74.772 ms]
                        change: [-15.704% -15.562% -15.420%] (p = 0.00 < 0.05)
                        Performance has improved.

[B3.4] 20√N clients concurrently insert text in Array/1540
                        time:   [79.798 ms 79.986 ms 80.184 ms]
                        change: [-25.145% -24.815% -24.564%] (p = 0.00 < 0.05)
                        Performance has improved.

[B4.2] Apply real-world document snapshot of size/400972
                        time:   [2.8472 ms 2.8609 ms 2.8737 ms]
                        change: [+1.5890% +2.2442% +2.7989%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking [B4.1] Apply real-world editing dataset/259778: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 63.5s.
[B4.1] Apply real-world editing dataset/259778
                        time:   [6.2379 s 6.3363 s 6.4403 s]
                        change: [+0.1770% +1.8360% +3.6152%] (p = 0.07 > 0.05)
                        No change in performance detected.
```

Tbh. I expected better results. There are 4-24% improvements in cases when we talk about concurrent 20√N client benchmarks, but for sequential cases improvements are minimal.