### PR TITLE
lib0::Any: using Arc instead of Box

### DIFF
--- a/lib0/src/macros.rs
+++ b/lib0/src/macros.rs
@@ -206,14 +206,14 @@ macro_rules! any_internal {
     };
 
     ({}) => {
-        $crate::any::Any::Map(std::boxed::Box::new(std::collections::HashMap::new()))
+        $crate::any::Any::Map(std::sync::Arc::new(std::collections::HashMap::new()))
     };
 
     ({ $($tt:tt)+ }) => {
         $crate::any::Any::Map({
-            let mut object = std::boxed::Box::new(std::collections::HashMap::new());
+            let mut object = std::collections::HashMap::new();
             any_internal!(@object object () ($($tt)+) ($($tt)+));
-            object
+            std::sync::Arc::new(object)
         })
     };
 
@@ -228,7 +228,7 @@ macro_rules! any_internal {
 #[doc(hidden)]
 macro_rules! any_internal_array {
     ($($content:tt)*) => {
-        std::boxed::Box::from([$($content)*])
+        std::sync::Arc::from([$($content)*])
     };
 }
 

--- a/lib0/src/number.rs
+++ b/lib0/src/number.rs
@@ -4,9 +4,6 @@ use crate::error::Error;
 use std::convert::TryInto;
 use std::mem::size_of;
 
-pub const F64_MAX_SAFE_INTEGER: f64 = (i64::pow(2, 53) - 1) as f64;
-pub const F64_MIN_SAFE_INTEGER: f64 = -F64_MAX_SAFE_INTEGER;
-
 pub trait VarInt: Sized + Copy {
     fn write<W: Write>(&self, w: &mut W);
     fn read<R: Read>(r: &mut R) -> Result<Self, Error>;

--- a/lib0/tests/encoding_test.rs
+++ b/lib0/tests/encoding_test.rs
@@ -8,18 +8,17 @@ pub fn arb_any() -> impl Strategy<Value = Any> {
         Just(Any::Null),
         Just(Any::Undefined),
         any::<bool>().prop_map(Any::Bool),
-        any::<f64>().prop_map(Any::Number),
-        any::<i64>().prop_map(|i| Any::Number(i as f64)),
-        any::<String>().prop_map(|i| Any::String(i.into())),
-        any::<Box<[u8]>>().prop_map(Any::Buffer),
+        any::<f64>().prop_map(Any::from),
+        any::<i64>().prop_map(Any::from),
+        any::<String>().prop_map(Any::from),
+        any::<Vec<u8>>().prop_map(Any::from),
     ]
     .boxed();
 
     leaf.prop_recursive(8, 256, 10, |inner| {
         prop_oneof![
-            prop::collection::vec(inner.clone(), 0..10)
-                .prop_map(|v| Any::Array(v.into_boxed_slice())),
-            prop::collection::hash_map(".*", inner, 0..10).prop_map(|v| Any::Map(Box::new(v))),
+            prop::collection::vec(inner.clone(), 0..10).prop_map(Any::from),
+            prop::collection::hash_map(".*", inner, 0..10).prop_map(Any::from),
         ]
     })
 }

--- a/lib0/tests/json_test.rs
+++ b/lib0/tests/json_test.rs
@@ -47,38 +47,29 @@ mod test {
 
     #[test]
     fn json_any_array() {
-        let expected = Any::Array(
-            vec![
-                Any::Number(-10.0),
-                Any::String("hello \\world".into()),
-                Any::Null,
-                Any::Bool(true),
-            ]
-            .into_boxed_slice(),
-        );
+        let expected = Any::from(vec![
+            Any::Number(-10.0),
+            Any::String("hello \\world".into()),
+            Any::Null,
+            Any::Bool(true),
+        ]);
         let actual = roundtrip(&expected);
         assert_eq!(actual, expected);
     }
 
     #[test]
     fn json_any_map() {
-        let expected = Any::Map(Box::new(HashMap::from([
+        let expected = Any::from(HashMap::from([
             ("a".to_string(), Any::Number(-10.2)),
             ("b".to_string(), Any::String("hello world".into())),
             ("c".to_string(), Any::Null),
             ("d".to_string(), Any::Bool(true)),
-            (
-                "e".to_string(),
-                Any::Array(vec![Any::String("abc".into())].into_boxed_slice()),
-            ),
+            ("e".to_string(), Any::from(vec![Any::String("abc".into())])),
             (
                 "f".to_string(),
-                Any::Map(Box::new(HashMap::from([(
-                    "fa".to_string(),
-                    Any::Number(1.5),
-                )]))),
+                Any::from(HashMap::from([("fa".to_string(), Any::Number(1.5))])),
             ),
-        ])));
+        ]));
         let actual = roundtrip(&expected);
         assert_eq!(actual, expected);
     }

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1292,7 +1292,10 @@ pub unsafe extern "C" fn ytext_insert_embed(
 
 fn map_attrs(attrs: Any) -> Option<Attrs> {
     if let Any::Map(attrs) = attrs {
-        let attrs = attrs.into_iter().map(|(k, v)| (k.into(), v)).collect();
+        let attrs = attrs
+            .iter()
+            .map(|(k, v)| (k.as_str().into(), v.clone()))
+            .collect();
         Some(attrs)
     } else {
         None
@@ -2450,7 +2453,7 @@ impl YInput {
         let tag = self.tag;
         unsafe {
             if tag == Y_JSON_STR {
-                let str: Box<str> = CStr::from_ptr(self.value.str).to_str().unwrap().into();
+                let str = CStr::from_ptr(self.value.str).to_str().unwrap().into();
                 Any::String(str)
             } else if tag == Y_JSON_ARR {
                 let ptr = self.value.values;
@@ -2462,7 +2465,7 @@ impl YInput {
                     dst.push(any);
                     i += 1;
                 }
-                Any::Array(dst.into_boxed_slice())
+                Any::from(dst)
             } else if tag == Y_JSON_MAP {
                 let mut dst = HashMap::with_capacity(self.len as usize);
                 let keys = self.value.map.keys;
@@ -2477,7 +2480,7 @@ impl YInput {
                     dst.insert(key, value);
                     i += 1;
                 }
-                Any::Map(Box::new(dst))
+                Any::from(dst)
             } else if tag == Y_JSON_NULL {
                 Any::Null
             } else if tag == Y_JSON_UNDEF {
@@ -2491,8 +2494,7 @@ impl YInput {
             } else if tag == Y_JSON_BUF {
                 let slice =
                     std::slice::from_raw_parts(self.value.buf as *mut u8, self.len as usize);
-                let buf = Box::from(slice);
-                Any::Buffer(buf)
+                Any::from(slice)
             } else if tag == Y_DOC {
                 Any::Undefined
             } else {
@@ -2715,11 +2717,10 @@ impl Drop for YOutput {
                     self.len as usize,
                 ));
             } else if tag == Y_JSON_BUF {
-                drop(Vec::from_raw_parts(
-                    self.value.buf,
-                    self.len as usize,
-                    self.len as usize,
-                ));
+                let slice =
+                    std::slice::from_raw_parts(self.value.buf as *mut u8, self.len as usize);
+                let arc: Arc<[u8]> = Arc::from_raw(slice);
+                drop(arc);
             } else if tag == Y_DOC {
                 drop(Box::from_raw(self.value.y_doc))
             }
@@ -2784,14 +2785,19 @@ impl From<Any> for YOutput {
                     tag: Y_JSON_BUF,
                     len: v.len() as u32,
                     value: YOutputContent {
-                        buf: Box::into_raw(v.clone()) as *mut _,
+                        buf: {
+                            let ptr: *const [u8] = Arc::into_raw(v);
+                            let head: *const u8 = &(*ptr)[0];
+                            head as *const _
+                        },
                     },
                 },
-                Any::Array(v) => {
-                    let len = v.len() as u32;
-                    let v = Vec::from(v);
-                    let mut array: Vec<_> = v.into_iter().map(|v| YOutput::from(v)).collect();
-                    array.shrink_to_fit();
+                Any::Array(values) => {
+                    let len = values.len() as u32;
+                    let mut array = Vec::with_capacity(values.len());
+                    for v in values.iter() {
+                        array.push(YOutput::from(v.clone()));
+                    }
                     let ptr = array.as_mut_ptr();
                     forget(array);
                     YOutput {
@@ -2802,10 +2808,9 @@ impl From<Any> for YOutput {
                 }
                 Any::Map(v) => {
                     let len = v.len() as u32;
-                    let v = *v;
                     let mut array: Vec<_> = v
-                        .into_iter()
-                        .map(|(k, v)| YMapEntry::new(k.as_str(), Value::Any(v)))
+                        .iter()
+                        .map(|(k, v)| YMapEntry::new(k.as_str(), Value::Any(v.clone())))
                         .collect();
                     array.shrink_to_fit();
                     let ptr = array.as_mut_ptr();
@@ -2911,7 +2916,7 @@ union YOutputContent {
     num: f64,
     integer: i64,
     str: *mut c_char,
-    buf: *mut c_char,
+    buf: *const c_char,
     array: *mut YOutput,
     map: *mut YMapEntry,
     y_type: *mut Branch,

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -529,7 +529,7 @@ impl ToJson for Doc {
         for (key, value) in txn.root_refs() {
             m.insert(key.to_string(), value.to_json(txn));
         }
-        Any::Map(Box::new(m))
+        Any::from(m)
     }
 }
 
@@ -609,7 +609,7 @@ impl Options {
         m.insert("encoding".to_owned(), Any::BigInt(encoding));
         m.insert("autoLoad".to_owned(), self.auto_load.into());
         m.insert("shouldLoad".to_owned(), self.should_load.into());
-        Any::Map(Box::new(m))
+        Any::from(m)
     }
 }
 

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -94,7 +94,7 @@ impl ToJson for MapRef {
                 }
             }
         }
-        Any::Map(Box::new(res))
+        Any::from(res)
     }
 }
 

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -841,12 +841,12 @@ impl ToJson for Value {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {
         match self {
             Value::Any(a) => a.clone(),
-            Value::YText(v) => Any::String(v.get_string(txn).into_boxed_str()),
+            Value::YText(v) => Any::from(v.get_string(txn)),
             Value::YArray(v) => v.to_json(txn),
             Value::YMap(v) => v.to_json(txn),
-            Value::YXmlElement(v) => Any::String(v.get_string(txn).into_boxed_str()),
-            Value::YXmlText(v) => Any::String(v.get_string(txn).into_boxed_str()),
-            Value::YXmlFragment(v) => Any::String(v.get_string(txn).into_boxed_str()),
+            Value::YXmlElement(v) => Any::from(v.get_string(txn)),
+            Value::YXmlText(v) => Any::from(v.get_string(txn)),
+            Value::YXmlFragment(v) => Any::from(v.get_string(txn)),
             Value::YDoc(doc) => any!({"guid": doc.guid().as_ref()}),
         }
     }

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1082,8 +1082,8 @@ impl TextEvent {
                         let value = if let Some(str) = self.insert.take() {
                             str
                         } else {
-                            let value = self.insert_string.take().unwrap().into_boxed_str();
-                            Any::String(value).into()
+                            let value = self.insert_string.take().unwrap();
+                            Any::from(value).into()
                         };
                         let attrs = if self.current_attrs.is_empty() {
                             None

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -3835,7 +3835,7 @@ fn insert_at(dst: &ArrayRef, txn: &mut TransactionMut, index: u32, src: Vec<JsVa
 
 fn js_into_any(v: &JsValue) -> Option<Any> {
     if v.is_string() {
-        Some(Any::String(v.as_string()?.into_boxed_str()))
+        Some(Any::from(v.as_string()?))
     } else if v.is_bigint() {
         let i = js_sys::BigInt::from(v.clone()).as_f64()?;
         Some(Any::BigInt(i as i64))
@@ -3853,7 +3853,7 @@ fn js_into_any(v: &JsValue) -> Option<Any> {
         for value in array.iter() {
             result.push(js_into_any(&value)?);
         }
-        Some(Any::Array(result.into_boxed_slice()))
+        Some(Any::from(result))
     } else if v.is_object() {
         if let Ok(_) = Shared::try_from(v) {
             None
@@ -3867,7 +3867,7 @@ fn js_into_any(v: &JsValue) -> Option<Any> {
                 let value = js_into_any(&tuple.get(1))?;
                 map.insert(key, value);
             }
-            Some(Any::Map(Box::new(map)))
+            Some(Any::from(map))
         }
     } else {
         None


### PR DESCRIPTION
Changes:

- (Following discussion from #315) Make all integer numbers < 2^53-1 convert to `Any::Number(f64)` by default. Above that threshold - use `Any::BigInt(i64)`.
- Replace `Into<Any>` trait with `From<T> for Any` as it will auto-generate `Into<Any>` equivalent anyway.
- `Any`: replace `Box` heap allocation with `Arc` (thread-safe reference counter). Why? Because when reading `ItemContent`, we did deep copies of underlying objects (it means ie. full copy of strings and binaries). Since these were heap allocated anyway, I've switched them to use refcounted variant, so now we only increment refs, which is much faster. It's also safe as `Any` are never internally modified by yrs - always replaced in full.