### PR TITLE
lib0 binary encoding: encode small ints as integer not big int

### DIFF
--- a/lib0/src/any.rs
+++ b/lib0/src/any.rs
@@ -140,9 +140,18 @@ impl Any {
                 }
             }
             Any::BigInt(num) => {
-                // TYPE 122: BigInt
-                encoder.write_u8(122);
-                encoder.write_i64(*num)
+                let num = *num;
+                if num <= crate::number::I64_MAX_SAFE_INTEGER
+                    && num >= crate::number::I64_MIN_SAFE_INTEGER
+                {
+                    // TYPE 125: INTEGER
+                    encoder.write_u8(125);
+                    encoder.write_var(num)
+                } else {
+                    // TYPE 122: BigInt
+                    encoder.write_u8(122);
+                    encoder.write_i64(num)
+                }
             }
             Any::Array(arr) => {
                 // TYPE 117: Array

--- a/lib0/src/json_parser.rs
+++ b/lib0/src/json_parser.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::iter::Peekable;
 
-use crate::any::Any;
+use crate::any::{Any, Number};
 
 #[derive(Debug)]
 pub struct JsonParseError {
@@ -155,7 +155,7 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
         let mut m = HashMap::new();
         loop {
             let key = match self.parse_any()? {
-                Any::String(s) => s.into_string(),
+                Any::String(s) => s,
                 v => return self.err(format!("Key of object must be string but found {:?}", v)),
             };
 
@@ -189,14 +189,14 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
 
         if self.peek()? == ']' {
             self.consume().unwrap();
-            return Ok(Any::Array(Box::new([])));
+            return Ok(Any::Array(Vec::new()));
         }
 
         let mut v = vec![self.parse_any()?];
         loop {
             match self.consume()? {
                 ',' => {}
-                ']' => return Ok(Any::Array(v.into_boxed_slice())),
+                ']' => return Ok(Any::Array(v)),
                 c => {
                     return self.err(format!(
                         "',' or ']' is expected for array but actually found '{}'",
@@ -260,7 +260,7 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
                 },
                 '"' => {
                     self.push_utf16(&mut s, &mut utf16)?;
-                    return Ok(Any::String(s.into_boxed_str()));
+                    return Ok(Any::String(s));
                 }
                 // Note: c.is_control() is not available here because JSON accepts 0x7f (DEL) in
                 // string literals but 0x7f is control character.
@@ -395,9 +395,13 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
             }
         }
 
-        match s.parse::<f64>() {
-            Ok(n) => Ok(Any::Number(if neg { -n } else { n })),
-            Err(err) => self.err(format!("Invalid number literal '{}': {}", s, err)),
+        if let Ok(n) = s.parse::<i64>() {
+            Ok(Any::Number((if neg { -n } else { n }).into()))
+        } else {
+            match s.parse::<f64>() {
+                Ok(n) => Ok(Any::Number(Number::Float(if neg { -n } else { n }))),
+                Err(err) => self.err(format!("Invalid number literal '{}': {}", s, err)),
+            }
         }
     }
 

--- a/lib0/src/json_parser.rs
+++ b/lib0/src/json_parser.rs
@@ -155,7 +155,7 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
         let mut m = HashMap::new();
         loop {
             let key = match self.parse_any()? {
-                Any::String(s) => s,
+                Any::String(s) => s.into(),
                 v => return self.err(format!("Key of object must be string but found {:?}", v)),
             };
 
@@ -171,7 +171,7 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
 
             match self.consume()? {
                 ',' => {}
-                '}' => return Ok(Any::Map(Box::new(m))),
+                '}' => return Ok(Any::Map(Box::from(m))),
                 c => {
                     return self.err(format!(
                         "',' or '}}' is expected for object but actually found '{}'",
@@ -189,14 +189,14 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
 
         if self.peek()? == ']' {
             self.consume().unwrap();
-            return Ok(Any::Array(Vec::new()));
+            return Ok(Any::Array(Box::default()));
         }
 
         let mut v = vec![self.parse_any()?];
         loop {
             match self.consume()? {
                 ',' => {}
-                ']' => return Ok(Any::Array(v)),
+                ']' => return Ok(Any::Array(v.into_boxed_slice())),
                 c => {
                     return self.err(format!(
                         "',' or ']' is expected for array but actually found '{}'",
@@ -260,7 +260,7 @@ impl<I: Iterator<Item = char>> JsonParser<I> {
                 },
                 '"' => {
                     self.push_utf16(&mut s, &mut utf16)?;
-                    return Ok(Any::String(s));
+                    return Ok(Any::String(Box::from(s)));
                 }
                 // Note: c.is_control() is not available here because JSON accepts 0x7f (DEL) in
                 // string literals but 0x7f is control character.

--- a/lib0/src/macros.rs
+++ b/lib0/src/macros.rs
@@ -228,7 +228,7 @@ macro_rules! any_internal {
 #[doc(hidden)]
 macro_rules! any_internal_array {
     ($($content:tt)*) => {
-        std::boxed::Box::from([$($content)*])
+        std::vec::Vec::from([$($content)*])
     };
 }
 

--- a/lib0/src/macros.rs
+++ b/lib0/src/macros.rs
@@ -228,7 +228,7 @@ macro_rules! any_internal {
 #[doc(hidden)]
 macro_rules! any_internal_array {
     ($($content:tt)*) => {
-        std::vec::Vec::from([$($content)*])
+        std::boxed::Box::from([$($content)*])
     };
 }
 

--- a/lib0/src/number.rs
+++ b/lib0/src/number.rs
@@ -4,12 +4,6 @@ use crate::error::Error;
 use std::convert::TryInto;
 use std::mem::size_of;
 
-pub const I64_MAX_SAFE_INTEGER: i64 = i64::pow(2, 53) - 1;
-pub const I64_MIN_SAFE_INTEGER: i64 = -I64_MAX_SAFE_INTEGER;
-
-pub const F64_MAX_SAFE_INTEGER: f64 = I64_MAX_SAFE_INTEGER as f64;
-pub const F64_MIN_SAFE_INTEGER: f64 = -F64_MAX_SAFE_INTEGER;
-
 pub trait VarInt: Sized + Copy {
     fn write<W: Write>(&self, w: &mut W);
     fn read<R: Read>(r: &mut R) -> Result<Self, Error>;

--- a/lib0/src/number.rs
+++ b/lib0/src/number.rs
@@ -4,7 +4,10 @@ use crate::error::Error;
 use std::convert::TryInto;
 use std::mem::size_of;
 
-pub const F64_MAX_SAFE_INTEGER: f64 = (i64::pow(2, 53) - 1) as f64;
+pub const I64_MAX_SAFE_INTEGER: i64 = i64::pow(2, 53) - 1;
+pub const I64_MIN_SAFE_INTEGER: i64 = -I64_MAX_SAFE_INTEGER;
+
+pub const F64_MAX_SAFE_INTEGER: f64 = I64_MAX_SAFE_INTEGER as f64;
 pub const F64_MIN_SAFE_INTEGER: f64 = -F64_MAX_SAFE_INTEGER;
 
 pub trait VarInt: Sized + Copy {

--- a/lib0/tests/encoding_test.rs
+++ b/lib0/tests/encoding_test.rs
@@ -8,17 +8,16 @@ pub fn arb_any() -> impl Strategy<Value = Any> {
         Just(Any::Null),
         Just(Any::Undefined),
         any::<bool>().prop_map(Any::Bool),
-        any::<f64>().prop_map(Any::Number),
-        any::<i64>().prop_map(|i| Any::Number(i as f64)),
+        any::<f64>().prop_map(Any::from),
+        any::<i64>().prop_map(Any::from),
         any::<String>().prop_map(|i| Any::String(i.into())),
-        any::<Box<[u8]>>().prop_map(Any::Buffer),
+        any::<Vec<u8>>().prop_map(Any::Buffer),
     ]
     .boxed();
 
     leaf.prop_recursive(8, 256, 10, |inner| {
         prop_oneof![
-            prop::collection::vec(inner.clone(), 0..10)
-                .prop_map(|v| Any::Array(v.into_boxed_slice())),
+            prop::collection::vec(inner.clone(), 0..10).prop_map(|v| Any::Array(v)),
             prop::collection::hash_map(".*", inner, 0..10).prop_map(|v| Any::Map(Box::new(v))),
         ]
     })

--- a/lib0/tests/encoding_test.rs
+++ b/lib0/tests/encoding_test.rs
@@ -10,14 +10,14 @@ pub fn arb_any() -> impl Strategy<Value = Any> {
         any::<bool>().prop_map(Any::Bool),
         any::<f64>().prop_map(Any::from),
         any::<i64>().prop_map(Any::from),
-        any::<String>().prop_map(|i| Any::String(i.into())),
-        any::<Vec<u8>>().prop_map(Any::Buffer),
+        any::<String>().prop_map(Any::from),
+        any::<Vec<u8>>().prop_map(Any::from),
     ]
     .boxed();
 
     leaf.prop_recursive(8, 256, 10, |inner| {
         prop_oneof![
-            prop::collection::vec(inner.clone(), 0..10).prop_map(|v| Any::Array(v)),
+            prop::collection::vec(inner.clone(), 0..10).prop_map(Any::from),
             prop::collection::hash_map(".*", inner, 0..10).prop_map(|v| Any::Map(Box::new(v))),
         ]
     })

--- a/lib0/tests/json_test.rs
+++ b/lib0/tests/json_test.rs
@@ -47,12 +47,15 @@ mod test {
 
     #[test]
     fn json_any_array() {
-        let expected = Any::Array(vec![
-            Any::Number((-10.1f64).into()),
-            Any::String("hello \\world".into()),
-            Any::Null,
-            Any::Bool(true),
-        ]);
+        let expected = Any::Array(
+            vec![
+                Any::Number((-10.1f64).into()),
+                Any::String("hello \\world".into()),
+                Any::Null,
+                Any::Bool(true),
+            ]
+            .into(),
+        );
         let actual = roundtrip(&expected);
         assert_eq!(actual, expected);
     }
@@ -64,7 +67,10 @@ mod test {
             ("b".to_string(), Any::String("hello world".into())),
             ("c".to_string(), Any::Null),
             ("d".to_string(), Any::Bool(true)),
-            ("e".to_string(), Any::Array(vec![Any::String("abc".into())])),
+            (
+                "e".to_string(),
+                Any::Array(vec![Any::String("abc".into())].into()),
+            ),
             (
                 "f".to_string(),
                 Any::Map(Box::new(HashMap::from([(

--- a/lib0/tests/json_test.rs
+++ b/lib0/tests/json_test.rs
@@ -30,7 +30,7 @@ mod test {
     #[test]
     fn json_any_number() {
         for v in [1.8, -1.5, 0.2, 0.25, 2349464814556456.4] {
-            let expected = Any::Number(v);
+            let expected = Any::Number(v.into());
             let actual = roundtrip(&expected);
             assert_eq!(actual, expected);
         }
@@ -47,15 +47,12 @@ mod test {
 
     #[test]
     fn json_any_array() {
-        let expected = Any::Array(
-            vec![
-                Any::Number(-10.0),
-                Any::String("hello \\world".into()),
-                Any::Null,
-                Any::Bool(true),
-            ]
-            .into_boxed_slice(),
-        );
+        let expected = Any::Array(vec![
+            Any::Number((-10.1f64).into()),
+            Any::String("hello \\world".into()),
+            Any::Null,
+            Any::Bool(true),
+        ]);
         let actual = roundtrip(&expected);
         assert_eq!(actual, expected);
     }
@@ -63,19 +60,16 @@ mod test {
     #[test]
     fn json_any_map() {
         let expected = Any::Map(Box::new(HashMap::from([
-            ("a".to_string(), Any::Number(-10.2)),
+            ("a".to_string(), Any::from(-10.2)),
             ("b".to_string(), Any::String("hello world".into())),
             ("c".to_string(), Any::Null),
             ("d".to_string(), Any::Bool(true)),
-            (
-                "e".to_string(),
-                Any::Array(vec![Any::String("abc".into())].into_boxed_slice()),
-            ),
+            ("e".to_string(), Any::Array(vec![Any::String("abc".into())])),
             (
                 "f".to_string(),
                 Any::Map(Box::new(HashMap::from([(
                     "fa".to_string(),
-                    Any::Number(1.5),
+                    Any::from(1.5),
                 )]))),
             ),
         ])));

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -2451,7 +2451,7 @@ impl YInput {
         unsafe {
             if tag == Y_JSON_STR {
                 let str: String = CStr::from_ptr(self.value.str).to_str().unwrap().into();
-                Any::String(str)
+                Any::from(str)
             } else if tag == Y_JSON_ARR {
                 let ptr = self.value.values;
                 let mut dst: Vec<Any> = Vec::with_capacity(self.len as usize);
@@ -2462,7 +2462,7 @@ impl YInput {
                     dst.push(any);
                     i += 1;
                 }
-                Any::Array(dst)
+                Any::Array(dst.into())
             } else if tag == Y_JSON_MAP {
                 let mut dst = HashMap::with_capacity(self.len as usize);
                 let keys = self.value.map.keys;
@@ -2492,7 +2492,7 @@ impl YInput {
                 let slice =
                     std::slice::from_raw_parts(self.value.buf as *mut u8, self.len as usize);
                 let buf = Vec::from(slice);
-                Any::Buffer(buf)
+                Any::Buffer(buf.into())
             } else if tag == Y_DOC {
                 Any::Undefined
             } else {
@@ -2776,14 +2776,14 @@ impl From<Any> for YOutput {
                     tag: Y_JSON_STR,
                     len: v.len() as u32,
                     value: YOutputContent {
-                        str: CString::new(v).unwrap().into_raw(),
+                        str: CString::new(String::from(v)).unwrap().into_raw(),
                     },
                 },
                 Any::Buffer(v) => YOutput {
                     tag: Y_JSON_BUF,
                     len: v.len() as u32,
                     value: YOutputContent {
-                        buf: Box::into_raw(v.clone().into_boxed_slice()) as *mut _,
+                        buf: Box::into_raw(v.clone()) as *mut _,
                     },
                 },
                 Any::Array(v) => {

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -1787,7 +1787,7 @@ impl ItemContent {
                     let chars = v.chars().skip(offset).take(buf.len());
                     let mut j = 0;
                     for c in chars {
-                        buf[j] = Value::Any(Any::String(c.to_string()));
+                        buf[j] = Value::Any(Any::from(c.to_string()));
                         j += 1;
                     }
                     j
@@ -1796,15 +1796,15 @@ impl ItemContent {
                     let mut i = offset;
                     let mut j = 0;
                     while i < elements.len() && j < buf.len() {
-                        let elem = &elements[i];
-                        buf[j] = Value::Any(Any::String(elem.clone()));
+                        let elem = elements[i].as_str();
+                        buf[j] = Value::Any(Any::from(elem));
                         i += 1;
                         j += 1;
                     }
                     j
                 }
                 ItemContent::Binary(v) => {
-                    buf[0] = Value::Any(Any::Buffer(v.clone()));
+                    buf[0] = Value::Any(Any::Buffer(v.clone().into_boxed_slice()));
                     1
                 }
                 ItemContent::Doc(_, doc) => {
@@ -1844,14 +1844,16 @@ impl ItemContent {
     pub fn get_first(&self) -> Option<Value> {
         match self {
             ItemContent::Any(v) => v.first().map(|a| Value::Any(a.clone())),
-            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone()))),
+            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone().into_boxed_slice()))),
             ItemContent::Deleted(_) => None,
             ItemContent::Move(_) => None,
             ItemContent::Doc(_, v) => Some(Value::YDoc(v.clone())),
-            ItemContent::JSON(v) => v.first().map(|v| Value::Any(Any::String(v.clone()))),
+            ItemContent::JSON(v) => v
+                .first()
+                .map(|v| Value::Any(Any::String(v.clone().into_boxed_str()))),
             ItemContent::Embed(v) => Some(Value::Any(*v.clone())),
             ItemContent::Format(_, _) => None,
-            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().to_string()))),
+            ItemContent::String(v) => Some(Value::Any(Any::from(v.as_str()))),
             ItemContent::Type(c) => Some(BranchPtr::from(c).into()),
         }
     }
@@ -1860,14 +1862,16 @@ impl ItemContent {
     pub fn get_last(&self) -> Option<Value> {
         match self {
             ItemContent::Any(v) => v.last().map(|a| Value::Any(a.clone())),
-            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone()))),
+            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone().into_boxed_slice()))),
             ItemContent::Deleted(_) => None,
             ItemContent::Move(_) => None,
             ItemContent::Doc(_, v) => Some(Value::YDoc(v.clone())),
-            ItemContent::JSON(v) => v.last().map(|v| Value::Any(Any::String(v.clone()))),
+            ItemContent::JSON(v) => v
+                .last()
+                .map(|v| Value::Any(Any::String(v.clone().into_boxed_str()))),
             ItemContent::Embed(v) => Some(Value::Any(*v.clone())),
             ItemContent::Format(_, _) => None,
-            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().to_string()))),
+            ItemContent::String(v) => Some(Value::Any(Any::from(v.as_str()))),
             ItemContent::Type(c) => Some(BranchPtr::from(c).into()),
         }
     }

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -1787,7 +1787,7 @@ impl ItemContent {
                     let chars = v.chars().skip(offset).take(buf.len());
                     let mut j = 0;
                     for c in chars {
-                        buf[j] = Value::Any(Any::String(c.to_string().into_boxed_str()));
+                        buf[j] = Value::Any(Any::String(c.to_string()));
                         j += 1;
                     }
                     j
@@ -1797,14 +1797,14 @@ impl ItemContent {
                     let mut j = 0;
                     while i < elements.len() && j < buf.len() {
                         let elem = &elements[i];
-                        buf[j] = Value::Any(Any::String(elem.clone().into_boxed_str()));
+                        buf[j] = Value::Any(Any::String(elem.clone()));
                         i += 1;
                         j += 1;
                     }
                     j
                 }
                 ItemContent::Binary(v) => {
-                    buf[0] = Value::Any(Any::Buffer(v.clone().into_boxed_slice()));
+                    buf[0] = Value::Any(Any::Buffer(v.clone()));
                     1
                 }
                 ItemContent::Doc(_, doc) => {
@@ -1844,16 +1844,14 @@ impl ItemContent {
     pub fn get_first(&self) -> Option<Value> {
         match self {
             ItemContent::Any(v) => v.first().map(|a| Value::Any(a.clone())),
-            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone().into_boxed_slice()))),
+            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone()))),
             ItemContent::Deleted(_) => None,
             ItemContent::Move(_) => None,
             ItemContent::Doc(_, v) => Some(Value::YDoc(v.clone())),
-            ItemContent::JSON(v) => v
-                .first()
-                .map(|v| Value::Any(Any::String(v.clone().into_boxed_str()))),
+            ItemContent::JSON(v) => v.first().map(|v| Value::Any(Any::String(v.clone()))),
             ItemContent::Embed(v) => Some(Value::Any(*v.clone())),
             ItemContent::Format(_, _) => None,
-            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().into()))),
+            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().to_string()))),
             ItemContent::Type(c) => Some(BranchPtr::from(c).into()),
         }
     }
@@ -1862,16 +1860,14 @@ impl ItemContent {
     pub fn get_last(&self) -> Option<Value> {
         match self {
             ItemContent::Any(v) => v.last().map(|a| Value::Any(a.clone())),
-            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone().into_boxed_slice()))),
+            ItemContent::Binary(v) => Some(Value::Any(Any::Buffer(v.clone()))),
             ItemContent::Deleted(_) => None,
             ItemContent::Move(_) => None,
             ItemContent::Doc(_, v) => Some(Value::YDoc(v.clone())),
-            ItemContent::JSON(v) => v
-                .last()
-                .map(|v| Value::Any(Any::String(v.clone().into_boxed_str()))),
+            ItemContent::JSON(v) => v.last().map(|v| Value::Any(Any::String(v.clone()))),
             ItemContent::Embed(v) => Some(Value::Any(*v.clone())),
             ItemContent::Format(_, _) => None,
-            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().into()))),
+            ItemContent::String(v) => Some(Value::Any(Any::String(v.clone().to_string()))),
             ItemContent::Type(c) => Some(BranchPtr::from(c).into()),
         }
     }
@@ -2328,7 +2324,7 @@ where
 {
     type Return = T::Return;
 
-    fn into_content(mut self, txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
+    fn into_content(self, txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
         match self {
             EmbedPrelim::Primitive(any) => (ItemContent::Embed(Box::new(any)), None),
             EmbedPrelim::Shared(prelim) => {

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -12,7 +12,7 @@ use crate::{
     XmlFragmentRef, XmlTextRef,
 };
 use atomic_refcell::{AtomicRef, AtomicRefMut, BorrowError, BorrowMutError};
-use lib0::any::Any;
+use lib0::any::{Any, Number};
 use lib0::error::Error;
 use rand::Rng;
 use std::collections::HashMap;
@@ -606,7 +606,7 @@ impl Options {
             OffsetKind::Utf16 => 0, // 0 for compatibility with Yjs, which doesn't have this option
             OffsetKind::Utf32 => 2,
         };
-        m.insert("encoding".to_owned(), Any::BigInt(encoding));
+        m.insert("encoding".to_owned(), Any::from(encoding));
         m.insert("autoLoad".to_owned(), self.auto_load.into());
         m.insert("shouldLoad".to_owned(), self.should_load.into());
         Any::Map(Box::new(m))
@@ -645,8 +645,12 @@ impl Decode for Options {
                     ("collectionId", Any::String(cid)) => {
                         options.collection_id = Some(cid.to_string())
                     }
-                    ("encoding", Any::BigInt(1)) => options.offset_kind = OffsetKind::Bytes,
-                    ("encoding", Any::BigInt(2)) => options.offset_kind = OffsetKind::Utf32,
+                    ("encoding", Any::Number(Number::Int(1))) => {
+                        options.offset_kind = OffsetKind::Bytes
+                    }
+                    ("encoding", Any::Number(Number::Int(2))) => {
+                        options.offset_kind = OffsetKind::Utf32
+                    }
                     ("encoding", _) => options.offset_kind = OffsetKind::Utf16,
                     _ => { /* do nothing */ }
                 }

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -935,7 +935,7 @@ mod test {
         assert_eq!(
             delta.borrow_mut().take(),
             Some(vec![Change::Added(vec![
-                Any::Number(4.0).into(),
+                Any::from(4.0).into(),
                 Any::String("dtrn".into()).into()
             ])])
         );
@@ -964,7 +964,7 @@ mod test {
             delta.borrow_mut().take(),
             Some(vec![
                 Change::Retain(1),
-                Change::Added(vec![Any::Number(0.5).into()])
+                Change::Added(vec![Any::from(0.5).into()])
             ])
         );
 
@@ -996,7 +996,7 @@ mod test {
             delta.borrow_mut().take(),
             Some(vec![Change::Added(vec![
                 Any::String("dtrn".into()).into(),
-                Any::Number(0.5).into(),
+                Any::from(0.5).into(),
             ])])
         );
     }
@@ -1064,7 +1064,7 @@ mod test {
                     yarray.move_to(&mut txn, pos, new_pos);
 
                     let actual = yarray.to_json(&txn);
-                    assert_eq!(actual, Any::Array(expected.into_boxed_slice()))
+                    assert_eq!(actual, Any::Array(expected))
                 } else {
                     panic!("should not happen")
                 }
@@ -1077,7 +1077,7 @@ mod test {
             let len = rng.between(1, 4);
             let content: Vec<_> = (0..len)
                 .into_iter()
-                .map(|_| Any::BigInt(unique_number))
+                .map(|_| Any::from(unique_number))
                 .collect();
             let mut pos = rng.between(0, yarray.len(&txn)) as usize;
             if let Any::Array(expected) = yarray.to_json(&txn) {
@@ -1089,7 +1089,7 @@ mod test {
                     pos += 1;
                 }
                 let actual = yarray.to_json(&txn);
-                assert_eq!(actual, Any::Array(expected.into_boxed_slice()))
+                assert_eq!(actual, Any::Array(expected))
             } else {
                 panic!("should not happen")
             }
@@ -1100,7 +1100,7 @@ mod test {
             let mut txn = doc.transact_mut();
             let pos = rng.between(0, yarray.len(&txn));
             let array2 = yarray.insert(&mut txn, pos, ArrayPrelim::from([1, 2, 3, 4]));
-            let expected: Box<[Any]> = (1..=4).map(|i| Any::Number(i as f64)).collect();
+            let expected: Vec<_> = (1..=4).map(|i| Any::from(i as f64)).collect();
             assert_eq!(array2.to_json(&txn), Any::Array(expected));
         }
 
@@ -1132,10 +1132,7 @@ mod test {
                         let mut old_content = Vec::from(old_content);
                         yarray.remove_range(&mut txn, pos, del_len);
                         old_content.drain(pos as usize..(pos + del_len) as usize);
-                        assert_eq!(
-                            yarray.to_json(&txn),
-                            Any::Array(old_content.into_boxed_slice())
-                        );
+                        assert_eq!(yarray.to_json(&txn), Any::Array(old_content));
                     } else {
                         panic!("should not happen")
                     }

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -657,7 +657,7 @@ mod test {
             let actual: Vec<_> = a1.iter(&t1).collect();
             assert_eq!(
                 actual,
-                vec![Value::from(1.0), Value::from(true), Value::from(false)]
+                vec![Value::from(1), Value::from(true), Value::from(false)]
             );
         }
 
@@ -668,7 +668,7 @@ mod test {
         let actual: Vec<_> = a2.iter(&t2).collect();
         assert_eq!(
             actual,
-            vec![Value::from(1.0), Value::from(true), Value::from(false)]
+            vec![Value::from(1), Value::from(true), Value::from(false)]
         );
     }
 
@@ -858,7 +858,7 @@ mod test {
         for (i, value) in a.iter(&txn).enumerate() {
             match value {
                 Value::YMap(_) => {
-                    assert_eq!(value.to_json(&txn), any!({"value": (i as f64) }))
+                    assert_eq!(value.to_json(&txn), any!({"value": i as i64 }))
                 }
                 _ => panic!("Value of array at index {} was no YMap", i),
             }
@@ -935,7 +935,7 @@ mod test {
         assert_eq!(
             delta.borrow_mut().take(),
             Some(vec![Change::Added(vec![
-                Any::from(4.0).into(),
+                Any::from(4).into(),
                 Any::String("dtrn".into()).into()
             ])])
         );
@@ -1100,7 +1100,7 @@ mod test {
             let mut txn = doc.transact_mut();
             let pos = rng.between(0, yarray.len(&txn));
             let array2 = yarray.insert(&mut txn, pos, ArrayPrelim::from([1, 2, 3, 4]));
-            let expected: Vec<_> = (1..=4).map(|i| Any::from(i as f64)).collect();
+            let expected: Vec<_> = (1..=4).map(|i| Any::from(i)).collect();
             assert_eq!(array2.to_json(&txn), Any::Array(expected));
         }
 

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -1064,7 +1064,7 @@ mod test {
                     yarray.move_to(&mut txn, pos, new_pos);
 
                     let actual = yarray.to_json(&txn);
-                    assert_eq!(actual, Any::Array(expected))
+                    assert_eq!(actual, Any::Array(expected.into_boxed_slice()))
                 } else {
                     panic!("should not happen")
                 }
@@ -1089,7 +1089,7 @@ mod test {
                     pos += 1;
                 }
                 let actual = yarray.to_json(&txn);
-                assert_eq!(actual, Any::Array(expected))
+                assert_eq!(actual, Any::Array(expected.into_boxed_slice()))
             } else {
                 panic!("should not happen")
             }
@@ -1101,7 +1101,7 @@ mod test {
             let pos = rng.between(0, yarray.len(&txn));
             let array2 = yarray.insert(&mut txn, pos, ArrayPrelim::from([1, 2, 3, 4]));
             let expected: Vec<_> = (1..=4).map(|i| Any::from(i)).collect();
-            assert_eq!(array2.to_json(&txn), Any::Array(expected));
+            assert_eq!(array2.to_json(&txn), Any::Array(expected.into()));
         }
 
         fn insert_type_map(doc: &mut Doc, rng: &mut StdRng) {
@@ -1132,7 +1132,7 @@ mod test {
                         let mut old_content = Vec::from(old_content);
                         yarray.remove_range(&mut txn, pos, del_len);
                         old_content.drain(pos as usize..(pos + del_len) as usize);
-                        assert_eq!(yarray.to_json(&txn), Any::Array(old_content));
+                        assert_eq!(yarray.to_json(&txn), Any::Array(old_content.into()));
                     } else {
                         panic!("should not happen")
                     }

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -477,7 +477,7 @@ mod test {
         //TODO: YArray within YMap
         fn compare_all<T: ReadTxn>(m: &MapRef, txn: &T) {
             assert_eq!(m.len(txn), 5);
-            assert_eq!(m.get(txn, &"number".to_owned()), Some(Value::from(1f64)));
+            assert_eq!(m.get(txn, &"number".to_owned()), Some(Value::from(1)));
             assert_eq!(m.get(txn, &"boolean0".to_owned()), Some(Value::from(false)));
             assert_eq!(m.get(txn, &"boolean1".to_owned()), Some(Value::from(true)));
             assert_eq!(
@@ -780,7 +780,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Inserted(Any::from(1.0).into())
+                EntryChange::Inserted(Any::from(1).into())
             )]))
         );
 
@@ -793,7 +793,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Updated(Any::from(1.0).into(), Any::from(2.0).into())
+                EntryChange::Updated(Any::from(1).into(), Any::from(2).into())
             )]))
         );
 
@@ -807,7 +807,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Updated(Any::from(2.0).into(), Any::from(4.0).into())
+                EntryChange::Updated(Any::from(2).into(), Any::from(4).into())
             )]))
         );
 
@@ -820,7 +820,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Removed(Any::from(4.0).into())
+                EntryChange::Removed(Any::from(4).into())
             )]))
         );
 
@@ -834,7 +834,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "b".into(),
-                EntryChange::Inserted(Any::from(2.0).into())
+                EntryChange::Inserted(Any::from(2).into())
             )]))
         );
 
