### PR TITLE
release v0.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "yffi"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "rand 0.7.3",
  "yrs",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "atomic_refcell",
  "criterion",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -239,6 +239,11 @@ typedef struct StickyIndex {} StickyIndex;
  */
 #define ERR_CODE_OTHER 6
 
+/**
+ * Error code: not enough memory to perform an operation.
+ */
+#define ERR_NOT_ENOUGH_MEMORY 7
+
 #define YCHANGE_ADD 1
 
 #define YCHANGE_RETAIN 0

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.17.2", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.17.3", features = ["weak"] }
 rand = "0.7.0"
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.17.2"
+version = "0.17.3"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
@@ -23,7 +23,7 @@ serde = { version = "1.0" }
 serde_json = "1.0"
 
 [dev-dependencies]
-criterion = "~0.5"
+criterion = "0.5"
 flate2 = { version = "1.0.22", features = ["zlib-ng-compat"], default-features = false }
 ropey = "1.6.0"
 proptest = "1.2"

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.17.2", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.17.3", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by


### PR DESCRIPTION
- Fixed #371
- `Update::decode` introduced `Error:NotEnoughMemory`. Useful in cases when malformed update payload may cause panic during memory allocation. #369 
- Reworked garbage collected blocks to not occupy unnecessary memory. #365