### PR TITLE
Feature flag: weak

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: test
-        run: cargo test --release
+        run: cargo test --release --all-features
 
   test-windows:
     runs-on: windows-latest
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: test
-        run: cargo test --release
+        run: cargo test --release --all-features
 
   test-macos:
     runs-on: macos-latest
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: test
-        run: cargo test --release
+        run: cargo test --release --all-features
 
   wasm:
     runs-on: ubuntu-latest

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.16.10" }
+yrs = { path = "../yrs", version = "0.16.10", features = ["weak"] }
 rand = "0.7.0"
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://github.com/y-crdt/y-crdt/"
 repository = "https://github.com/y-crdt/y-crdt/"
 readme = "./README.md"
 
+[features]
+weak = []
+
 [dependencies]
 thiserror = "1"
 rand = { version = "0.7.0", features = ["wasm-bindgen"] }

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -4,7 +4,6 @@ use crate::moving::Move;
 use crate::store::{Store, WeakStoreRef};
 use crate::transaction::TransactionMut;
 use crate::types::text::update_current_attributes;
-use crate::types::weak::join_linked_range;
 use crate::types::{Attrs, Branch, BranchPtr, TypePtr, TypeRef, Value};
 use crate::undo::UndoStack;
 use crate::updates::decoder::{Decode, Decoder};
@@ -553,12 +552,13 @@ impl BlockPtr {
                             parent_ref.block_len += this.len;
                             parent_ref.content_len += this.content_len(encoding);
                         }
