### PR TITLE
fix: serialize i64

### DIFF
--- a/yrs/src/encoding/serde/ser.rs
+++ b/yrs/src/encoding/serde/ser.rs
@@ -715,4 +715,11 @@ mod test {
 
         assert_eq!(any, to_any(&any.clone()).unwrap())
     }
+
+    #[test]
+    fn test_serialize_i64_to_any() {
+        let i64_value:i64 = 1;
+        let any = to_any(i64_value).unwrap();
+        assert_eq!(any, Any::BigInt(i64_value));
+    }
 }


### PR DESCRIPTION
When an integer (e.g., `1` as `i64`) is converted to the `Any` type using `Any::from`, it is transformed into a `number` representation within the `Any` type.  For example, if you serialize `1` (as `i64`), you might expect to deserialize it back to an integer `1`, but instead, you get a floating-point `1.0`.