### PR TITLE
Changed type refs enum representation

### DIFF
--- a/yrs/benches/benches.rs
+++ b/yrs/benches/benches.rs
@@ -435,7 +435,7 @@ fn b4_2(c: &mut Criterion, name: &str) {
     let doc = Doc::new();
     let txt = doc.get_or_insert_text("text");
     let mut buf = Vec::with_capacity(400 * 1024);
-    let mut f = std::fs::File::open("./yrs/benches/input/b4-update.bin").unwrap();
+    let mut f = std::fs::File::open("./assets/bench-input/b4-update.bin").unwrap();
     std::io::Read::read_to_end(&mut f, &mut buf).unwrap();
 
     c.bench_with_input(

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -2,10 +2,7 @@ use crate::block::{Block, BlockPtr, ClientID, ItemContent, Prelim};
 use crate::event::{SubdocsEvent, TransactionCleanupEvent, UpdateEvent};
 use crate::store::{Store, StoreRef};
 use crate::transaction::{Origin, Transaction, TransactionMut};
-use crate::types::{
-    Branch, BranchPtr, ToJson, TYPE_REFS_ARRAY, TYPE_REFS_MAP, TYPE_REFS_TEXT,
-    TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_FRAGMENT, TYPE_REFS_XML_TEXT,
-};
+use crate::types::{Branch, BranchPtr, ToJson, TypeRef};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::OptionExt;
@@ -129,7 +126,7 @@ impl Doc {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
-        let mut c = r.get_or_create_type(name, None, TYPE_REFS_TEXT);
+        let mut c = r.get_or_create_type(name, TypeRef::Text);
         c.store = Some(self.store.weak_ref());
         TextRef::from(c)
     }
@@ -155,7 +152,7 @@ impl Doc {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
-        let mut c = r.get_or_create_type(name, None, TYPE_REFS_MAP);
+        let mut c = r.get_or_create_type(name, TypeRef::Map);
         c.store = Some(self.store.weak_ref());
         MapRef::from(c)
     }
@@ -180,7 +177,7 @@ impl Doc {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
-        let mut c = r.get_or_create_type(name, None, TYPE_REFS_ARRAY);
+        let mut c = r.get_or_create_type(name, TypeRef::Array);
         c.store = Some(self.store.weak_ref());
         ArrayRef::from(c)
     }
@@ -207,7 +204,7 @@ impl Doc {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
-        let mut c = r.get_or_create_type(name, None, TYPE_REFS_XML_FRAGMENT);
+        let mut c = r.get_or_create_type(name, TypeRef::XmlFragment);
         c.store = Some(self.store.weak_ref());
         XmlFragmentRef::from(c)
     }
@@ -234,7 +231,7 @@ impl Doc {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
-        let mut c = r.get_or_create_type(name, Some(name.into()), TYPE_REFS_XML_ELEMENT);
+        let mut c = r.get_or_create_type(name, TypeRef::XmlElement(name.into()));
         c.store = Some(self.store.weak_ref());
         XmlElementRef::from(c)
     }
@@ -259,7 +256,7 @@ impl Doc {
         let mut r = self.store.try_borrow_mut().expect(
             "tried to get a root level type while another transaction on the document is open",
         );
-        let mut c = r.get_or_create_type(name, None, TYPE_REFS_XML_TEXT);
+        let mut c = r.get_or_create_type(name, TypeRef::XmlText);
         c.store = Some(self.store.weak_ref());
         XmlTextRef::from(c)
     }

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -8,7 +8,7 @@ use crate::{ReadTxn, WriteTxn, ID};
 use lib0::error::Error;
 use std::collections::HashSet;
 use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Move {
@@ -658,7 +658,7 @@ pub enum IndexScope {
     Nested(ID),
     /// If a containing collection is a root-level y-type, which is empty, this case allows us to
     /// identify that nested type.
-    Root(Rc<str>),
+    Root(Arc<str>),
 }
 
 impl Encode for IndexScope {

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -2,7 +2,7 @@ use crate::block::{ClientID, Item, ItemContent};
 use crate::id_set::{DeleteSet, IdSet};
 use crate::store::Store;
 use crate::types::xml::XmlFragment;
-use crate::types::{Branch, ToJson, TypePtr, TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_TEXT};
+use crate::types::{Branch, ToJson, TypePtr, TypeRef};
 use crate::update::{BlockCarrier, Update};
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::Encode;
@@ -247,7 +247,7 @@ fn xml_fragment_insert() {
             None,
             TypePtr::Named("fragment-name".into()),
             None,
-            ItemContent::Type(Branch::new(TYPE_REFS_XML_TEXT, None)),
+            ItemContent::Type(Branch::new(TypeRef::XmlText)),
         )
         .into(),
         Item::new(
@@ -258,7 +258,7 @@ fn xml_fragment_insert() {
             None,
             TypePtr::Unknown,
             None,
-            ItemContent::Type(Branch::new(TYPE_REFS_XML_ELEMENT, Some("node-name".into()))),
+            ItemContent::Type(Branch::new(TypeRef::XmlElement("node-name".into()))),
         )
         .into(),
     ];

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -16,7 +16,7 @@ use std::fmt::Formatter;
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::rc::Rc;
+use std::sync::Arc;
 use updates::encoder::*;
 
 /// Trait defining read capabilities present in a transaction. Implemented by both lightweight
@@ -249,7 +249,7 @@ pub struct TransactionMut<'doc> {
     pub(crate) prev_moved: HashMap<BlockPtr, BlockPtr>,
     /// All types that were directly modified (property added or child inserted/deleted).
     /// New types are not included in this Set.
-    pub(crate) changed: HashMap<TypePtr, HashSet<Option<Rc<str>>>>,
+    pub(crate) changed: HashMap<TypePtr, HashSet<Option<Arc<str>>>>,
     pub(crate) changed_parent_types: Vec<BranchPtr>,
     pub(crate) subdocs: Option<Box<Subdocs>>,
     pub(crate) origin: Option<Origin>,
@@ -613,7 +613,7 @@ impl<'doc> TransactionMut<'doc> {
         &mut self,
         pos: &block::ItemPosition,
         value: T,
-        parent_sub: Option<Rc<str>>,
+        parent_sub: Option<Arc<str>>,
     ) -> BlockPtr {
         let (left, right, origin, id) = {
             let store = self.store_mut();
@@ -837,7 +837,7 @@ impl<'doc> TransactionMut<'doc> {
         }
     }
 
-    pub(crate) fn add_changed_type(&mut self, parent: BranchPtr, parent_sub: Option<Rc<str>>) {
+    pub(crate) fn add_changed_type(&mut self, parent: BranchPtr, parent_sub: Option<Arc<str>>) {
         let trigger = if let Some(ptr) = parent.item {
             (ptr.id().clock < self.before_state.get(&ptr.id().client)) && !ptr.is_deleted()
         } else {
@@ -890,7 +890,7 @@ impl<'doc> TransactionMut<'doc> {
 }
 
 /// Iterator struct used to traverse over all of the root level types defined in a corresponding [Doc].
-pub struct RootRefs<'doc>(std::collections::hash_map::Iter<'doc, Rc<str>, Box<Branch>>);
+pub struct RootRefs<'doc>(std::collections::hash_map::Iter<'doc, Arc<str>, Box<Branch>>);
 
 impl<'doc> Iterator for RootRefs<'doc> {
     type Item = (&'doc str, Value);

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -4,7 +4,7 @@ use crate::moving::StickyIndex;
 use crate::transaction::TransactionMut;
 use crate::types::{
     event_change_set, Branch, BranchPtr, Change, ChangeSet, EventHandler, Observers, Path, ToJson,
-    Value, TYPE_REFS_ARRAY,
+    TypeRef, Value,
 };
 use crate::{Assoc, IndexedSequence, Observable, ReadTxn, ID};
 use lib0::any::Any;
@@ -411,7 +411,7 @@ where
     type Return = ArrayRef;
 
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
-        let inner = Branch::new(TYPE_REFS_ARRAY, None);
+        let inner = Branch::new(TypeRef::Array);
         (ItemContent::Type(inner), Some(self))
     }
 

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -2,7 +2,7 @@ use crate::block::{Block, BlockPtr, EmbedPrelim, Item, ItemContent, ItemPosition
 use crate::block_store::Snapshot;
 use crate::transaction::TransactionMut;
 use crate::types::{
-    Attrs, Branch, BranchPtr, Delta, EventHandler, Observers, Path, Value, TYPE_REFS_TEXT,
+    Attrs, Branch, BranchPtr, Delta, EventHandler, Observers, Path, TypeRef, Value,
 };
 use crate::utils::OptionExt;
 use crate::*;
@@ -1260,7 +1260,7 @@ impl<T: Borrow<str>> Prelim for TextPrelim<T> {
     type Return = TextRef;
 
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
-        let inner = Branch::new(TYPE_REFS_TEXT, None);
+        let inner = Branch::new(TypeRef::Text);
         (ItemContent::Type(inner), Some(self))
     }
 


### PR DESCRIPTION
This PR introduces 2 changes:
1. Replaced basically all cases when `Rc<str>` was used with `Arc<str>`. This adds cross-thread safety and enables us to share some of the strings between threads (Rc cannot be passed between threads).
2. Replaces internal `u8` flag representing which shared type given Branch represents with complex enum: `TypeRef`. It's representation is made so that if maps to the same flag for serialization/deserialization, however it can have custom field eg.:
    - `Branch::name` field was moved into `TypeRef::XmlElement` as that field was used only by XML elements.
    - For the [WeakLinks](https://github.com/yjs/yjs/pull/539) we'll need some extra field linking.
    - For `ArrayRef` and `TextRef` we'll probably need these fields to store cursor search markers.