### PR TITLE
added methods to check if shared collection references has been deleted

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -1126,6 +1126,13 @@ YTransaction *ybranch_write_transaction(Branch *branch);
 YTransaction *ybranch_read_transaction(Branch *branch);
 
 /**
+ * Check if current branch is still alive (returns `Y_TRUE`, otherwise `Y_FALSE`).
+ * If it was deleted, this branch pointer is no longer a valid pointer and cannot be used to
+ * execute any functions using it.
+ */
+uint8_t ybranch_alive(Branch *branch, const YTransaction *txn);
+
+/**
  * Returns a list of subdocs existing within current document.
  */
 YDoc **ytransaction_subdocs(YTransaction *txn, uint32_t *len);

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -1130,7 +1130,7 @@ YTransaction *ybranch_read_transaction(Branch *branch);
  * If it was deleted, this branch pointer is no longer a valid pointer and cannot be used to
  * execute any functions using it.
  */
-uint8_t ybranch_alive(Branch *branch, const YTransaction *txn);
+uint8_t ytransaction_alive(const YTransaction *txn, Branch *branch);
 
 /**
  * Returns a list of subdocs existing within current document.

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -688,8 +688,8 @@ pub unsafe extern "C" fn ybranch_alive(branch: *mut Branch, txn: *const Transact
         Y_FALSE
     } else {
         let txn = txn.as_ref().unwrap();
-        let branch = BranchPtr::from(branch.as_mut().unwrap());
-        if txn.store().is_alive(&branch) {
+        let branch = branch.as_ref().unwrap();
+        if txn.store().is_alive(&BranchPtr::from(branch)) {
             Y_TRUE
         } else {
             Y_FALSE

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -683,7 +683,7 @@ pub unsafe extern "C" fn ybranch_read_transaction(branch: *mut Branch) -> *mut T
 /// If it was deleted, this branch pointer is no longer a valid pointer and cannot be used to
 /// execute any functions using it.
 #[no_mangle]
-pub unsafe extern "C" fn ybranch_alive(branch: *mut Branch, txn: *const Transaction) -> u8 {
+pub unsafe extern "C" fn ytransaction_alive(txn: *const Transaction, branch: *mut Branch) -> u8 {
     if branch.is_null() {
         Y_FALSE
     } else {

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -679,6 +679,24 @@ pub unsafe extern "C" fn ybranch_read_transaction(branch: *mut Branch) -> *mut T
     }
 }
 
+/// Check if current branch is still alive (returns `Y_TRUE`, otherwise `Y_FALSE`).
+/// If it was deleted, this branch pointer is no longer a valid pointer and cannot be used to
+/// execute any functions using it.
+#[no_mangle]
+pub unsafe extern "C" fn ybranch_alive(branch: *mut Branch, txn: *const Transaction) -> u8 {
+    if branch.is_null() {
+        Y_FALSE
+    } else {
+        let txn = txn.as_ref().unwrap();
+        let branch = BranchPtr::from(branch.as_mut().unwrap());
+        if txn.store().is_alive(&branch) {
+            Y_TRUE
+        } else {
+            Y_FALSE
+        }
+    }
+}
+
 /// Returns a list of subdocs existing within current document.
 #[no_mangle]
 pub unsafe extern "C" fn ytransaction_subdocs(

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -627,7 +627,12 @@ impl BlockPtr {
                         }
                         ItemContent::Type(branch) => {
                             branch.store = this.parent.as_branch().and_then(|b| b.store.clone());
-                            let ptr = BranchPtr::from(branch);
+                            let ptr = if this.info.is_deleted() {
+                                BranchPtr::from(branch)
+                            } else {
+                                // if current node is alive register is as such
+                                txn.store.register(branch)
+                            };
                             if let TypeRef::WeakLink(source) = &ptr.type_ref {
                                 source.materialize(txn, ptr);
                             }

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -477,8 +477,8 @@ impl BlockIter {
         let parent = TypePtr::Branch(self.branch);
         let right = self.right();
         let left = self.left();
-        let (content, remainder) = value.into_content(txn);
-        let inner_ref = if let ItemContent::Type(inner_ref) = &content {
+        let (mut content, remainder) = value.into_content(txn);
+        let inner_ref = if let ItemContent::Type(inner_ref) = &mut content {
             Some(BranchPtr::from(inner_ref))
         } else {
             None

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -899,9 +899,9 @@ mod test {
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{
-        any, Any, Array, ArrayPrelim, ArrayRef, DeleteSet, Doc, GetString, Map, MapRef, Options,
-        StateVector, SubscriptionId, Text, TextRef, Transact, Uuid, XmlElementPrelim, XmlFragment,
-        XmlFragmentRef, XmlTextRef,
+        any, Any, Array, ArrayPrelim, ArrayRef, DeleteSet, Doc, GetString, Map, MapPrelim, MapRef,
+        Options, StateVector, SubscriptionId, Text, TextRef, Transact, Uuid, XmlElementPrelim,
+        XmlFragment, XmlFragmentRef, XmlTextRef,
     };
     use std::cell::{Cell, RefCell, RefMut};
     use std::collections::BTreeSet;
@@ -2024,5 +2024,47 @@ mod test {
             "xml-element": "<xml-element><body></body></xml-element>"
         });
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn check_liveness() {
+        let d1 = Doc::new();
+        let r1 = d1.get_or_insert_map("root");
+
+        let d2 = Doc::new();
+        let r2 = d2.get_or_insert_map("root");
+
+        let mut t1 = d1.transact_mut();
+        assert!(t1.is_alive(&r1), "root is always alive");
+        let a1 = r1.insert(&mut t1, "a", MapPrelim::<i32>::new());
+        assert!(t1.is_alive(&a1), "1st level nesting");
+        let aa1 = a1.insert(&mut t1, "aa", MapPrelim::<i32>::new());
+        assert!(t1.is_alive(&aa1), "2nd level nesting");
+        drop(t1);
+
+        exchange_updates(&[&d1, &d2]);
+
+        let t2 = d2.transact();
+        let a2 = r2.get(&t2, "a").unwrap().cast::<MapRef>().unwrap();
+        let aa2 = a2.get(&t2, "aa").unwrap().cast::<MapRef>().unwrap();
+        assert!(t2.is_alive(&r2), "root is always alive (remote)");
+        assert!(t2.is_alive(&a2), "1st level nesting (remote)");
+        assert!(t2.is_alive(&aa2), "2nd level nesting (remote)");
+        drop(t2);
+
+        // delete nested
+        let mut t1 = d1.transact_mut();
+        r1.remove(&mut t1, "a");
+        assert!(t1.is_alive(&r1), "root is always alive");
+        assert!(!t1.is_alive(&a1), "child was removed");
+        assert!(!t1.is_alive(&aa1), "parent was removed");
+        drop(t1);
+
+        exchange_updates(&[&d1, &d2]);
+
+        let t2 = d2.transact();
+        assert!(t2.is_alive(&r2), "root is always alive (remote)");
+        assert!(!t2.is_alive(&a2), "child was removed (remote)");
+        assert!(!t2.is_alive(&aa2), "parent was removed (remote)");
     }
 }

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -1908,6 +1908,18 @@ impl YText {
         }
     }
 
+    /// Checks if current YText reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        if let SharedType::Integrated(value) = &*self.0.borrow() {
+            txn.is_alive(value)
+        } else {
+            false
+        }
+    }
+
     /// Returns length of an underlying string stored in this `YText` instance,
     /// understood as a number of UTF-8 encoded bytes.
     #[wasm_bindgen(js_name = length)]
@@ -2357,6 +2369,18 @@ impl YArray {
         }
     }
 
+    /// Checks if current YArray reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        if let SharedType::Integrated(value) = &*self.0.borrow() {
+            txn.is_alive(value)
+        } else {
+            false
+        }
+    }
+
     /// Returns a number of elements stored within this instance of `YArray`.
     #[wasm_bindgen(js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
@@ -2734,6 +2758,18 @@ impl YMap {
         }
     }
 
+    /// Checks if current YMap reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        if let SharedType::Integrated(value) = &*self.0.borrow() {
+            txn.is_alive(value)
+        } else {
+            false
+        }
+    }
+
     /// Returns a number of entries stored within this instance of `YMap`.
     #[wasm_bindgen(js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
@@ -2948,6 +2984,14 @@ pub struct YXmlElement(XmlElementRef);
 
 #[wasm_bindgen]
 impl YXmlElement {
+    /// Checks if current YXmlElement reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        txn.is_alive(&self.0)
+    }
+
     /// Returns a tag name of this XML node.
     #[wasm_bindgen(getter)]
     pub fn name(&self) -> JsValue {
@@ -3212,6 +3256,14 @@ pub struct YXmlFragment(XmlFragmentRef);
 
 #[wasm_bindgen]
 impl YXmlFragment {
+    /// Checks if current YXmlFragment reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        txn.is_alive(&self.0)
+    }
+
     /// Returns a number of child XML nodes stored within this `YXMlElement` instance.
     #[wasm_bindgen(js_name = length)]
     pub fn length(&self, txn: &ImplicitTransaction) -> u32 {
@@ -3377,6 +3429,14 @@ pub struct YXmlText(XmlTextRef);
 
 #[wasm_bindgen]
 impl YXmlText {
+    /// Checks if current YXmlText reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        txn.is_alive(&self.0)
+    }
+
     /// Returns length of an underlying string stored in this `YXmlText` instance,
     /// understood as a number of UTF-8 encoded bytes.
     #[wasm_bindgen]
@@ -3701,6 +3761,19 @@ impl YWeakLink {
     pub fn prelim(&self) -> bool {
         if let SharedType::Prelim(_) = &*self.0.borrow() {
             true
+        } else {
+            false
+        }
+    }
+
+    /// Checks if current YWeakLink reference is alive and has not been deleted by its parent collection.
+    /// This method only works on already integrated shared types and will return false is current
+    /// type is preliminary (has not been integrated into document).
+    #[wasm_bindgen(js_name = alive)]
+    pub fn alive(&self, txn: &YTransaction) -> bool {
+        if let SharedType::Integrated(value) = &*self.0.borrow() {
+            let branch = value.as_ref();
+            txn.store().is_alive(&BranchPtr::from(branch))
         } else {
             false
         }


### PR DESCRIPTION
Related to #347

This PR introduces set of functions to check if nested shared collection has been destroyed (therefore checked reference is no longer valid and using it will panic):

- *yrs*: `transaction.is_alive(&map_ref)` etc.
- *ywasm*: `map_ref.alive(transaction)`
- *yffi*: `ytransaction_alive(transaction, map_ref)`

This implementation is using a set in document store that keeps information about valid branch pointers around. It's filled and emptied when branch type is integrated or deleted from the document store.

In related discussion we were talking about replacing BranchPtr with synthetic pointer that's only valid in scope of the transaction however that's not fully possible in current design, since it would require to *all* operations related to shared collection to have a transaction parameter as well, which doesn't always has sense (ie. unsubscribing given type's observer).