@@ -870,7 +870,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "b".into(),
-                EntryChange::Inserted(Any::from(2.0).into())
+                EntryChange::Inserted(Any::from(2).into())
             )]))
         );
     }

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -780,7 +780,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Inserted(Any::Number(1.0).into())
+                EntryChange::Inserted(Any::from(1.0).into())
             )]))
         );
 
@@ -793,7 +793,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Updated(Any::Number(1.0).into(), Any::Number(2.0).into())
+                EntryChange::Updated(Any::from(1.0).into(), Any::from(2.0).into())
             )]))
         );
 
@@ -807,7 +807,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Updated(Any::Number(2.0).into(), Any::Number(4.0).into())
+                EntryChange::Updated(Any::from(2.0).into(), Any::from(4.0).into())
             )]))
         );
 
@@ -820,7 +820,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "a".into(),
-                EntryChange::Removed(Any::Number(4.0).into())
+                EntryChange::Removed(Any::from(4.0).into())
             )]))
         );
 
@@ -834,7 +834,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "b".into(),
-                EntryChange::Inserted(Any::Number(2.0).into())
+                EntryChange::Inserted(Any::from(2.0).into())
             )]))
         );
 
@@ -870,7 +870,7 @@ mod test {
             entries.take(),
             Some(HashMap::from([(
                 "b".into(),
-                EntryChange::Inserted(Any::Number(2.0).into())
+                EntryChange::Inserted(Any::from(2.0).into())
             )]))
         );
     }

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -841,12 +841,12 @@ impl ToJson for Value {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {
         match self {
             Value::Any(a) => a.clone(),
-            Value::YText(v) => Any::String(v.get_string(txn).into_boxed_str()),
+            Value::YText(v) => Any::String(v.get_string(txn)),
             Value::YArray(v) => v.to_json(txn),
             Value::YMap(v) => v.to_json(txn),
-            Value::YXmlElement(v) => Any::String(v.get_string(txn).into_boxed_str()),
-            Value::YXmlText(v) => Any::String(v.get_string(txn).into_boxed_str()),
-            Value::YXmlFragment(v) => Any::String(v.get_string(txn).into_boxed_str()),
+            Value::YXmlElement(v) => Any::String(v.get_string(txn)),
+            Value::YXmlText(v) => Any::String(v.get_string(txn)),
+            Value::YXmlFragment(v) => Any::String(v.get_string(txn)),
             Value::YDoc(doc) => any!({"guid": doc.guid().as_ref()}),
         }
     }

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -841,12 +841,12 @@ impl ToJson for Value {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {
         match self {
             Value::Any(a) => a.clone(),
-            Value::YText(v) => Any::String(v.get_string(txn)),
+            Value::YText(v) => v.get_string(txn).into(),
             Value::YArray(v) => v.to_json(txn),
             Value::YMap(v) => v.to_json(txn),
-            Value::YXmlElement(v) => Any::String(v.get_string(txn)),
-            Value::YXmlText(v) => Any::String(v.get_string(txn)),
-            Value::YXmlFragment(v) => Any::String(v.get_string(txn)),
+            Value::YXmlElement(v) => v.get_string(txn).into(),
+            Value::YXmlText(v) => v.get_string(txn).into(),
+            Value::YXmlFragment(v) => v.get_string(txn).into(),
             Value::YDoc(doc) => any!({"guid": doc.guid().as_ref()}),
         }
     }

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1083,7 +1083,7 @@ impl TextEvent {
                             str
                         } else {
                             let value = self.insert_string.take().unwrap();
-                            Any::String(value).into()
+                            Any::String(value.into()).into()
                         };
                         let attrs = if self.current_attrs.is_empty() {
                             None

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -2050,7 +2050,7 @@ mod test {
             let mut txn = d1.transact_mut();
             txt1.insert_with_attributes(&mut txn, 0, "ab", a1.clone());
 
-            let a2: Attrs = HashMap::from([("width".into(), Any::from(100.0))]);
+            let a2: Attrs = HashMap::from([("width".into(), Any::from(100))]);
 
             txt1.insert_embed_with_attributes(&mut txn, 1, embed.clone(), a2.clone());
             drop(txn);
@@ -2079,10 +2079,7 @@ mod test {
         };
 
         let a1 = Some(Box::new(a1));
-        let a2 = Some(Box::new(HashMap::from([(
-            "width".into(),
-            Any::from(100.0),
-        )])));
+        let a2 = Some(Box::new(HashMap::from([("width".into(), Any::from(100))])));
 
         let expected = vec![
             Diff::new("a".into(), a1.clone()),

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1082,7 +1082,7 @@ impl TextEvent {
                         let value = if let Some(str) = self.insert.take() {
                             str
                         } else {
-                            let value = self.insert_string.take().unwrap().into_boxed_str();
+                            let value = self.insert_string.take().unwrap();
                             Any::String(value).into()
                         };
                         let attrs = if self.current_attrs.is_empty() {
@@ -2050,7 +2050,7 @@ mod test {
             let mut txn = d1.transact_mut();
             txt1.insert_with_attributes(&mut txn, 0, "ab", a1.clone());
 
-            let a2: Attrs = HashMap::from([("width".into(), Any::Number(100.0))]);
+            let a2: Attrs = HashMap::from([("width".into(), Any::from(100.0))]);
 
             txt1.insert_embed_with_attributes(&mut txn, 1, embed.clone(), a2.clone());
             drop(txn);
@@ -2081,7 +2081,7 @@ mod test {
         let a1 = Some(Box::new(a1));
         let a2 = Some(Box::new(HashMap::from([(
             "width".into(),
-            Any::Number(100.0),
+            Any::from(100.0),
         )])));
 
         let expected = vec![

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -3835,7 +3835,7 @@ fn insert_at(dst: &ArrayRef, txn: &mut TransactionMut, index: u32, src: Vec<JsVa
 
 fn js_into_any(v: &JsValue) -> Option<Any> {
     if v.is_string() {
-        Some(Any::String(v.as_string()?))
+        Some(Any::from(v.as_string()?))
     } else if v.is_bigint() {
         let i = js_sys::BigInt::from(v.clone()).as_f64()?;
         Some(Any::Number(Number::BigInt(i as i64)))
@@ -3853,7 +3853,7 @@ fn js_into_any(v: &JsValue) -> Option<Any> {
         for value in array.iter() {
             result.push(js_into_any(&value)?);
         }
-        Some(Any::Array(result))
+        Some(Any::Array(result.into()))
     } else if v.is_object() {
         if let Ok(_) = Shared::try_from(v) {
             None


### PR DESCRIPTION
Fixes #314

Basically we did JS safe int bounds check for `Any::Number` but not for `Any::BigInt`.