### PR TITLE
y-wasm release v0.16.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.16.5"
+version = "0.16.6"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.16.5",
+      "version": "0.16.6",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.16.5"
+version = "0.16.6"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"


### PR DESCRIPTION
- fixed `new YDoc()`: utf-16 encoding was not set when no option parameter has been sent to constructor