### PR TITLE
added root types accessor in ywasm

### DIFF
--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -266,3 +266,30 @@ export const testLiveness = tc => {
         t.assert(!aa2.alive(tx), 'parent was deleted (local)')
     })
 }
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRoots = tc => {
+    const d1 = new Y.YDoc()
+    const a = d1.getMap('a')
+    const b = d1.getText('b')
+    const c = d1.getArray('c')
+    const d = d1.getXmlFragment('d')
+
+    const roots = d1.roots()
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([k,v]) => [k, v.constructor])
+    t.compare(roots, [
+        ['a', Y.YMap],
+        ['b', Y.YText],
+        ['c', Y.YArray],
+        ['d', Y.YXmlFragment]
+    ])
+
+    a.set('hello', 'world')
+
+    let d2 = new Y.YDoc()
+    exchangeUpdates([d1, d2])
+    t.compare(d2.roots(), [['a', undefined]])
+}


### PR DESCRIPTION
Added `YDoc.roots` method to access root collection of root types.