### PR TITLE
Added Any::cast, Value::cast and standarized casting rules

### DIFF
--- a/lib0/benches/lib0_benchmarks.rs
+++ b/lib0/benches/lib0_benchmarks.rs
@@ -84,7 +84,7 @@ fn bench_serialization(c: &mut Criterion) {
     use lib0::any::Any;
     use std::collections::HashMap;
 
-    let any = Any::Map(Box::new(HashMap::from([
+    let any = Any::from(HashMap::from([
         ("bool".into(), Any::Bool(true)),
         ("int".into(), Any::BigInt(1)),
         ("negativeInt".into(), Any::BigInt(-1)),
@@ -96,7 +96,7 @@ fn bench_serialization(c: &mut Criterion) {
         ("null".into(), Any::Null),
         (
             "map".into(),
-            Any::Map(Box::new(HashMap::from([
+            Any::from(HashMap::from([
                 ("bool".into(), Any::Bool(true)),
                 ("int".into(), Any::BigInt(1)),
                 ("negativeInt".into(), Any::BigInt(-1)),
@@ -106,26 +106,23 @@ fn bench_serialization(c: &mut Criterion) {
                 ("maxNumber".into(), Any::Number(f64::MIN)),
                 ("minNumber".into(), Any::Number(f64::MAX)),
                 ("null".into(), Any::Null),
-            ]))),
+            ])),
         ),
         (
             "key6".into(),
-            Any::Array(
-                vec![
-                    Any::Bool(true),
-                    Any::BigInt(1),
-                    Any::BigInt(-1),
-                    Any::BigInt(i64::MAX),
-                    Any::BigInt(i64::MIN),
-                    Any::Number(-123.2387f64),
-                    Any::Number(f64::MIN),
-                    Any::Number(f64::MAX),
-                    Any::Null,
-                ]
-                .into_boxed_slice(),
-            ),
+            Any::from(vec![
+                Any::Bool(true),
+                Any::BigInt(1),
+                Any::BigInt(-1),
+                Any::BigInt(i64::MAX),
+                Any::BigInt(i64::MIN),
+                Any::Number(-123.2387f64),
+                Any::Number(f64::MIN),
+                Any::Number(f64::MAX),
+                Any::Null,
+            ]),
         ),
-    ])));
+    ]));
 
     let any_json = serde_json::to_string(&any).unwrap();
 

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -7,7 +7,7 @@ use crate::update::{BlockCarrier, Update};
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::Encode;
 use crate::{
-    ArrayPrelim, Doc, GetString, Map, MapPrelim, ReadTxn, StateVector, Transact, Xml,
+    ArrayPrelim, Doc, GetString, Map, MapPrelim, MapRef, ReadTxn, StateVector, Transact, Xml,
     XmlElementRef, XmlTextRef, ID,
 };
 use lib0::any::Any;
@@ -386,7 +386,11 @@ fn negative_zero_decoding_v2() {
     let mut txn = doc.transact_mut();
 
     root.insert(&mut txn, "sequence", MapPrelim::<bool>::new()); //NOTE: This is how I put nested map.
-    let sequence = root.get(&txn, "sequence").unwrap().to_ymap().unwrap();
+    let sequence = root
+        .get(&txn, "sequence")
+        .unwrap()
+        .cast::<MapRef>()
+        .unwrap();
     sequence.insert(&mut txn, "id", "V9Uk9pxUKZIrW6cOkC0Rg".to_string());
     sequence.insert(&mut txn, "cuts", ArrayPrelim::<_, Any>::from([]));
     sequence.insert(&mut txn, "name", "new sequence".to_string());

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -140,6 +140,17 @@ impl TryFrom<BlockPtr> for ArrayRef {
     }
 }
 
+impl TryFrom<Value> for ArrayRef {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YArray(value) => Ok(value),
+            other => Err(other),
+        }
+    }
+}
+
 pub trait Array: AsRef<Branch> {
     /// Returns a number of elements stored in current array.
     fn len<T: ReadTxn>(&self, txn: &T) -> u32 {
@@ -518,7 +529,7 @@ mod test {
     use crate::types::map::MapPrelim;
     use crate::types::{Change, DeepObservable, Event, Path, PathSegment, ToJson, Value};
     use crate::{
-        Array, ArrayPrelim, Assoc, Doc, Map, Observable, StateVector, Transact, Update, ID,
+        Array, ArrayPrelim, Assoc, Doc, Map, MapRef, Observable, StateVector, Transact, Update, ID,
     };
     use lib0::any::Any;
     use rand::prelude::StdRng;
@@ -1194,7 +1205,7 @@ mod test {
 
         {
             let mut txn = doc.transact_mut();
-            let map = array.get(&txn, 0).unwrap().to_ymap().unwrap();
+            let map = array.get(&txn, 0).unwrap().cast::<MapRef>().unwrap();
             map.insert(&mut txn, "a", "a");
             array.insert(&mut txn, 0, 0);
         }

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -122,6 +122,17 @@ impl TryFrom<BlockPtr> for MapRef {
     }
 }
 
+impl TryFrom<Value> for MapRef {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YMap(value) => Ok(value),
+            other => Err(other),
+        }
+    }
+}
+
 pub trait Map: AsRef<Branch> {
     /// Returns a number of entries stored within current map.
     fn len<T: ReadTxn>(&self, txn: &T) -> u32 {
@@ -431,8 +442,8 @@ mod test {
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encoder, EncoderV1};
     use crate::{
-        Array, ArrayPrelim, Doc, Map, MapPrelim, MapRef, Observable, StateVector, Text, Transact,
-        Update,
+        Array, ArrayPrelim, ArrayRef, Doc, Map, MapPrelim, MapRef, Observable, StateVector, Text,
+        Transact, Update,
     };
     use lib0::any;
     use lib0::any::Any;
@@ -961,7 +972,7 @@ mod test {
         let nested2 = nested
             .get(&nested.transact(), "array")
             .unwrap()
-            .to_yarray()
+            .cast::<ArrayRef>()
             .unwrap();
         nested2.insert(&mut doc.transact_mut(), 0, "content");
 

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -153,6 +153,17 @@ impl TryFrom<BlockPtr> for TextRef {
     }
 }
 
+impl TryFrom<Value> for TextRef {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YText(value) => Ok(value),
+            other => Err(other),
+        }
+    }
+}
+
 pub trait Text: AsRef<Branch> {
     /// Returns a number of characters visible in a current text data structure.
     fn len<T: ReadTxn>(&self, txn: &T) -> u32 {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -100,6 +100,19 @@ impl TryFrom<BranchPtr> for XmlNode {
     }
 }
 
+impl TryFrom<Value> for XmlNode {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YXmlElement(n) => Ok(XmlNode::Element(n)),
+            Value::YXmlFragment(n) => Ok(XmlNode::Fragment(n)),
+            Value::YXmlText(n) => Ok(XmlNode::Text(n)),
+            other => Err(other),
+        }
+    }
+}
+
 /// XML element data type. It represents an XML node, which can contain key-value attributes
 /// (interpreted as strings) as well as other nested XML elements or rich text (represented by
 /// [XmlTextRef] type).
@@ -229,6 +242,17 @@ impl TryFrom<BlockPtr> for XmlElementRef {
             Ok(Self::from(branch))
         } else {
             Err(value)
+        }
+    }
+}
+
+impl TryFrom<Value> for XmlElementRef {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YXmlElement(value) => Ok(value),
+            other => Err(other),
         }
     }
 }
