### PR TITLE
Added metadata info to UndoManager stack items

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -884,12 +884,49 @@ typedef struct YUndoManagerOptions {
   int32_t capture_timeout_millis;
 } YUndoManagerOptions;
 
+/**
+ * Event type related to `UndoManager` observer operations, such as `yundo_manager_observe_popped`
+ * and `yundo_manager_observe_added`. It contains various informations about the context in which
+ * undo/redo operations are executed.
+ */
 typedef struct YUndoEvent {
+  /**
+   * Informs if current event is related to executed undo (`Y_KIND_UNDO`) or redo (`Y_KIND_REDO`)
+   * operation.
+   */
   char kind;
+  /**
+   * Origin assigned to a transaction, in context of which this event is being executed.
+   * Transaction origin is specified via `ydoc_write_transaction(doc, origin_len, origin)`.
+   */
   const char *origin;
+  /**
+   * Length of an `origin` field assigned to a transaction, in context of which this event is
+   * being executed.
+   * Transaction origin is specified via `ydoc_write_transaction(doc, origin_len, origin)`.
+   */
   uint32_t origin_len;
+  /**
+   * Set of identifiers of all insert operations that happened in a scope of a current undo/redo
+   * operation.
+   */
   struct YDeleteSet insertions;
+  /**
+   * Set of identifiers of all remove operations that happened in a scope of a current undo/redo
+   * operation.
+   */
   struct YDeleteSet deletions;
+  /**
+   * Pointer to a custom metadata object that can be passed between
+   * `yundo_manager_observe_popped` and `yundo_manager_observe_added`. It's useful for passing
+   * around custom user data ie. cursor position, that needs to be remembered and restored as
+   * part of undo/redo operations.
+   *
+   * This field always starts with no value (`NULL`) assigned to it and can be set/unset in
+   * corresponding callback calls. In such cases it's up to a programmer to handle allocation
+   * and deallocation of memory that this pointer will point to. Not releasing it properly may
+   * lead to memory leaks.
+   */
   void *meta;
 } YUndoEvent;
 

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -361,7 +361,7 @@ typedef union YOutputContent {
   double num;
   int64_t integer;
   char *str;
-  char *buf;
+  const char *buf;
   struct YOutput *array;
   struct YMapEntry *map;
   Branch *y_type;
@@ -881,7 +881,7 @@ typedef struct YEventKeyChange {
 } YEventKeyChange;
 
 typedef struct YUndoManagerOptions {
-  uint32_t capture_timeout_millis;
+  int32_t capture_timeout_millis;
 } YUndoManagerOptions;
 
 typedef struct YUndoEvent {
@@ -890,6 +890,7 @@ typedef struct YUndoEvent {
   uint32_t origin_len;
   struct YDeleteSet insertions;
   struct YDeleteSet deletions;
+  void *meta;
 } YUndoEvent;
 
 /**
@@ -1041,7 +1042,7 @@ YTransaction *ydoc_read_transaction(YDoc *doc);
  *
  * `origin_len` and `origin` are optional parameters to specify a byte sequence used to mark
  * the origin of this transaction (eg. you may decide to give different origins for transaction
- * applying remote updates). These can be used by event handlers or `UndoManager` to perform
+ * applying remote updates). These can be used by event handlers or `YUndoManager` to perform
  * specific actions. If origin should not be set, call `ydoc_write_transaction(doc, 0, NULL)`.
  *
  * Returns `NULL` if read-write transaction couldn't be created, i.e. when another transaction is

--- a/tests-wasm/y-undo.tests.js
+++ b/tests-wasm/y-undo.tests.js
@@ -195,3 +195,26 @@ export const testUndoXml = tc => {
     undoManager.undo()
     t.assert(xml0.toString() === '<undefined><p>con<bold>tent</bold></p></undefined>')
 }
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testUndoEvents = tc => {
+    const d0 = new Y.YDoc({clientID:1})
+    const text0 = d0.getText("text")
+    const undoManager = new Y.YUndoManager(d0, text0)
+    let counter = 0
+    let receivedMetadata = -1
+    undoManager.onStackItemAdded( event => {
+        event.stackItem.meta = event.stackItem.meta || new Map()
+        event.stackItem.meta.set('test', counter++)
+    })
+    undoManager.onStackItemPopped(event => {
+        receivedMetadata = event.stackItem.meta.get('test')
+    })
+    text0.insert(0, 'abc')
+    undoManager.undo()
+    t.assert(receivedMetadata === 0)
+    undoManager.redo()
+    t.assert(receivedMetadata === 1)
+}

--- a/yffi/cbindgen.toml
+++ b/yffi/cbindgen.toml
@@ -99,7 +99,8 @@ exclude = [
     "ArrayIter",
     "MapIter",
     "Attributes",
-    "TreeWalker"
+    "TreeWalker",
+    "YUndoManager"
 ]
 
 [export.rename]

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -4437,7 +4437,7 @@ pub struct YUndoEvent {
 
 impl YUndoEvent {
     unsafe fn new(e: &yrs::undo::Event<AtomicPtr<c_void>>) -> Self {
-        let (origin, origin_len) = if let Some(origin) = e.origin.as_ref() {
+        let (origin, origin_len) = if let Some(origin) = e.origin() {
             let bytes = origin.as_ref();
             let origin_len = bytes.len() as u32;
             let origin = bytes.as_ptr() as *const c_char;
@@ -4446,14 +4446,14 @@ impl YUndoEvent {
             (null(), 0)
         };
         YUndoEvent {
-            kind: match e.kind {
+            kind: match e.kind() {
                 EventKind::Undo => Y_KIND_UNDO,
                 EventKind::Redo => Y_KIND_REDO,
             },
             origin,
             origin_len,
-            insertions: YDeleteSet::new(&e.item.insertions),
-            deletions: YDeleteSet::new(&e.item.deletions),
+            insertions: YDeleteSet::new(e.item.insertions()),
+            deletions: YDeleteSet::new(e.item.deletions()),
             meta: e.item.meta.load(Ordering::Acquire),
         }
     }

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -3,8 +3,10 @@ use std::ffi::{c_char, c_void, CStr, CString};
 use std::mem::{forget, ManuallyDrop, MaybeUninit};
 use std::ops::Deref;
 use std::ptr::{null, null_mut};
+use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::Arc;
 use yrs::block::{ClientID, ItemContent, Prelim, Unused};
+use yrs::encoding::read::Error;
 use yrs::types::array::ArrayEvent;
 use yrs::types::array::ArrayIter as NativeArrayIter;
 use yrs::types::map::MapEvent;
@@ -22,13 +24,11 @@ use yrs::undo::EventKind;
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use yrs::{
-    uuid_v4, Array, ArrayRef, Assoc, DeleteSet, GetString, Map, MapRef, Observable, OffsetKind,
-    Options, Origin, ReadTxn, Snapshot, StateVector, StickyIndex, Store, SubdocsEvent,
-    SubdocsEventIter, SubscriptionId, Text, TextRef, Transact, TransactionCleanupEvent,
-    UndoManager, Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragmentRef, XmlTextPrelim,
-    XmlTextRef, Any
+    uuid_v4, Any, Array, ArrayRef, Assoc, DeleteSet, GetString, Map, MapRef, Observable,
+    OffsetKind, Options, Origin, ReadTxn, Snapshot, StateVector, StickyIndex, Store, SubdocsEvent,
+    SubdocsEventIter, SubscriptionId, Text, TextRef, Transact, TransactionCleanupEvent, Update,
+    Xml, XmlElementPrelim, XmlElementRef, XmlFragmentRef, XmlTextPrelim, XmlTextRef,
 };
-use yrs::encoding::read::Error;
 
 /// Flag used by `YInput` and `YOutput` to tag boolean values.
 pub const Y_JSON_BOOL: i8 = -8;
@@ -613,7 +613,7 @@ pub unsafe extern "C" fn ydoc_read_transaction(doc: *mut Doc) -> *mut Transactio
 ///
 /// `origin_len` and `origin` are optional parameters to specify a byte sequence used to mark
 /// the origin of this transaction (eg. you may decide to give different origins for transaction
-/// applying remote updates). These can be used by event handlers or `UndoManager` to perform
+/// applying remote updates). These can be used by event handlers or `YUndoManager` to perform
 /// specific actions. If origin should not be set, call `ydoc_write_transaction(doc, 0, NULL)`.
 ///
 /// Returns `NULL` if read-write transaction couldn't be created, i.e. when another transaction is
@@ -4245,9 +4245,11 @@ pub unsafe extern "C" fn yevent_keys_destroy(keys: *mut YEventKeyChange, len: u3
     }
 }
 
+pub type YUndoManager = yrs::undo::UndoManager<AtomicPtr<c_void>>;
+
 #[repr(C)]
 pub struct YUndoManagerOptions {
-    pub capture_timeout_millis: u32,
+    pub capture_timeout_millis: i32,
 }
 
 #[no_mangle]
@@ -4255,7 +4257,7 @@ pub unsafe extern "C" fn yundo_manager(
     doc: *const Doc,
     ytype: *const Branch,
     options: *const YUndoManagerOptions,
-) -> *mut UndoManager {
+) -> *mut YUndoManager {
     let doc = doc.as_ref().unwrap();
     let branch = ytype.as_ref().unwrap();
 
@@ -4265,18 +4267,22 @@ pub unsafe extern "C" fn yundo_manager(
             o.capture_timeout_millis = options.capture_timeout_millis as u64;
         }
     };
-    let boxed = Box::new(UndoManager::with_options(doc, &BranchPtr::from(branch), o));
+    let boxed = Box::new(yrs::undo::UndoManager::with_options(
+        doc,
+        &BranchPtr::from(branch),
+        o,
+    ));
     Box::into_raw(boxed)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_destroy(mgr: *mut UndoManager) {
+pub unsafe extern "C" fn yundo_manager_destroy(mgr: *mut YUndoManager) {
     drop(Box::from_raw(mgr));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_add_origin(
-    mgr: *mut UndoManager,
+    mgr: *mut YUndoManager,
     origin_len: u32,
     origin: *const c_char,
 ) {
@@ -4287,7 +4293,7 @@ pub unsafe extern "C" fn yundo_manager_add_origin(
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_remove_origin(
-    mgr: *mut UndoManager,
+    mgr: *mut YUndoManager,
     origin_len: u32,
     origin: *const c_char,
 ) {
@@ -4297,14 +4303,14 @@ pub unsafe extern "C" fn yundo_manager_remove_origin(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_add_scope(mgr: *mut UndoManager, ytype: *const Branch) {
+pub unsafe extern "C" fn yundo_manager_add_scope(mgr: *mut YUndoManager, ytype: *const Branch) {
     let mgr = mgr.as_mut().unwrap();
     let branch = ytype.as_ref().unwrap();
     mgr.expand_scope(&BranchPtr::from(branch));
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_clear(mgr: *mut UndoManager) -> u8 {
+pub unsafe extern "C" fn yundo_manager_clear(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     match mgr.clear() {
         Ok(_) => Y_TRUE,
@@ -4313,31 +4319,33 @@ pub unsafe extern "C" fn yundo_manager_clear(mgr: *mut UndoManager) -> u8 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_stop(mgr: *mut UndoManager) {
+pub unsafe extern "C" fn yundo_manager_stop(mgr: *mut YUndoManager) {
     let mgr = mgr.as_mut().unwrap();
     mgr.reset();
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut UndoManager) -> u8 {
+pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     match mgr.undo() {
-        Ok(_) => Y_TRUE,
+        Ok(true) => Y_TRUE,
+        Ok(false) => Y_FALSE,
         Err(_) => Y_FALSE,
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_redo(mgr: *mut UndoManager) -> u8 {
+pub unsafe extern "C" fn yundo_manager_redo(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     match mgr.redo() {
-        Ok(_) => Y_TRUE,
+        Ok(true) => Y_TRUE,
+        Ok(false) => Y_FALSE,
         Err(_) => Y_FALSE,
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_can_undo(mgr: *mut UndoManager) -> u8 {
+pub unsafe extern "C" fn yundo_manager_can_undo(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     if mgr.can_undo() {
         Y_TRUE
@@ -4347,7 +4355,7 @@ pub unsafe extern "C" fn yundo_manager_can_undo(mgr: *mut UndoManager) -> u8 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_can_redo(mgr: *mut UndoManager) -> u8 {
+pub unsafe extern "C" fn yundo_manager_can_redo(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
     if mgr.can_redo() {
         Y_TRUE
@@ -4358,15 +4366,19 @@ pub unsafe extern "C" fn yundo_manager_can_redo(mgr: *mut UndoManager) -> u8 {
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_observe_added(
-    mgr: *mut UndoManager,
+    mgr: *mut YUndoManager,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YUndoEvent),
 ) -> u32 {
     let mgr = mgr.as_mut().unwrap();
     let subscription_id: SubscriptionId = mgr
         .observe_item_added(move |_, e| {
-            let event = YUndoEvent::new(e);
-            cb(state, &event as *const YUndoEvent);
+            let meta_ptr = {
+                let event = YUndoEvent::new(e);
+                cb(state, &event as *const YUndoEvent);
+                event.meta
+            };
+            e.item.meta.store(meta_ptr, Ordering::Release);
         })
         .into();
     subscription_id
@@ -4374,7 +4386,7 @@ pub unsafe extern "C" fn yundo_manager_observe_added(
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_unobserve_added(
-    mgr: *mut UndoManager,
+    mgr: *mut YUndoManager,
     subscription_id: u32,
 ) {
     let mgr = mgr.as_mut().unwrap();
@@ -4383,15 +4395,19 @@ pub unsafe extern "C" fn yundo_manager_unobserve_added(
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_observe_popped(
-    mgr: *mut UndoManager,
+    mgr: *mut YUndoManager,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YUndoEvent),
 ) -> u32 {
     let mgr = mgr.as_mut().unwrap();
     let subscription_id: SubscriptionId = mgr
         .observe_item_popped(move |_, e| {
-            let event = YUndoEvent::new(e);
-            cb(state, &event as *const YUndoEvent);
+            let meta_ptr = {
+                let event = YUndoEvent::new(e);
+                cb(state, &event as *const YUndoEvent);
+                event.meta
+            };
+            e.item.meta.store(meta_ptr, Ordering::Release);
         })
         .into();
     subscription_id
@@ -4399,7 +4415,7 @@ pub unsafe extern "C" fn yundo_manager_observe_popped(
 
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_unobserve_popped(
-    mgr: *mut UndoManager,
+    mgr: *mut YUndoManager,
     subscription_id: u32,
 ) {
     let mgr = mgr.as_mut().unwrap();
@@ -4416,10 +4432,11 @@ pub struct YUndoEvent {
     pub origin_len: u32,
     pub insertions: YDeleteSet,
     pub deletions: YDeleteSet,
+    pub meta: *mut c_void,
 }
 
 impl YUndoEvent {
-    unsafe fn new(e: &yrs::undo::Event) -> Self {
+    unsafe fn new(e: &yrs::undo::Event<AtomicPtr<c_void>>) -> Self {
         let (origin, origin_len) = if let Some(origin) = e.origin.as_ref() {
             let bytes = origin.as_ref();
             let origin_len = bytes.len() as u32;
@@ -4435,8 +4452,9 @@ impl YUndoEvent {
             },
             origin,
             origin_len,
-            insertions: YDeleteSet::new(e.item.insertions()),
-            deletions: YDeleteSet::new(e.item.deletions()),
+            insertions: YDeleteSet::new(&e.item.insertions),
+            deletions: YDeleteSet::new(&e.item.deletions),
+            meta: e.item.meta.load(Ordering::Acquire),
         }
     }
 }

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -4425,13 +4425,36 @@ pub unsafe extern "C" fn yundo_manager_unobserve_popped(
 pub const Y_KIND_UNDO: c_char = 0;
 pub const Y_KIND_REDO: c_char = 1;
 
+/// Event type related to `UndoManager` observer operations, such as `yundo_manager_observe_popped`
+/// and `yundo_manager_observe_added`. It contains various informations about the context in which
+/// undo/redo operations are executed.
 #[repr(C)]
 pub struct YUndoEvent {
+    /// Informs if current event is related to executed undo (`Y_KIND_UNDO`) or redo (`Y_KIND_REDO`)
+    /// operation.
     pub kind: c_char,
+    /// Origin assigned to a transaction, in context of which this event is being executed.
+    /// Transaction origin is specified via `ydoc_write_transaction(doc, origin_len, origin)`.
     pub origin: *const c_char,
+    /// Length of an `origin` field assigned to a transaction, in context of which this event is
+    /// being executed.
+    /// Transaction origin is specified via `ydoc_write_transaction(doc, origin_len, origin)`.
     pub origin_len: u32,
+    /// Set of identifiers of all insert operations that happened in a scope of a current undo/redo
+    /// operation.
     pub insertions: YDeleteSet,
+    /// Set of identifiers of all remove operations that happened in a scope of a current undo/redo
+    /// operation.
     pub deletions: YDeleteSet,
+    /// Pointer to a custom metadata object that can be passed between
+    /// `yundo_manager_observe_popped` and `yundo_manager_observe_added`. It's useful for passing
+    /// around custom user data ie. cursor position, that needs to be remembered and restored as
+    /// part of undo/redo operations.
+    ///
+    /// This field always starts with no value (`NULL`) assigned to it and can be set/unset in
+    /// corresponding callback calls. In such cases it's up to a programmer to handle allocation
+    /// and deallocation of memory that this pointer will point to. Not releasing it properly may
+    /// lead to memory leaks.
     pub meta: *mut c_void,
 }
 

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -439,6 +439,7 @@ pub mod any;
 pub mod atomic;
 mod block_iter;
 pub mod encoding;
+mod error;
 mod moving;
 pub mod observer;
 #[cfg(test)]
@@ -446,7 +447,6 @@ mod test_utils;
 #[cfg(test)]
 mod tests;
 pub mod undo;
-mod error;
 
 pub use crate::alt::{
     diff_updates_v1, diff_updates_v2, encode_state_vector_from_update_v1,
@@ -501,10 +501,10 @@ pub use crate::types::DeepObservable;
 pub use crate::types::GetString;
 pub use crate::types::Observable;
 pub use crate::types::Value;
-pub use crate::undo::UndoManager;
 pub use crate::update::Update;
 use rand::RngCore;
 
+pub type UndoManager = crate::undo::UndoManager<()>;
 pub type Uuid = std::sync::Arc<str>;
 
 /// Generate random v4 UUID.

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -566,6 +566,10 @@ impl Default for Options {
 pub struct StackItem<T> {
     deletions: DeleteSet,
     insertions: DeleteSet,
+
+    /// A custom user metadata that can be attached to a particular [StackItem]. It can be used
+    /// to carry over the additional information (such as ie. user cursor position) between
+    /// undo/redo operations.
     pub meta: T,
 }
 
@@ -606,6 +610,8 @@ impl<M> std::fmt::Display for StackItem<M> {
 
 #[derive(Debug)]
 pub struct Event<'a, M> {
+    /// Field representing the updates (both intertions and deletions), that happened over the
+    /// scope current event is related to.
     pub item: &'a mut StackItem<M>,
     origin: Option<Origin>,
     kind: EventKind,


### PR DESCRIPTION
Related #342

Atm. stack items have no means to attach metadata - users have to do it by themselves. This PR makes it possible. It also extends ywasm and yffi undo manager events to propagate meta field.