### PR TITLE
Expose a `root_keys` iterator on a transaction

### DIFF
--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -86,6 +86,12 @@ pub trait ReadTxn: Sized {
         RootRefs(store.types.iter())
     }
 
+    /// Returns an iterator over top level (root) keys available in current [Doc].
+    fn root_keys(&self) -> RootKeys {
+        let store = self.store();
+        RootKeys(store.types.keys())
+    }
+
     /// Returns a collection of globally unique identifiers of sub documents linked within
     /// the structures of this document store.
     fn subdoc_guids(&self) -> SubdocGuids {
@@ -902,6 +908,19 @@ impl<'doc> Iterator for RootRefs<'doc> {
         Some((key, ptr.into()))
     }
 }
+
+pub struct RootKeys<'doc>(std::collections::hash_map::Keys<'doc, Arc<str>, Box<Branch>>);
+
+impl<'doc> Iterator for RootKeys<'doc> {
+    type Item = &'doc str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let key = self.0.next()?;
+        let key = key.as_ref();
+        Some(key)
+    }
+}
+
 
 #[derive(Default)]
 pub struct Subdocs {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -87,9 +87,9 @@ pub trait ReadTxn: Sized {
     }
 
     /// Returns an iterator over top level (root) keys available in current [Doc].
-    fn root_keys(&self) -> std::collections::hash_map::Keys<Arc<str>, Box<Branch>> {
+    fn root_keys(&self) -> RootKeys {
         let store = self.store();
-        store.types.keys()
+        RootKeys(store.types.keys())
     }
 
     /// Returns a collection of globally unique identifiers of sub documents linked within
@@ -906,6 +906,16 @@ impl<'doc> Iterator for RootRefs<'doc> {
         let key = key.as_ref();
         let ptr = BranchPtr::from(branch);
         Some((key, ptr.into()))
+    }
+}
+
+pub struct RootKeys<'doc>(std::collections::hash_map::Keys<'doc, Arc<str>, Box<Branch>>);
+
+impl<'doc> Iterator for RootKeys<'doc> {
+    type Item = &'doc str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|key| key.as_ref())
     }
 }
 

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -912,10 +912,10 @@ impl<'doc> Iterator for RootRefs<'doc> {
 pub struct RootKeys<'doc>(std::collections::hash_map::Keys<'doc, Arc<str>, Box<Branch>>);
 
 impl<'doc> Iterator for RootKeys<'doc> {
-    type Item = &'doc str;
+    type Item = Arc<str>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|key| key.as_ref())
+        self.0.next().map(|k| k.clone())
     }
 }
 

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -87,9 +87,9 @@ pub trait ReadTxn: Sized {
     }
 
     /// Returns an iterator over top level (root) keys available in current [Doc].
-    fn root_keys(&self) -> RootKeys {
+    fn root_keys(&self) -> std::collections::hash_map::Keys<Arc<str>, Box<Branch>> {
         let store = self.store();
-        RootKeys(store.types.keys())
+        store.types.keys()
     }
 
     /// Returns a collection of globally unique identifiers of sub documents linked within
@@ -908,19 +908,6 @@ impl<'doc> Iterator for RootRefs<'doc> {
         Some((key, ptr.into()))
     }
 }
-
-pub struct RootKeys<'doc>(std::collections::hash_map::Keys<'doc, Arc<str>, Box<Branch>>);
-
-impl<'doc> Iterator for RootKeys<'doc> {
-    type Item = &'doc str;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let key = self.0.next()?;
-        let key = key.as_ref();
-        Some(key)
-    }
-}
-
 
 #[derive(Default)]
 pub struct Subdocs {


### PR DESCRIPTION
As far as I can tell, there is currently no way to iterate over keys in a document without calling `BranchPtr::into<Value>`. This is unfortunate since `BranchPtr::into` [will panic](https://github.com/y-crdt/y-crdt/blob/50d4cb6372d73e66d9243a38efe1668fda486b2b/yrs/src/types/mod.rs#L276) if that key is not already associated with a type.

This PR exposes an iterator that can be used to read the keys without doing anything with the associated values. The keys can then be used with `Transcation::get_array`, `Transaction::get_map`, etc. to access views of that data. This is useful for reflection when the set of keys is not known in advance and needs to be determined programatically.