+                        #[cfg(feature = "weak")]
                         match (this.left, this.right) {
                             (Some(left), Some(right)) => match (left.deref(), right.deref()) {
                                 (Block::Item(l), Block::Item(r))
                                     if l.info.is_linked() || r.info.is_linked() =>
                                 {
-                                    join_linked_range(self_ptr, txn)
+                                    crate::types::weak::join_linked_range(self_ptr, txn)
                                 }
                                 _ => {}
                             },

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -221,6 +221,11 @@
 //!
 //! # Weak links and quotations
 //!
+//! This functionality requires a "weak" feature flag to be turned on:
+//! ```toml
+//! yrs = { version = "0.17", features = ["weak"] }
+//! ```
+//!
 //! Yrs document structure can be represented as a tree of elements. That means that usually a node
 //! can have only one parent and cannot be referenced by any other node. This can be changed by
 //! usage of weak links - they offer you a way to reference to values existing in other parts of
@@ -549,7 +554,8 @@ pub use crate::types::map::MapRef;
 pub use crate::types::text::Text;
 pub use crate::types::text::TextPrelim;
 pub use crate::types::text::TextRef;
-pub use crate::types::weak::{Quotable, WeakRef, WeakPrelim};
+#[cfg(feature = "weak")]
+pub use crate::types::weak::{Quotable, WeakPrelim, WeakRef};
 pub use crate::types::xml::Xml;
 pub use crate::types::xml::XmlElementPrelim;
 pub use crate::types::xml::XmlElementRef;

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -2,7 +2,6 @@ use crate::block::{BlockPtr, EmbedPrelim, ItemContent, Prelim, Unused};
 use crate::block_iter::BlockIter;
 use crate::moving::StickyIndex;
 use crate::transaction::TransactionMut;
-use crate::types::weak::Quotable;
 use crate::types::{
     event_change_set, Branch, BranchPtr, Change, ChangeSet, EventHandler, Observers, Path,
     SharedRef, ToJson, TypeRef, Value,
@@ -76,8 +75,10 @@ pub struct ArrayRef(BranchPtr);
 
 impl SharedRef for ArrayRef {}
 impl Array for ArrayRef {}
-impl Quotable for ArrayRef {}
 impl IndexedSequence for ArrayRef {}
+
+#[cfg(feature = "weak")]
+impl crate::Quotable for ArrayRef {}
 
 impl ToJson for ArrayRef {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -1,6 +1,5 @@
 use crate::block::{Block, BlockPtr, EmbedPrelim, ItemContent, ItemPosition, Prelim};
 use crate::transaction::TransactionMut;
-use crate::types::weak::WeakPrelim;
 use crate::types::{
     event_keys, Branch, BranchPtr, Entries, EntryChange, EventHandler, Observers, Path, SharedRef,
     ToJson, TypeRef, Value,
@@ -207,12 +206,13 @@ pub trait Map: AsRef<Branch> + Sized {
     }
 
     /// Returns [WeakPrelim] to a given `key`, if it exists in a current map.
-    fn link<T: ReadTxn>(&self, txn: &T, key: &str) -> Option<WeakPrelim<Self>> {
+    #[cfg(feature = "weak")]
+    fn link<T: ReadTxn>(&self, txn: &T, key: &str) -> Option<crate::WeakPrelim<Self>> {
         let ptr = BranchPtr::from(self.as_ref());
         let block = ptr.map.get(key)?;
         let start = StickyIndex::from_id(block.id().clone(), Assoc::Before);
         let end = StickyIndex::from_id(block.id().clone(), Assoc::After);
-        let link = WeakPrelim::new(start, end);
+        let link = crate::WeakPrelim::new(start, end);
         Some(link)
     }
 

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod array;
 pub mod map;
 pub mod text;
+#[cfg(feature = "weak")]
 pub mod weak;
 pub mod xml;
 
@@ -18,6 +19,7 @@ use crate::transaction::{Origin, TransactionMut};
 use crate::types::array::{ArrayEvent, ArrayRef};
 use crate::types::map::MapEvent;
 use crate::types::text::TextEvent;
+#[cfg(feature = "weak")]
 use crate::types::weak::{LinkSource, WeakEvent, WeakRef};
 use crate::types::xml::{XmlElementRef, XmlEvent, XmlTextEvent, XmlTextRef};
 use crate::updates::decoder::{Decode, Decoder};
@@ -72,6 +74,7 @@ pub enum TypeRef {
     XmlHook = TYPE_REFS_XML_HOOK,
     XmlText = TYPE_REFS_XML_TEXT,
     SubDoc = TYPE_REFS_DOC,
+    #[cfg(feature = "weak")]
     WeakLink(Arc<LinkSource>) = TYPE_REFS_WEAK,
     Undefined = TYPE_REFS_UNDEFINED,
 }
@@ -804,6 +807,7 @@ pub enum Value {
     YXmlFragment(XmlFragmentRef),
     YXmlText(XmlTextRef),
     YDoc(Doc),
+    #[cfg(feature = "weak")]
     YWeakLink(WeakRef<BranchPtr>),
 }
 
@@ -1163,6 +1167,7 @@ pub(crate) enum Observers {
     Map(EventHandler<crate::types::map::MapEvent>),
     XmlFragment(EventHandler<crate::types::xml::XmlEvent>),
     XmlText(EventHandler<crate::types::xml::XmlTextEvent>),
+    #[cfg(feature = "weak")]
     Weak(EventHandler<crate::types::weak::WeakEvent>),
 }
 
@@ -1586,6 +1591,7 @@ pub enum Event {
     Map(MapEvent),
     XmlFragment(XmlEvent),
     XmlText(XmlTextEvent),
+    #[cfg(feature = "weak")]
     Weak(WeakEvent),
 }
 

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -93,8 +93,9 @@ pub struct TextRef(BranchPtr);
 
 impl SharedRef for TextRef {}
 impl Text for TextRef {}
-impl Quotable for TextRef {}
 impl IndexedSequence for TextRef {}
+#[cfg(feature = "weak")]
+impl crate::Quotable for TextRef {}
 
 impl Into<XmlTextRef> for TextRef {
     fn into(self) -> XmlTextRef {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -7,8 +7,8 @@ use crate::types::{
     EntryChange, EventHandler, MapRef, Observers, Path, SharedRef, ToJson, TypePtr, TypeRef, Value,
 };
 use crate::{
-    Any, ArrayRef, GetString, IndexedSequence, Map, Observable, Quotable, ReadTxn, StickyIndex,
-    Text, TextRef, ID,
+    Any, ArrayRef, GetString, IndexedSequence, Map, Observable, ReadTxn, StickyIndex, Text,
+    TextRef, ID,
 };
 use std::borrow::Borrow;
 use std::cell::UnsafeCell;
@@ -435,8 +435,9 @@ impl XmlTextRef {
 impl SharedRef for XmlTextRef {}
 impl Xml for XmlTextRef {}
 impl Text for XmlTextRef {}
-impl Quotable for XmlTextRef {}
 impl IndexedSequence for XmlTextRef {}
+#[cfg(feature = "weak")]
+impl crate::Quotable for XmlTextRef {}
 
 impl Into<TextRef> for XmlTextRef {
     fn into(self) -> TextRef {

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.16.10" }
+yrs = { path = "../yrs", version = "0.16.10", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
This PR introduces a new feature flag "weak" turns on `WeakRef` and related features (ie. `Map::link` or `Quotable` trait).

It's turned off by default on yrs, however since yffi and ywasm cannot reference yrs conditionally, it's turned on for both of them.