@@ -465,6 +489,17 @@ impl TryFrom<BlockPtr> for XmlTextRef {
     }
 }
 
+impl TryFrom<Value> for XmlTextRef {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YXmlText(value) => Ok(value),
+            other => Err(other),
+        }
+    }
+}
+
 /// A preliminary type that will be materialized into an [XmlTextRef] once it will be integrated
 /// into Yrs document.
 #[derive(Debug)]
@@ -585,6 +620,17 @@ impl TryFrom<BlockPtr> for XmlFragmentRef {
             Ok(Self::from(branch))
         } else {
             Err(value)
+        }
+    }
+}
+
+impl TryFrom<Value> for XmlFragmentRef {
+    type Error = Value;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::YXmlFragment(value) => Ok(value),
+            other => Err(other),
         }
     }
 }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -645,8 +645,9 @@ mod test {
     use crate::undo::{Options, UndoManager};
     use crate::updates::decoder::Decode;
     use crate::{
-        Array, Doc, GetString, Map, MapPrelim, ReadTxn, StateVector, Text, TextPrelim, Transact,
-        Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragment, XmlTextPrelim,
+        Array, Doc, GetString, Map, MapPrelim, MapRef, ReadTxn, StateVector, Text, TextPrelim,
+        TextRef, Transact, Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragment,
+        XmlTextPrelim,
     };
     use lib0::any;
     use lib0::any::Any;
@@ -870,7 +871,11 @@ mod test {
 
         exchange_updates(&[&d1, &d2]);
 
-        let map2 = array2.get(&d2.transact(), 0).unwrap().to_ymap().unwrap();
+        let map2 = array2
+            .get(&d2.transact(), 0)
+            .unwrap()
+            .cast::<MapRef>()
+            .unwrap();
         map2.insert(&mut d2.transact_mut(), "b", 2);
         exchange_updates(&[&d1, &d2]);
 
@@ -1061,7 +1066,7 @@ mod test {
         let text = design
             .get(&doc.transact(), "text")
             .unwrap()
-            .to_ymap()
+            .cast::<MapRef>()
             .unwrap();
 
         {
@@ -1129,7 +1134,11 @@ mod test {
                 ("y".to_owned(), 0.into()),
             ])),
         );
-        let point = root.get(&doc.transact(), "a").unwrap().to_ymap().unwrap();
+        let point = root
+            .get(&doc.transact(), "a")
+            .unwrap()
+            .cast::<MapRef>()
+            .unwrap();
         mgr.reset();
 
         point.insert(&mut doc.transact_mut(), "x", 100);
@@ -1163,7 +1172,11 @@ mod test {
         assert_eq!(root.get(&doc.transact(), "a"), None);
 
         mgr.redo().unwrap(); // x=0, y=0
-        let point = root.get(&doc.transact(), "a").unwrap().to_ymap().unwrap();
+        let point = root
+            .get(&doc.transact(), "a")
+            .unwrap()
+            .cast::<MapRef>()
+            .unwrap();
 
         assert_eq!(actual, Any::from_json(r#"{"x":0,"y":0}"#).unwrap());
 
@@ -1423,7 +1436,7 @@ mod test {
 
         exchange_updates(&[&d1, &d2]);
         let diff = txt2.diff(&d1.transact(), YChange::identity);
-        let nested2 = diff[0].insert.clone().to_ytext().unwrap();
+        let nested2 = diff[0].insert.clone().cast::<TextRef>().unwrap();
         assert_eq!(
             nested2.get_string(&d2.transact()),
             "initial text".to_string()


### PR DESCRIPTION
Implemented `Any::cast` and `Value::cast` methods that make it easier to specify generic type that we want to cast them to - this methods works automatically for any generic type implementing `TryFrom<Any>` and `TryFrom<Value>`. This way we also removed `Value::to_ymap`/`Value::to_ytext`/`Value::to_yarray` etc. as they can be replaced by cast method ie. `value.cast::<MapRef>`/`value::cast<TextRef>`/`value::cast<ArrayRef>` etc.