### PR TITLE
chore: replace from with_capacity with try_reserve

### DIFF
--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1175,12 +1175,16 @@ pub const ERR_CODE_INVALID_JSON: u8 = 5;
 /// Error code: other error type than the one specified.
 pub const ERR_CODE_OTHER: u8 = 6;
 
+/// Error code: allocated buffer is too small to hold a decoded value.
+pub const ERR_NOT_ENOUGH_BYTES: u8 = 7;
+
 fn err_code(e: Error) -> u8 {
     match e {
         Error::VarIntSizeExceeded(_) => ERR_CODE_VAR_INT,
         Error::EndOfBuffer(_) => ERR_CODE_EOS,
         Error::UnexpectedValue => ERR_CODE_UNEXPECTED_VALUE,
         Error::InvalidJSON(_) => ERR_CODE_INVALID_JSON,
+        Error::NotEnoughBytes(_) => ERR_NOT_ENOUGH_BYTES,
     }
 }
 

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1175,8 +1175,8 @@ pub const ERR_CODE_INVALID_JSON: u8 = 5;
 /// Error code: other error type than the one specified.
 pub const ERR_CODE_OTHER: u8 = 6;
 
-/// Error code: allocated buffer is too small to hold a decoded value.
-pub const ERR_NOT_ENOUGH_BYTES: u8 = 7;
+/// Error code: not enough memory to perform an operation.
+pub const ERR_NOT_ENOUGH_MEMORY: u8 = 7;
 
 fn err_code(e: Error) -> u8 {
     match e {
@@ -1184,7 +1184,7 @@ fn err_code(e: Error) -> u8 {
         Error::EndOfBuffer(_) => ERR_CODE_EOS,
         Error::UnexpectedValue => ERR_CODE_UNEXPECTED_VALUE,
         Error::InvalidJSON(_) => ERR_CODE_INVALID_JSON,
-        Error::NotEnoughBytes(_) => ERR_NOT_ENOUGH_BYTES,
+        Error::NotEnoughMemory(_) => ERR_NOT_ENOUGH_MEMORY,
     }
 }
 

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -2005,7 +2005,9 @@ impl ItemContent {
             BLOCK_ITEM_DELETED_REF_NUMBER => Ok(ItemContent::Deleted(decoder.read_len()?)),
             BLOCK_ITEM_JSON_REF_NUMBER => {
                 let mut remaining = decoder.read_len()? as i32;
-                let mut buf = Vec::with_capacity(remaining as usize);
+                let mut buf = Vec::new();
+                buf.try_reserve(remaining as usize)?;
+
                 while remaining >= 0 {
                     buf.push(decoder.read_string()?.to_owned());
                     remaining -= 1;
@@ -2026,7 +2028,9 @@ impl ItemContent {
             }
             BLOCK_ITEM_ANY_REF_NUMBER => {
                 let len = decoder.read_len()? as usize;
-                let mut values = Vec::with_capacity(len);
+                let mut values = Vec::new();
+                values.try_reserve(len)?;
+
                 let mut i = 0;
                 while i < len {
                     values.push(decoder.read_any()?);

--- a/yrs/src/encoding/read.rs
+++ b/yrs/src/encoding/read.rs
@@ -1,5 +1,6 @@
-use thiserror::Error;
 use crate::encoding::varint::{Signed, SignedVarInt, VarInt};
+use std::collections::TryReserveError;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -11,6 +12,9 @@ pub enum Error {
 
     #[error("while reading, an unexpected value was found")]
     UnexpectedValue,
+
+    #[error("failed to allocate memory: {0}")]
+    NotEnoughBytes(#[from] TryReserveError),
 
     #[error("JSON parsing error: {0}")]
     InvalidJSON(#[from] serde_json::Error),

--- a/yrs/src/encoding/read.rs
+++ b/yrs/src/encoding/read.rs
@@ -14,7 +14,7 @@ pub enum Error {
     UnexpectedValue,
 
     #[error("failed to allocate memory: {0}")]
-    NotEnoughBytes(#[from] TryReserveError),
+    NotEnoughMemory(#[from] TryReserveError),
 
     #[error("JSON parsing error: {0}")]
     InvalidJSON(#[from] serde_json::Error),

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -933,7 +933,9 @@ impl Into<Store> for Update {
         for (client_id, vec) in self.blocks.clients {
             let blocks = store
                 .blocks
-                .get_client_blocks_with_capacity_mut(client_id, vec.len());
+                .get_client_blocks_with_capacity_mut(client_id, vec.len())
+                .expect("The client block should be created");
+
             for block in vec {
                 if let BlockCarrier::Block(block) = block {
                     blocks.push(block);

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -703,12 +703,10 @@ impl Decode for Update {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
         // read blocks
         let clients_len: u32 = decoder.read_var()?;
-        let mut blocks = UpdateBlocks {
-            clients: HashMap::with_capacity_and_hasher(
-                clients_len as usize,
-                BuildHasherDefault::default(),
-            ),
-        };
+        let mut clients = HashMap::with_hasher(BuildHasherDefault::default());
+        clients.try_reserve(clients_len as usize)?;
+
+        let mut blocks = UpdateBlocks { clients };
         for _ in 0..clients_len {
             let blocks_len = decoder.read_var::<u32>()? as usize;
 
@@ -717,7 +715,10 @@ impl Decode for Update {
             let blocks = blocks
                 .clients
                 .entry(client)
-                .or_insert_with(|| VecDeque::with_capacity(blocks_len));
+                .or_insert_with(|| VecDeque::new());
+            // Attempt to pre-allocate memory for the blocks. If the capacity overflows and
+            // allocation fails, return an error.
+            blocks.try_reserve(blocks_len)?;
 
             for _ in 0..blocks_len {
                 let id = ID::new(client, clock);


### PR DESCRIPTION
Replace the use of `with_capacity` with `try_reserve` in collections specifically when decoding the `Update` to better handle potential memory allocation errors. For now, this change should be applied only in the context of `Update` decoding, without altering other instances of `with_capacity` usage. 

If needed, please let me know, and I can handle the remaining tasks