### PR TITLE
Reduced ClientID to 63bit/31bit

### DIFF
--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -298,7 +298,7 @@ impl Into<Options> for YOptions {
             Some(str)
         };
         Options {
-            client_id: self.id as ClientID,
+            client_id: ClientID::new(self.id),
             guid,
             collection_id,
             skip_gc: if self.skip_gc == 0 { false } else { true },
@@ -312,7 +312,7 @@ impl Into<Options> for YOptions {
 impl From<Options> for YOptions {
     fn from(o: Options) -> Self {
         YOptions {
-            id: o.client_id,
+            id: o.client_id.into(),
             guid: CString::new(o.guid.as_ref()).unwrap().into_raw(),
             collection_id: if let Some(collection_id) = o.collection_id {
                 CString::new(collection_id).unwrap().into_raw()
@@ -412,7 +412,7 @@ pub extern "C" fn ydoc_new_with_options(options: YOptions) -> *mut Doc {
 #[no_mangle]
 pub unsafe extern "C" fn ydoc_id(doc: *mut Doc) -> u64 {
     let doc = doc.as_ref().unwrap();
-    doc.client_id()
+    doc.client_id().into()
 }
 
 /// Returns a unique document identifier of this [Doc] instance.
@@ -3549,7 +3549,7 @@ impl YStateVector {
         let mut client_ids = Vec::with_capacity(sv.len());
         let mut clocks = Vec::with_capacity(sv.len());
         for (&client, &clock) in sv.iter() {
-            client_ids.push(client as u64);
+            client_ids.push(u64::from(client));
             clocks.push(clock as u32);
         }
 

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -123,7 +123,7 @@ impl Decode for StateVector {
         while i < len {
             let client = decoder.read_var()?;
             let clock = decoder.read_var()?;
-            sv.insert(client, clock);
+            sv.insert(ClientID::new(client), clock);
             i += 1;
         }
         Ok(StateVector(sv))
@@ -134,7 +134,7 @@ impl Encode for StateVector {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         encoder.write_var(self.len());
         for (&client, &clock) in self.iter() {
-            encoder.write_var(client);
+            encoder.write_var(u64::from(client));
             encoder.write_var(clock);
         }
     }

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -786,10 +786,13 @@ impl Offset {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::moving::Assoc;
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::Encode;
     use crate::{Doc, IndexedSequence, StickyIndex, Text, TextRef, Transact};
+
+    const A: ClientID = ClientID::new(1);
 
     fn check_sticky_indexes(text: &TextRef) {
         // test if all positions are encoded and restored correctly
@@ -812,7 +815,7 @@ mod test {
 
     #[test]
     fn sticky_index_case_1() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
 
         {
@@ -829,7 +832,7 @@ mod test {
 
     #[test]
     fn sticky_index_case_2() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
 
         txt.insert(&mut doc.transact_mut(), 0, "abc");
@@ -838,7 +841,7 @@ mod test {
 
     #[test]
     fn sticky_index_case_3() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
 
         {
@@ -853,7 +856,7 @@ mod test {
 
     #[test]
     fn sticky_index_case_4() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
 
         txt.insert(&mut doc.transact_mut(), 0, "1");
@@ -862,7 +865,7 @@ mod test {
 
     #[test]
     fn sticky_index_case_5() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
 
         {
@@ -876,14 +879,14 @@ mod test {
 
     #[test]
     fn sticky_index_case_6() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
         check_sticky_indexes(&txt);
     }
 
     #[test]
     fn sticky_index_association_difference() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let txt = doc.get_or_insert_text("test");
 
         let mut txn = doc.transact_mut();

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -44,7 +44,7 @@ fn text_insert_delete() {
         97, 98, 193, 152, 234, 173, 126, 4, 152, 234, 173, 126, 0, 1, 129, 152, 234, 173, 126, 2,
         1, 132, 152, 234, 173, 126, 6, 2, 104, 105, 1, 152, 234, 173, 126, 2, 0, 3, 5, 2,
     ];
-    const CLIENT_ID: ClientID = 264992024;
+    const CLIENT_ID: ClientID = ClientID::new(264992024);
     let expected_blocks = vec![
         Item::new(
             ID::new(CLIENT_ID, 0),
@@ -141,7 +141,7 @@ fn map_set() {
            console.log(payload_v2);
         ```
     */
-    const CLIENT_ID: ClientID = 440166001;
+    const CLIENT_ID: ClientID = ClientID::new(440166001);
     let expected = vec![
         Item::new(
             ID::new(CLIENT_ID, 0),
@@ -195,7 +195,7 @@ fn array_insert() {
            console.log(payload_v2);
         ```
     */
-    const CLIENT_ID: ClientID = 2525665872;
+    const CLIENT_ID: ClientID = ClientID::new(2525665872);
     let expected = vec![Item::new(
         ID::new(CLIENT_ID, 0),
         None,
@@ -237,7 +237,7 @@ fn xml_fragment_insert() {
            console.log(payload_v2);
         ```
     */
-    const CLIENT_ID: ClientID = 2459881872;
+    const CLIENT_ID: ClientID = ClientID::new(2459881872);
     let expected = vec![
         Item::new(
             ID::new(CLIENT_ID, 0),
@@ -296,8 +296,8 @@ fn state_vector() {
     */
     let payload = &[2, 178, 219, 218, 44, 3, 190, 212, 225, 6, 2];
     let mut expected = StateVector::default();
-    expected.inc_by(14182974, 2);
-    expected.inc_by(93760946, 3);
+    expected.inc_by(14182974.into(), 2);
+    expected.inc_by(93760946.into(), 3);
 
     let sv = StateVector::decode_v1(payload).unwrap();
     assert_eq!(sv, expected);

--- a/yrs/src/tests/edit_traces_tests.rs
+++ b/yrs/src/tests/edit_traces_tests.rs
@@ -1,6 +1,10 @@
+use crate::test_utils::{get_thread_memory_usage, get_thread_num_allocations, TracingAlloc};
 use crate::tests::edit_traces::load_testing_data;
 use crate::{Doc, GetString, OffsetKind, Options, Text, Transact};
 use std::time::Instant;
+
+#[global_allocator]
+static A: TracingAlloc = TracingAlloc;
 
 #[test]
 fn edit_trace_automerge() {
@@ -59,6 +63,11 @@ fn test_editing_trace(fpath: &str) {
         }
     }
     let finish = Instant::now();
-    println!("elapsed: {}ms", (finish - start).as_millis());
+    let mem_usage = get_thread_memory_usage();
+    println!(
+        "elapsed: {}ms - mem used(bytes): {}",
+        (finish - start).as_millis(),
+        mem_usage
+    );
     assert_eq!(txt.get_string(&doc.transact()), data.end_content);
 }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1,4 +1,4 @@
-use crate::block::{Block, BlockPtr, Item, ItemContent, Prelim, ID};
+use crate::block::{Block, BlockPtr, ClientID, Item, ItemContent, Prelim, ID};
 use crate::block_store::{Snapshot, StateVector};
 use crate::doc::DocAddr;
 use crate::event::SubdocsEvent;
@@ -982,3 +982,10 @@ impl_origin!(i32);
 impl_origin!(i64);
 impl_origin!(i128);
 impl_origin!(isize);
+
+impl From<ClientID> for Origin {
+    fn from(client_id: ClientID) -> Self {
+        let v: u64 = client_id.into();
+        Origin(SmallVec::from_slice(&v.to_be_bytes()))
+    }
+}

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -528,9 +528,13 @@ mod test {
     use std::ops::Deref;
     use std::rc::Rc;
 
+    const A: ClientID = ClientID::new(1);
+    const B: ClientID = ClientID::new(2);
+    const C: ClientID = ClientID::new(3);
+
     #[test]
     fn push_back() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let a = doc.get_or_insert_array("array");
         let mut txn = doc.transact_mut();
 
@@ -544,7 +548,7 @@ mod test {
 
     #[test]
     fn push_front() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let a = doc.get_or_insert_array("array");
         let mut txn = doc.transact_mut();
 
@@ -558,7 +562,7 @@ mod test {
 
     #[test]
     fn insert() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let a = doc.get_or_insert_array("array");
         let mut txn = doc.transact_mut();
 
@@ -572,8 +576,8 @@ mod test {
 
     #[test]
     fn basic() {
-        let d1 = Doc::with_client_id(1);
-        let d2 = Doc::with_client_id(2);
+        let d1 = Doc::with_client_id(A);
+        let d2 = Doc::with_client_id(B);
 
         let a1 = d1.get_or_insert_array("array");
 
@@ -592,7 +596,7 @@ mod test {
 
     #[test]
     fn len() {
-        let d = Doc::with_client_id(1);
+        let d = Doc::with_client_id(A);
         let a = d.get_or_insert_array("array");
 
         {
@@ -635,7 +639,7 @@ mod test {
 
     #[test]
     fn remove_insert() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let a1 = d1.get_or_insert_array("array");
 
         let mut t1 = d1.transact_mut();
@@ -645,8 +649,8 @@ mod test {
 
     #[test]
     fn insert_3_elements_try_re_get() {
-        let d1 = Doc::with_client_id(1);
-        let d2 = Doc::with_client_id(2);
+        let d1 = Doc::with_client_id(A);
+        let d2 = Doc::with_client_id(B);
         let a1 = d1.get_or_insert_array("array");
         {
             let mut t1 = d1.transact_mut();
@@ -674,20 +678,20 @@ mod test {
 
     #[test]
     fn concurrent_insert_with_3_conflicts() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let a = d1.get_or_insert_array("array");
         {
             let mut txn = d1.transact_mut();
             a.insert(&mut txn, 0, 0);
         }
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         {
             let mut txn = d1.transact_mut();
             a.insert(&mut txn, 0, 1);
         }
 
-        let d3 = Doc::with_client_id(3);
+        let d3 = Doc::with_client_id(C);
         {
             let mut txn = d1.transact_mut();
             a.insert(&mut txn, 0, 2);
@@ -710,14 +714,14 @@ mod test {
 
     #[test]
     fn concurrent_insert_remove_with_3_conflicts() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         {
             let a = d1.get_or_insert_array("array");
             let mut txn = d1.transact_mut();
             a.insert_range(&mut txn, 0, ["x", "y", "z"]);
         }
-        let d2 = Doc::with_client_id(2);
-        let d3 = Doc::with_client_id(3);
+        let d2 = Doc::with_client_id(B);
+        let d3 = Doc::with_client_id(C);
 
         exchange_updates(&[&d1, &d2, &d3]);
 
@@ -749,15 +753,15 @@ mod test {
 
     #[test]
     fn insertions_in_late_sync() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         {
             let a = d1.get_or_insert_array("array");
             let mut txn = d1.transact_mut();
             a.push_back(&mut txn, "x");
             a.push_back(&mut txn, "y");
         }
-        let d2 = Doc::with_client_id(2);
-        let d3 = Doc::with_client_id(3);
+        let d2 = Doc::with_client_id(B);
+        let d3 = Doc::with_client_id(C);
 
         exchange_updates(&[&d1, &d2, &d3]);
 
@@ -786,14 +790,14 @@ mod test {
 
     #[test]
     fn removals_in_late_sync() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         {
             let a = d1.get_or_insert_array("array");
             let mut txn = d1.transact_mut();
             a.push_back(&mut txn, "x");
             a.push_back(&mut txn, "y");
         }
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
 
         exchange_updates(&[&d1, &d2]);
 
@@ -817,7 +821,7 @@ mod test {
 
     #[test]
     fn insert_then_merge_delete_on_sync() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         {
             let a = d1.get_or_insert_array("array");
             let mut txn = d1.transact_mut();
@@ -825,7 +829,7 @@ mod test {
             a.push_back(&mut txn, "y");
             a.push_back(&mut txn, "z");
         }
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
 
         exchange_updates(&[&d1, &d2]);
 
@@ -846,7 +850,7 @@ mod test {
 
     #[test]
     fn iter_array_containing_types() {
-        let d = Doc::with_client_id(1);
+        let d = Doc::with_client_id(A);
         let a = d.get_or_insert_array("arr");
         let mut txn = d.transact_mut();
         for i in 0..10 {
@@ -867,7 +871,7 @@ mod test {
 
     #[test]
     fn insert_and_remove_events() {
-        let d = Doc::with_client_id(1);
+        let d = Doc::with_client_id(A);
         let mut array = d.get_or_insert_array("array");
         let happened = Rc::new(Cell::new(false));
         let happened_clone = happened.clone();
@@ -908,7 +912,7 @@ mod test {
 
     #[test]
     fn insert_and_remove_event_changes() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let mut array = d1.get_or_insert_array("array");
         let added = Rc::new(RefCell::new(None));
         let removed = Rc::new(RefCell::new(None));
@@ -929,7 +933,7 @@ mod test {
         }
         assert_eq!(
             added.borrow_mut().take(),
-            Some(HashSet::from([ID::new(1, 0), ID::new(1, 1)]))
+            Some(HashSet::from([ID::new(A, 0), ID::new(A, 1)]))
         );
         assert_eq!(removed.borrow_mut().take(), Some(HashSet::new()));
         assert_eq!(
@@ -947,7 +951,7 @@ mod test {
         assert_eq!(added.borrow_mut().take(), Some(HashSet::new()));
         assert_eq!(
             removed.borrow_mut().take(),
-            Some(HashSet::from([ID::new(1, 0)]))
+            Some(HashSet::from([ID::new(A, 0)]))
         );
         assert_eq!(delta.borrow_mut().take(), Some(vec![Change::Removed(1)]));
 
@@ -957,7 +961,7 @@ mod test {
         }
         assert_eq!(
             added.borrow_mut().take(),
-            Some(HashSet::from([ID::new(1, 2)]))
+            Some(HashSet::from([ID::new(A, 2)]))
         );
         assert_eq!(removed.borrow_mut().take(), Some(HashSet::new()));
         assert_eq!(
@@ -968,7 +972,7 @@ mod test {
             ])
         );
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let mut array2 = d2.get_or_insert_array("array");
         let (added_c, removed_c, delta_c) = (added.clone(), removed.clone(), delta.clone());
         let _sub = array2.observe(move |txn, e| {
@@ -989,7 +993,7 @@ mod test {
 
         assert_eq!(
             added.borrow_mut().take(),
-            Some(HashSet::from([ID::new(1, 1)]))
+            Some(HashSet::from([ID::new(A, 1)]))
         );
         assert_eq!(removed.borrow_mut().take(), Some(HashSet::new()));
         assert_eq!(
@@ -1003,8 +1007,8 @@ mod test {
 
     #[test]
     fn target_on_local_and_remote() {
-        let d1 = Doc::with_client_id(1);
-        let d2 = Doc::with_client_id(2);
+        let d1 = Doc::with_client_id(A);
+        let d2 = Doc::with_client_id(B);
         let mut a1 = d1.get_or_insert_array("array");
         let mut a2 = d2.get_or_insert_array("array");
 
@@ -1029,6 +1033,7 @@ mod test {
         assert_eq!(c2.borrow_mut().take(), Some(a2));
     }
 
+    use crate::block::ClientID;
     use crate::transaction::ReadTxn;
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encoder, EncoderV1};
@@ -1168,7 +1173,7 @@ mod test {
 
     #[test]
     fn get_at_removed_index() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let a1 = d1.get_or_insert_array("array");
         let mut t1 = d1.transact_mut();
 
@@ -1181,7 +1186,7 @@ mod test {
 
     #[test]
     fn observe_deep_event_order() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let mut array = doc.get_or_insert_array("array");
 
         let paths = Rc::new(RefCell::new(Vec::new()));
@@ -1211,10 +1216,10 @@ mod test {
 
     #[test]
     fn move_1() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let mut a1 = d1.get_or_insert_array("array");
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let mut a2 = d2.get_or_insert_array("array");
 
         let e1: Rc<RefCell<Vec<Change>>> = Rc::new(RefCell::new(Vec::default()));
@@ -1263,10 +1268,10 @@ mod test {
 
     #[test]
     fn move_2() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let mut a1 = d1.get_or_insert_array("array");
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let mut a2 = d2.get_or_insert_array("array");
 
         let e1: Rc<RefCell<Vec<Change>>> = Rc::new(RefCell::new(Vec::default()));
@@ -1326,10 +1331,10 @@ mod test {
 
     #[test]
     fn move_cycles() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let a1 = d1.get_or_insert_array("array");
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let a2 = d2.get_or_insert_array("array");
 
         a1.insert_range(&mut d1.transact_mut(), 0, [1, 2, 3, 4]);
@@ -1351,7 +1356,7 @@ mod test {
     #[test]
     #[ignore] //TODO: investigate (see: https://github.com/y-crdt/y-crdt/pull/266)
     fn move_range_to() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let arr = doc.get_or_insert_array("array");
         // Move 1-2 to 4
         {
@@ -1577,7 +1582,7 @@ mod test {
         use std::sync::{Arc, RwLock};
         use std::thread::{sleep, spawn};
 
-        let doc = Arc::new(RwLock::new(Doc::with_client_id(1)));
+        let doc = Arc::new(RwLock::new(Doc::with_client_id(A)));
 
         let d2 = doc.clone();
         let h2 = spawn(move || {
@@ -1618,7 +1623,7 @@ mod test {
     fn move_last_elem_iter() {
         // https://github.com/y-crdt/y-crdt/issues/186
 
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let array = doc.get_or_insert_array("array");
         let mut txn = array.transact_mut();
         array.insert_range(&mut txn, 0, [1, 2, 3]);

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -424,6 +424,7 @@ impl MapEvent {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::test_utils::{exchange_updates, run_scenario};
     use crate::transaction::ReadTxn;
     use crate::types::text::TextPrelim;
@@ -445,13 +446,18 @@ mod test {
     use std::rc::Rc;
     use std::time::Duration;
 
+    const A: ClientID = ClientID::new(1);
+    const B: ClientID = ClientID::new(2);
+    const C: ClientID = ClientID::new(3);
+    const D: ClientID = ClientID::new(4);
+
     #[test]
     fn map_basic() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
@@ -504,7 +510,7 @@ mod test {
 
     #[test]
     fn map_get_set() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
@@ -513,7 +519,7 @@ mod test {
 
         let update = t1.encode_state_as_update_v1(&StateVector::default());
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
@@ -528,11 +534,11 @@ mod test {
 
     #[test]
     fn map_get_set_sync_with_conflicts() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
@@ -551,7 +557,7 @@ mod test {
 
     #[test]
     fn map_len_remove() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
@@ -577,7 +583,7 @@ mod test {
 
     #[test]
     fn map_clear() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let m1 = d1.get_or_insert_map("map");
         let mut t1 = d1.transact_mut();
 
@@ -589,7 +595,7 @@ mod test {
         assert_eq!(m1.get(&t1, &"key1".to_owned()), None);
         assert_eq!(m1.get(&t1, &"key2".to_owned()), None);
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let m2 = d2.get_or_insert_map("map");
         let mut t2 = d2.transact_mut();
 
@@ -603,10 +609,10 @@ mod test {
 
     #[test]
     fn map_clear_sync() {
-        let d1 = Doc::with_client_id(1);
-        let d2 = Doc::with_client_id(2);
-        let d3 = Doc::with_client_id(3);
-        let d4 = Doc::with_client_id(4);
+        let d1 = Doc::with_client_id(A);
+        let d2 = Doc::with_client_id(B);
+        let d3 = Doc::with_client_id(C);
+        let d4 = Doc::with_client_id(D);
 
         {
             let m1 = d1.get_or_insert_map("map");
@@ -669,9 +675,9 @@ mod test {
 
     #[test]
     fn map_get_set_with_3_way_conflicts() {
-        let d1 = Doc::with_client_id(1);
-        let d2 = Doc::with_client_id(2);
-        let d3 = Doc::with_client_id(3);
+        let d1 = Doc::with_client_id(A);
+        let d2 = Doc::with_client_id(B);
+        let d3 = Doc::with_client_id(C);
 
         {
             let m1 = d1.get_or_insert_map("map");
@@ -704,10 +710,10 @@ mod test {
 
     #[test]
     fn map_get_set_remove_with_3_way_conflicts() {
-        let d1 = Doc::with_client_id(1);
-        let d2 = Doc::with_client_id(2);
-        let d3 = Doc::with_client_id(3);
-        let d4 = Doc::with_client_id(4);
+        let d1 = Doc::with_client_id(A);
+        let d2 = Doc::with_client_id(B);
+        let d3 = Doc::with_client_id(C);
+        let d4 = Doc::with_client_id(D);
 
         {
             let m1 = d1.get_or_insert_map("map");
@@ -760,7 +766,7 @@ mod test {
 
     #[test]
     fn insert_and_remove_events() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let mut m1 = d1.get_or_insert_map("map");
 
         let entries = Rc::new(RefCell::new(None));
@@ -847,7 +853,7 @@ mod test {
         assert_eq!(entries.take(), Some(HashMap::new()));
 
         // copy updates over
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let mut m2 = d2.get_or_insert_map("map");
 
         let entries = Rc::new(RefCell::new(None));
@@ -937,7 +943,7 @@ mod test {
 
     #[test]
     fn observe_deep() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let mut map = doc.get_or_insert_map("map");
 
         let paths = Rc::new(RefCell::new(vec![]));
@@ -994,7 +1000,7 @@ mod test {
         use std::sync::{Arc, RwLock};
         use std::thread::{sleep, spawn};
 
-        let doc = Arc::new(RwLock::new(Doc::with_client_id(1)));
+        let doc = Arc::new(RwLock::new(Doc::with_client_id(A)));
 
         let d2 = doc.clone();
         let h2 = spawn(move || {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -1196,6 +1196,7 @@ impl XmlEvent {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::transaction::ReadTxn;
     use crate::types::xml::{Xml, XmlFragment, XmlNode};
     use crate::types::{Attrs, Change, EntryChange, Value};
@@ -1210,16 +1211,19 @@ mod test {
     use std::collections::HashMap;
     use std::rc::Rc;
 
+    const A: ClientID = ClientID::new(1);
+    const B: ClientID = ClientID::new(2);
+
     #[test]
     fn insert_attribute() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let f = d1.get_or_insert_xml_fragment("xml");
         let mut t1 = d1.transact_mut();
         let xml1 = f.push_back(&mut t1, XmlElementPrelim::empty("div"));
         xml1.insert_attribute(&mut t1, "height", 10.to_string());
         assert_eq!(xml1.get_attribute(&t1, "height"), Some("10".to_string()));
 
-        let d2 = Doc::with_client_id(1);
+        let d2 = Doc::with_client_id(A);
         let f = d2.get_or_insert_xml_fragment("xml");
         let mut t2 = d2.transact_mut();
         let xml2 = f.push_back(&mut t2, XmlElementPrelim::empty("div"));
@@ -1230,7 +1234,7 @@ mod test {
 
     #[test]
     fn tree_walker() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let root = doc.get_or_insert_xml_fragment("xml");
         let mut txn = doc.transact_mut();
         /*
@@ -1263,7 +1267,7 @@ mod test {
 
     #[test]
     fn text_attributes() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let f = doc.get_or_insert_xml_fragment("test");
         let mut txn = doc.transact_mut();
         let txt = f.push_back(&mut txn, XmlTextPrelim::new(""));
@@ -1276,7 +1280,7 @@ mod test {
 
     #[test]
     fn siblings() {
-        let doc = Doc::with_client_id(1);
+        let doc = Doc::with_client_id(A);
         let root = doc.get_or_insert_xml_fragment("root");
         let mut txn = doc.transact_mut();
         let first = root.push_back(&mut txn, XmlTextPrelim::new("hello"));
@@ -1307,7 +1311,7 @@ mod test {
 
     #[test]
     fn serialization() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let r1 = d1.get_or_insert_xml_fragment("root");
         let mut t1 = d1.transact_mut();
         let _first = r1.push_back(&mut t1, XmlTextPrelim::new("hello"));
@@ -1318,7 +1322,7 @@ mod test {
 
         let u1 = t1.encode_state_as_update_v1(&StateVector::default());
 
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let r2 = d2.get_or_insert_xml_fragment("root");
         let mut t2 = d2.transact_mut();
 
@@ -1328,7 +1332,7 @@ mod test {
 
     #[test]
     fn serialization_compatibility() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let r1 = d1.get_or_insert_xml_fragment("root");
         let mut t1 = d1.transact_mut();
         let _first = r1.push_back(&mut t1, XmlTextPrelim::new("hello"));
@@ -1356,7 +1360,7 @@ mod test {
 
     #[test]
     fn event_observers() {
-        let d1 = Doc::with_client_id(1);
+        let d1 = Doc::with_client_id(A);
         let mut xml = d1.get_or_insert_xml_element("test");
 
         let attributes = Rc::new(RefCell::new(None));
@@ -1446,7 +1450,7 @@ mod test {
         assert_eq!(attributes.borrow_mut().take(), Some(HashMap::new()));
 
         // copy updates over
-        let d2 = Doc::with_client_id(2);
+        let d2 = Doc::with_client_id(B);
         let mut xml2 = d2.get_or_insert_xml_element("test");
 
         let attributes = Rc::new(RefCell::new(None));

--- a/yrs/src/updates/decoder.rs
+++ b/yrs/src/updates/decoder.rs
@@ -85,9 +85,9 @@ impl<'a> DecoderV1<'a> {
     }
 
     fn read_id(&mut self) -> Result<ID, Error> {
-        let client: u32 = self.read_var()?;
+        let client: ClientID = self.read_var()?;
         let clock = self.read_var()?;
-        Ok(ID::new(client as ClientID, clock))
+        Ok(ID::new(client, clock))
     }
 }
 
@@ -143,8 +143,8 @@ impl<'a> Decoder for DecoderV1<'a> {
 
     #[inline]
     fn read_client(&mut self) -> Result<ClientID, Error> {
-        let client: u32 = self.cursor.read_var()?;
-        Ok(client as ClientID)
+        let client: ClientID = self.cursor.read_var()?;
+        Ok(client)
     }
 
     #[inline]
@@ -311,20 +311,20 @@ impl<'a> Decoder for DecoderV2<'a> {
 
     fn read_left_id(&mut self) -> Result<ID, Error> {
         Ok(ID::new(
-            self.client_decoder.read_u64()? as ClientID,
+            ClientID::new(self.client_decoder.read_u64()?),
             self.left_clock_decoder.read_u32()?,
         ))
     }
 
     fn read_right_id(&mut self) -> Result<ID, Error> {
         Ok(ID::new(
-            self.client_decoder.read_u64()? as ClientID,
+            ClientID::new(self.client_decoder.read_u64()?),
             self.right_clock_decoder.read_u32()?,
         ))
     }
 
     fn read_client(&mut self) -> Result<ClientID, Error> {
-        Ok(self.client_decoder.read_u64()? as ClientID)
+        Ok(ClientID::new(self.client_decoder.read_u64()?))
     }
 
     fn read_info(&mut self) -> Result<u8, Error> {

--- a/yrs/src/updates/encoder.rs
+++ b/yrs/src/updates/encoder.rs
@@ -278,18 +278,18 @@ impl Encoder for EncoderV2 {
     }
 
     fn write_left_id(&mut self, id: &ID) {
-        self.client_encoder.write_u64(id.client as u64);
+        self.client_encoder.write_u64(id.client.into());
         self.left_clock_encoder.write_u32(id.clock)
     }
 
     fn write_right_id(&mut self, id: &ID) {
-        self.client_encoder.write_u64(id.client as u64);
+        self.client_encoder.write_u64(id.client.into());
         self.right_clock_encoder.write_u32(id.clock)
     }
 
     #[inline]
     fn write_client(&mut self, client: ClientID) {
-        self.client_encoder.write_u64(client as u64)
+        self.client_encoder.write_u64(client.into())
     }
 
     #[inline]


### PR DESCRIPTION
This is an experiment where we're instructing Rust compiler to make better use of `ClientID`. Atm. it's just alias for `u64`. The thing is that when used as is it causes an explosion of memory usage. Consider following calculations:

```rust
type ClientID = u64; // mem. used 8B

// ID - memory used: 16B (8B for client_id, 4B for clock and 4B padding)
struct ID { client_id: ClientID, clock: u32 }
```

For `Option<ID>` each such structure uses **24B** (Option case adds 8B). These are all assuming x64 architecture. Now each Item uses two `Option<ID>` for it's neighbors, and `ID` for itself: 24 + 24 + 16 = **64B** just for these 3 fields.

One issue is that Option adds 8 bytes of extra overhead, even though 1bit should be sufficient - Rust does that since we're talking about value types. However Rust also has concept of `NonZeroU32`/`NonZeroU64` types, which are basically `u32`/`u64` that are guaranteed to never be equal to 0. Rust compiler knowing that can specialize `0` to represent `None` in any struct that defines field with such type: our `ID` included. This reduces the size of `Option<ID>` by 8 bytes (or at least 16 bytes per `Item`).

Furthermore if we use 31bit client IDs, we can also remove padding added by the compiler, which means that for `ClientID = NonZeroU32`, corresponding `Option<ID>` size drops from **24B** &rarr; **8B** (1/3 of its current size).

# Numbers

What does that mean in overall perspective? I'm running our trace editing tests (they are traces of real-life users editing their documents, taken from Sephs Gentle repository) with tracing allocator turned on. Here are the numbers:

Current main (our baseline):

|                 | elapsed (ms) | mem used (bytes) |
|-----------------|---------|------------------|
| automerge-paper | 16016 | 2446298 |
| friendsforever_flat | 56 | 672210 |
| seph-blog1 | 2025 | 2187595 |
| sveltecomponent| 9611 | 3136457 |
| rustcode | 339 | 991209 |

`ClientID` equal to `NonZeroU64` with highest bit set to make sure that ClientID zero will still work. The CPU time dropped, but at the same time overall memory used also dropped by 11%.

|                 | elapsed (ms) | mem used (bytes) |
|-----------------|---------|------------------|
| automerge-paper | 18079 | 2182994 |
| friendsforever_flat | 65 | 597402 |
| seph-blog1 | 2698 | 1946539 |
| sveltecomponent| 10681 | 2774249 |
| rustcode | 378 | 880161 |

`ClientID` equal to `NonZeroU32` (31 bit numbers) with highest bit set to make sure that ClientID zero will still work. The CPU time has not changed - probably since we add time on applying bit masks, but we get it in return since passing IDs by value can now be done in a single register mov - but at the same time overall memory used also dropped by 25-26%!

|                 | elapsed (ms) | mem used (bytes) |
|-----------------|---------|------------------|
| automerge-paper | 16065| 1831914 |
| friendsforever_flat | 56 | 497650 |
| seph-blog1 | 2046| 1625123 |
| sveltecomponent| 9615 | 2291297 |
| rustcode | 332| 732089 |