### PR TITLE
New observers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "arc-swap"
@@ -64,15 +64,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bumpalo"
@@ -109,9 +103,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -120,15 +114,15 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
@@ -136,18 +130,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.8"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.8"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -225,36 +219,34 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "either"
@@ -264,9 +256,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys",
@@ -310,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -321,21 +313,25 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crunchy",
+]
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
@@ -353,15 +349,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.65"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -374,9 +370,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -386,9 +382,9 @@ checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
 dependencies = [
  "cc",
  "cmake",
@@ -399,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -411,18 +407,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memory_units"
@@ -432,18 +419,18 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -451,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"
@@ -463,9 +450,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "plotters"
@@ -503,9 +490,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -518,7 +505,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -549,9 +536,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -615,7 +602,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.11",
+ "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -638,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -648,28 +635,19 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -679,9 +657,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -706,11 +684,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -731,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -751,36 +729,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.196"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -798,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "str_indices"
@@ -821,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -832,35 +804,34 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -924,9 +895,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -934,24 +905,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afec9963e3d0994cac82455b2b3502b81a7f40f9a0d32181f7528d9f4b43e02"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -961,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -971,28 +942,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.38"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6433b7c56db97397842c46b67e11873eda263170afeb3a2dc74a7cb370fee0d"
+checksum = "143ddeb4f833e2ed0d252e618986e18bfc7b0e52f2d28d77d05b2f045dd8eb61"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -1004,20 +975,20 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.38"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "493fcbab756bb764fa37e6bee8cec2dd709eb4273d06d0c282a5e74275ded735"
+checksum = "a5211b7550606857312bba1d978a8ec75692eae187becc5e680444fffc5e6f89"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.65"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db499c5f66323272151db0e666cd34f78617522fb0c1604d31a27c50c206a85"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1068,18 +1039,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1092,45 +1063,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "yffi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1144,7 @@ dependencies = [
 name = "yrs"
 version = "0.17.4"
 dependencies = [
+ "arc-swap",
  "atomic_refcell",
  "criterion",
  "flate2",

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -453,6 +453,13 @@ typedef struct YXmlAttr {
 } YXmlAttr;
 
 /**
+ * Subscription to any kind of observable events, like `ymap_observe`, `ydoc_observe_updates_v1` etc.
+ * This subscription can be destroyed by calling `yunobserve` function, which will cause to unsubscribe
+ * correlated callback.
+ */
+typedef YSubscription YSubscription;
+
+/**
  * Struct representing a state of a document. It contains the last seen clocks for blocks submitted
  * per any of the clients collaborating on document updates.
  */
@@ -936,16 +943,6 @@ typedef struct YUndoEvent {
    */
   uint32_t origin_len;
   /**
-   * Set of identifiers of all insert operations that happened in a scope of a current undo/redo
-   * operation.
-   */
-  struct YDeleteSet insertions;
-  /**
-   * Set of identifiers of all remove operations that happened in a scope of a current undo/redo
-   * operation.
-   */
-  struct YDeleteSet deletions;
-  /**
    * Pointer to a custom metadata object that can be passed between
    * `yundo_manager_observe_popped` and `yundo_manager_observe_added`. It's useful for passing
    * around custom user data ie. cursor position, that needs to be remembered and restored as
@@ -1062,27 +1059,23 @@ uint8_t ydoc_should_load(YDoc *doc);
  */
 uint8_t ydoc_auto_load(YDoc *doc);
 
-uint32_t ydoc_observe_updates_v1(YDoc *doc, void *state, void (*cb)(void*, uint32_t, const char*));
+YSubscription *ydoc_observe_updates_v1(YDoc *doc, void *state, void (*cb)(void*,
+                                                                          uint32_t,
+                                                                          const char*));
 
-uint32_t ydoc_observe_updates_v2(YDoc *doc, void *state, void (*cb)(void*, uint32_t, const char*));
+YSubscription *ydoc_observe_updates_v2(YDoc *doc, void *state, void (*cb)(void*,
+                                                                          uint32_t,
+                                                                          const char*));
 
-void ydoc_unobserve_updates_v1(YDoc *doc, uint32_t subscription_id);
+YSubscription *ydoc_observe_after_transaction(YDoc *doc,
+                                              void *state,
+                                              void (*cb)(void*, struct YAfterTransactionEvent*));
 
-void ydoc_unobserve_updates_v2(YDoc *doc, uint32_t subscription_id);
+YSubscription *ydoc_observe_subdocs(YDoc *doc,
+                                    void *state,
+                                    void (*cb)(void*, struct YSubdocsEvent*));
 
-uint32_t ydoc_observe_after_transaction(YDoc *doc,
-                                        void *state,
-                                        void (*cb)(void*, struct YAfterTransactionEvent*));
-
-void ydoc_unobserve_after_transaction(YDoc *doc, uint32_t subscription_id);
-
-uint32_t ydoc_observe_subdocs(YDoc *doc, void *state, void (*cb)(void*, struct YSubdocsEvent*));
-
-void ydoc_unobserve_subdocs(YDoc *doc, uint32_t subscription_id);
-
-uint32_t ydoc_observe_clear(YDoc *doc, void *state, void (*cb)(void*, YDoc*));
-
-void ydoc_unobserve_clear(YDoc *doc, uint32_t subscription_id);
+YSubscription *ydoc_observe_clear(YDoc *doc, void *state, void (*cb)(void*, YDoc*));
 
 /**
  * Manually send a load request to a parent document of this subdoc.
@@ -2103,48 +2096,57 @@ Branch *youtput_read_yxmltext(const struct YOutput *val);
 Branch *youtput_read_yweak(const struct YOutput *val);
 
 /**
+ * Unsubscribe callback from the oberver event it was previously subscribed to.
+ */
+void yunobserve(YSubscription *subscription);
+
+/**
  * Subscribes a given callback function `cb` to changes made by this `YText` instance. Callbacks
  * are triggered whenever a `ytransaction_commit` is called.
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `ytext_unobserve` function.
+ * `yunobserve` function.
  */
-uint32_t ytext_observe(const Branch *txt, void *state, void (*cb)(void*, const struct YTextEvent*));
+YSubscription *ytext_observe(const Branch *txt, void *state, void (*cb)(void*,
+                                                                        const struct YTextEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YMap` instance. Callbacks
  * are triggered whenever a `ytransaction_commit` is called.
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `ymap_unobserve` function.
+ * `yunobserve` function.
  */
-uint32_t ymap_observe(const Branch *map, void *state, void (*cb)(void*, const struct YMapEvent*));
+YSubscription *ymap_observe(const Branch *map, void *state, void (*cb)(void*,
+                                                                       const struct YMapEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YArray` instance. Callbacks
  * are triggered whenever a `ytransaction_commit` is called.
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `yarray_unobserve` function.
+ * `yunobserve` function.
  */
-uint32_t yarray_observe(const Branch *array, void *state, void (*cb)(void*,
-                                                                     const struct YArrayEvent*));
+YSubscription *yarray_observe(const Branch *array,
+                              void *state,
+                              void (*cb)(void*, const struct YArrayEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YXmlElement` instance.
  * Callbacks are triggered whenever a `ytransaction_commit` is called.
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `yxmlelem_unobserve` function.
+ * `yunobserve` function.
  */
-uint32_t yxmlelem_observe(const Branch *xml,
-                          void *state,
-                          void (*cb)(void*, const struct YXmlEvent*));
+YSubscription *yxmlelem_observe(const Branch *xml,
+                                void *state,
+                                void (*cb)(void*, const struct YXmlEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YXmlText` instance. Callbacks
  * are triggered whenever a `ytransaction_commit` is called.
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `yxmltext_unobserve` function.
+ * `yunobserve` function.
  */
-uint32_t yxmltext_observe(const Branch *xml, void *state, void (*cb)(void*,
-                                                                     const struct YXmlTextEvent*));
+YSubscription *yxmltext_observe(const Branch *xml,
+                                void *state,
+                                void (*cb)(void*, const struct YXmlTextEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this shared type instance as well
@@ -2152,53 +2154,11 @@ uint32_t yxmltext_observe(const Branch *xml, void *state, void (*cb)(void*,
  * `ytransaction_commit` is called.
  *
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `yunobserve_deep` function.
+ * `yunobserve` function.
  */
-uint32_t yobserve_deep(Branch *ytype,
-                       void *state,
-                       void (*cb)(void*, uint32_t, const struct YEvent*));
-
-/**
- * Releases a callback subscribed via `yweak_observe` function represented by passed
- * observer parameter.
- */
-void yweak_unobserve(const Branch *txt, uint32_t subscription_id);
-
-/**
- * Releases a callback subscribed via `ytext_observe` function represented by passed
- * observer parameter.
- */
-void ytext_unobserve(const Branch *txt, uint32_t subscription_id);
-
-/**
- * Releases a callback subscribed via `yarray_observe` function represented by passed
- * observer parameter.
- */
-void yarray_unobserve(const Branch *array, uint32_t subscription_id);
-
-/**
- * Releases a callback subscribed via `ymap_observe` function represented by passed
- * observer parameter.
- */
-void ymap_unobserve(const Branch *map, uint32_t subscription_id);
-
-/**
- * Releases a callback subscribed via `yxmlelem_observe` function represented by passed
- * observer parameter.
- */
-void yxmlelem_unobserve(const Branch *xml, uint32_t subscription_id);
-
-/**
- * Releases a callback subscribed via `yxmltext_observe` function represented by passed
- * observer parameter.
- */
-void yxmltext_unobserve(const Branch *xml, uint32_t subscription_id);
-
-/**
- * Releases a callback subscribed via `yobserve_deep` function represented by passed
- * observer parameter.
- */
-void yunobserve_deep(Branch *ytype, uint32_t subscription_id);
+YSubscription *yobserve_deep(Branch *ytype, void *state, void (*cb)(void*,
+                                                                    uint32_t,
+                                                                    const struct YEvent*));
 
 /**
  * Returns a pointer to a shared collection, which triggered passed event `e`.
@@ -2389,17 +2349,13 @@ uint8_t yundo_manager_can_undo(YUndoManager *mgr);
 
 uint8_t yundo_manager_can_redo(YUndoManager *mgr);
 
-uint32_t yundo_manager_observe_added(YUndoManager *mgr,
-                                     void *state,
-                                     void (*cb)(void*, const struct YUndoEvent*));
+YSubscription *yundo_manager_observe_added(YUndoManager *mgr,
+                                           void *state,
+                                           void (*cb)(void*, const struct YUndoEvent*));
 
-void yundo_manager_unobserve_added(YUndoManager *mgr, uint32_t subscription_id);
-
-uint32_t yundo_manager_observe_popped(YUndoManager *mgr,
-                                      void *state,
-                                      void (*cb)(void*, const struct YUndoEvent*));
-
-void yundo_manager_unobserve_popped(YUndoManager *mgr, uint32_t subscription_id);
+YSubscription *yundo_manager_observe_popped(YUndoManager *mgr,
+                                            void *state,
+                                            void (*cb)(void*, const struct YUndoEvent*));
 
 /**
  * Returns a value informing what kind of Yrs shared collection given `branch` represents.
@@ -2474,10 +2430,11 @@ char *yweak_xml_string(const Branch *xml_text_link, const YTransaction *txn);
  * Subscribes a given callback function `cb` to changes made by this `YText` instance. Callbacks
  * are triggered whenever a `ytransaction_commit` is called.
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
- * `yweak_unobserve` function.
+ * `yunobserve` function.
  */
-uint32_t yweak_observe(const Branch *weak, void *state, void (*cb)(void*,
-                                                                   const struct YWeakLinkEvent*));
+YSubscription *yweak_observe(const Branch *weak,
+                             void *state,
+                             void (*cb)(void*, const struct YWeakLinkEvent*));
 
 const Weak *ymap_link(const Branch *map, const YTransaction *txn, const char *key);
 

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -87,6 +87,7 @@ typedef struct YUndoManager {} YUndoManager;
 typedef struct LinkSource {} LinkSource;
 typedef struct Unquote {} Unquote;
 typedef struct StickyIndex {} StickyIndex;
+typedef struct YSubscription {} YSubscription;
 
 
 #include <stdarg.h>

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -424,7 +424,7 @@ TEST_CASE("YText observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YTextEventTest* t = ytext_event_test_new();
-    uint32_t sub = ytext_observe(txt, (void*)t, &ytext_test_observe);
+    YSubscription* sub = ytext_observe(txt, (void*)t, &ytext_test_observe);
 
     // insert initial data to an empty YText
     ytext_insert(txt, txn, 0, "abcd", NULL);
@@ -463,7 +463,7 @@ TEST_CASE("YText observe") {
 
     // free the observer and make sure that callback is no longer called
     ytext_test_clean(t);
-    ytext_unobserve(txt, sub);
+    yunobserve(sub);
 
     txn = ydoc_write_transaction(doc, 0, NULL);
     ytext_insert(txt, txn, 1, "fgh", NULL);
@@ -482,7 +482,7 @@ TEST_CASE("YText insert embed") {
     YTransaction *txn = ydoc_write_transaction(doc, 0, NULL);
 
     YTextEventTest *t = ytext_event_test_new();
-    uint32_t sub = ytext_observe(txt, (void *) t, &ytext_test_observe);
+    YSubscription* sub = ytext_observe(txt, (void *) t, &ytext_test_observe);
 
     char* _bold = (char*)"bold";
     YInput _true = yinput_bool(1);
@@ -530,7 +530,7 @@ TEST_CASE("YText insert embed") {
     REQUIRE(*youtput_read_bool(&d.attributes->value) == 1);
 
     ytext_test_clean(t);
-    ytext_unobserve(txt, sub);
+    yunobserve(sub);
     free(t);
     ydoc_destroy(doc);
 }
@@ -616,7 +616,7 @@ TEST_CASE("YArray observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YArrayEventTest* t = yarray_event_test_new();
-    uint32_t sub = yarray_observe(array, (void*)t, &yarray_test_observe);
+    YSubscription* sub = yarray_observe(array, (void*)t, &yarray_test_observe);
 
     // insert initial data to an empty YArray
     YInput* i = (YInput*)malloc(4 * sizeof(YInput));
@@ -668,7 +668,7 @@ TEST_CASE("YArray observe") {
     yarray_test_clean(t);
 
     // free the observer and make sure that callback is no longer called
-    yarray_unobserve(array, sub);
+    yunobserve(sub);
 
     i = (YInput*)malloc(1 * sizeof(YInput));
     i[0] = yinput_long(5);
@@ -718,7 +718,7 @@ TEST_CASE("YMap observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YMapEventTest* t = ymap_event_test_new();
-    uint32_t sub = ymap_observe(map, (void*)t, &ymap_test_observe);
+    YSubscription* sub = ymap_observe(map, (void*)t, &ymap_test_observe);
 
     // insert initial data to an empty YMap
     YInput i1 = yinput_string("value1");
@@ -785,7 +785,7 @@ TEST_CASE("YMap observe") {
 
     // free the observer and make sure that callback is no longer called
     ymap_test_clean(t);
-    ymap_unobserve(map, sub);
+    yunobserve(sub);
     txn = ydoc_write_transaction(doc, 0, NULL);
     ymap_remove(map, txn, "key2");
     ytransaction_commit(txn);
@@ -836,7 +836,7 @@ TEST_CASE("YXmlText observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YXmlTextEventTest* t = yxmltext_event_test_new();
-    uint32_t sub = yxmltext_observe(txt, (void*)t, &yxmltext_test_observe);
+    YSubscription* sub = yxmltext_observe(txt, (void*)t, &yxmltext_test_observe);
 
     // insert initial data to an empty YText
     yxmltext_insert(txt, txn, 0, "abcd", NULL);
@@ -875,7 +875,7 @@ TEST_CASE("YXmlText observe") {
 
     // free the observer and make sure that callback is no longer called
     yxmltext_test_clean(t);
-    yxmltext_unobserve(txt, sub);
+    yunobserve(sub);
 
     txn = ydoc_write_transaction(doc, 0, NULL);
     yxmltext_insert(txt, txn, 1, "fgh", NULL);
@@ -930,7 +930,7 @@ TEST_CASE("YXmlElement observe") {
     YTransaction* txn = ydoc_write_transaction(doc, 0, NULL);
 
     YXmlEventTest* t = yxml_event_test_new();
-    uint32_t sub = yxmlelem_observe(xml, (void*)t, &yxml_test_observe);
+    YSubscription* sub = yxmlelem_observe(xml, (void*)t, &yxml_test_observe);
 
     // insert initial attributes
     yxmlelem_insert_attr(xml, txn, "attr1", "value1");
@@ -1034,7 +1034,7 @@ TEST_CASE("YXmlElement observe") {
 
     // free the observer and make sure that callback is no longer called
     yxml_test_clean(t);
-    yxmlelem_unobserve(xml, sub);
+    yunobserve(sub);
     txn = ydoc_write_transaction(doc, 0, NULL);
     Branch* inner = yxmlelem_insert_elem(xml, txn, 0, "head");
     ytransaction_commit(txn);
@@ -1103,7 +1103,7 @@ TEST_CASE("YArray deep observe") {
     ytransaction_commit(txn);
 
     YDeepObserveTest* state = new_ydeepobserve_test();
-    uint32_t subscription_id = yobserve_deep(array, (void *) state, ydeepobserve_test);
+    YSubscription* sub = yobserve_deep(array, (void *) state, ydeepobserve_test);
 
     txn = ydoc_write_transaction(doc, 0, NULL);
     YInput input = yinput_ymap(NULL, NULL, 0);
@@ -1129,7 +1129,7 @@ TEST_CASE("YArray deep observe") {
     REQUIRE(path[0].tag == Y_EVENT_PATH_INDEX);
     REQUIRE(path[0].value.index == 1);
 
-    yunobserve_deep(array, subscription_id);
+    yunobserve(sub);
     ydeepobserve_test_clean(state);
     free(state);
     ydoc_destroy(doc);
@@ -1142,7 +1142,7 @@ TEST_CASE("YMap deep observe") {
     ytransaction_commit(txn);
 
     YDeepObserveTest* state = new_ydeepobserve_test();
-    uint32_t subscription_id = yobserve_deep(map, (void *) state, ydeepobserve_test);
+    YSubscription* sub = yobserve_deep(map, (void *) state, ydeepobserve_test);
 
     /* map.set(txn, 'map', new Y.YMap()) */
     txn = ydoc_write_transaction(doc, 0, NULL);
@@ -1192,7 +1192,7 @@ TEST_CASE("YMap deep observe") {
     REQUIRE(path[1].tag == Y_EVENT_PATH_KEY);
     REQUIRE(!strcmp(path[1].value.key, "array"));
 
-    yunobserve_deep(map, subscription_id);
+    yunobserve(sub);
     ydeepobserve_test_clean(state);
     free(state);
     ydoc_destroy(doc);
@@ -1240,7 +1240,7 @@ TEST_CASE("YDoc observe updates V1") {
 
     YDoc *doc2 = ydoc_new_with_id(2);
     Branch *txt2 = ytext(doc2, "test");
-    uint32_t subscription_id = ydoc_observe_updates_v1(doc2, t, observe_updates);
+    YSubscription* sub = ydoc_observe_updates_v1(doc2, t, observe_updates);
     txn = ydoc_write_transaction(doc2, 0, NULL);
     ytransaction_apply(txn, t->update, t->len);
     ytransaction_commit(txn);
@@ -1250,7 +1250,7 @@ TEST_CASE("YDoc observe updates V1") {
     reset_observe_updates(t);
 
     // check unsubscribe
-    ydoc_unobserve_updates_v1(doc2, subscription_id);
+    yunobserve(sub);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);
     ytext_insert(txt1, txn, 5, " world", NULL);
@@ -1282,7 +1282,7 @@ TEST_CASE("YDoc observe updates V2") {
 
     YDoc *doc2 = ydoc_new_with_id(2);
     Branch *txt2 = ytext(doc2, "test");
-    uint32_t subscription_id = ydoc_observe_updates_v2(doc2, t, observe_updates);
+    YSubscription* sub = ydoc_observe_updates_v2(doc2, t, observe_updates);
     txn = ydoc_write_transaction(doc2, 0, NULL);
     ytransaction_apply_v2(txn, t->update, t->len);
     ytransaction_commit(txn);
@@ -1292,7 +1292,7 @@ TEST_CASE("YDoc observe updates V2") {
     reset_observe_updates(t);
 
     // check unsubscribe
-    ydoc_unobserve_updates_v2(doc2, subscription_id);
+    yunobserve(sub);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);
     ytext_insert(txt1, txn, 5, " world", NULL);
@@ -1388,7 +1388,7 @@ TEST_CASE("YDoc observe after transaction") {
 
     YDoc *doc1 = ydoc_new_with_id(CLIENT_ID);
     Branch *txt1 = ytext(doc1, "test");
-    uint32_t subscription_id = ydoc_observe_after_transaction(doc1, &t, observe_after_transaction);
+    YSubscription* sub = ydoc_observe_after_transaction(doc1, &t, observe_after_transaction);
 
     YTransaction *txn = ydoc_write_transaction(doc1, 0, NULL);
     ytext_insert(txt1, txn, 0, "hello world", NULL);
@@ -1416,7 +1416,7 @@ TEST_CASE("YDoc observe after transaction") {
 
     REQUIRE_EQ(t.calls, 2);
 
-    ydoc_unobserve_after_transaction(doc1, subscription_id);
+    yunobserve(sub);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);
     ytext_insert(txt1, txn, 4, " the door", NULL);
@@ -1505,7 +1505,7 @@ TEST_CASE("YDoc observe subdocs") {
     YDoc *doc1 = ydoc_new_with_id(1);
     SubdocsTest t;
     memset(t.total, '\0', 20);
-    uint32_t subscription_id = ydoc_observe_subdocs(doc1, &t, observe_subdocs);
+    YSubscription* sub = ydoc_observe_subdocs(doc1, &t, observe_subdocs);
     Branch* subdocs = ymap(doc1, "mysubdocs");
 
     YOptions options = yoptions();
@@ -1613,7 +1613,7 @@ TEST_CASE("YDoc observe subdocs") {
     uint32_t update_len = 0;
     char* update = ytransaction_state_diff_v1(txn, NULL, 0, &update_len);
     ytransaction_commit(txn);
-    ydoc_unobserve_subdocs(doc1, subscription_id);
+    yunobserve(sub);
 
     YDoc *doc2 = ydoc_new_with_id(2);
     subscription_id = ydoc_observe_subdocs(doc2, &t, observe_subdocs);

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1616,7 +1616,7 @@ TEST_CASE("YDoc observe subdocs") {
     yunobserve(sub);
 
     YDoc *doc2 = ydoc_new_with_id(2);
-    subscription_id = ydoc_observe_subdocs(doc2, &t, observe_subdocs);
+    sub = ydoc_observe_subdocs(doc2, &t, observe_subdocs);
 
     txn = ydoc_write_transaction(doc2, 0, NULL);
     ytransaction_apply(txn,update, update_len);

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/tests-wasm/y-undo.tests.js
+++ b/tests-wasm/y-undo.tests.js
@@ -206,11 +206,11 @@ export const testUndoEvents = tc => {
     let counter = 0
     let receivedMetadata = -1
     undoManager.onStackItemAdded( event => {
-        event.stackItem.meta = event.stackItem.meta || new Map()
-        event.stackItem.meta.set('test', counter++)
+        event.meta = event.meta || {}
+        event.meta.test = counter++
     })
     undoManager.onStackItemPopped(event => {
-        receivedMetadata = event.stackItem.meta.get('test')
+        receivedMetadata = event.meta.test
     })
     text0.insert(0, 'abc')
     undoManager.undo()

--- a/yffi/cbindgen.toml
+++ b/yffi/cbindgen.toml
@@ -91,6 +91,7 @@ typedef struct YUndoManager {} YUndoManager;
 typedef struct LinkSource {} LinkSource;
 typedef struct Unquote {} Unquote;
 typedef struct StickyIndex {} StickyIndex;
+typedef struct YSubscription {} YSubscription;
 """
 
 trailer = """
@@ -108,7 +109,8 @@ exclude = [
     "MapIter",
     "Attributes",
     "TreeWalker",
-    "YUndoManager"
+    "YUndoManager",
+    "YSubscription"
 ]
 
 [export.rename]

--- a/yffi/cbindgen.toml
+++ b/yffi/cbindgen.toml
@@ -127,3 +127,4 @@ exclude = [
 "Attributes" = "YXmlAttrIter"
 "Observer" = "YObserver"
 "UndoManager" = "YUndoManager"
+"Subscription" = "YSubscription"

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -25,9 +25,8 @@ use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use yrs::{
     uuid_v4, Any, Array, ArrayRef, Assoc, DeleteSet, GetString, Map, MapRef, Observable,
     OffsetKind, Options, Origin, Quotable, ReadTxn, Snapshot, StateVector, StickyIndex, Store,
-    SubdocsEvent, SubdocsEventIter, SubscriptionId, Text, TextRef, Transact,
-    TransactionCleanupEvent, Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragmentRef,
-    XmlTextPrelim, XmlTextRef,
+    SubdocsEvent, SubdocsEventIter, Text, TextRef, Transact, TransactionCleanupEvent, Update, Xml,
+    XmlElementPrelim, XmlElementRef, XmlFragmentRef, XmlTextPrelim, XmlTextRef,
 };
 
 /// Flag used by `YInput` and `YOutput` to tag boolean values.

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -3432,7 +3432,7 @@ pub unsafe extern "C" fn ytext_observe(
 ) -> u32 {
     assert!(!txt.is_null());
 
-    let mut txt = TextRef::from_raw_branch(txt);
+    let txt = TextRef::from_raw_branch(txt);
     let observer = txt.observe(move |txn, e| {
         let e = YTextEvent::new(e, txn);
         cb(state, &e as *const YTextEvent);
@@ -3453,7 +3453,7 @@ pub unsafe extern "C" fn ymap_observe(
 ) -> u32 {
     assert!(!map.is_null());
 
-    let mut map = MapRef::from_raw_branch(map);
+    let map = MapRef::from_raw_branch(map);
     let observer = map.observe(move |txn, e| {
         let e = YMapEvent::new(e, txn);
         cb(state, &e as *const YMapEvent);
@@ -3474,7 +3474,7 @@ pub unsafe extern "C" fn yarray_observe(
 ) -> u32 {
     assert!(!array.is_null());
 
-    let mut array = ArrayRef::from_raw_branch(array);
+    let array = ArrayRef::from_raw_branch(array);
     let observer = array.observe(move |txn, e| {
         let e = YArrayEvent::new(e, txn);
         cb(state, &e as *const YArrayEvent);
@@ -3495,7 +3495,7 @@ pub unsafe extern "C" fn yxmlelem_observe(
 ) -> u32 {
     assert!(!xml.is_null());
 
-    let mut xml = XmlElementRef::from_raw_branch(xml);
+    let xml = XmlElementRef::from_raw_branch(xml);
     let observer = xml.observe(move |txn, e| {
         let e = YXmlEvent::new(e, txn);
         cb(state, &e as *const YXmlEvent);
@@ -3516,7 +3516,7 @@ pub unsafe extern "C" fn yxmltext_observe(
 ) -> u32 {
     assert!(!xml.is_null());
 
-    let mut xml = XmlTextRef::from_raw_branch(xml);
+    let xml = XmlTextRef::from_raw_branch(xml);
     let observer = xml.observe(move |txn, e| {
         let e = YXmlTextEvent::new(e, txn);
         cb(state, &e as *const YXmlTextEvent);
@@ -5267,7 +5267,7 @@ pub unsafe extern "C" fn yweak_observe(
 ) -> u32 {
     assert!(!weak.is_null());
 
-    let mut txt: WeakRef<BranchPtr> = WeakRef::from_raw_branch(weak);
+    let txt: WeakRef<BranchPtr> = WeakRef::from_raw_branch(weak);
     let observer = txt.observe(move |txn, e| {
         let e = YWeakLinkEvent::new(e, txn);
         cb(state, &e as *const YWeakLinkEvent);

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -120,6 +120,11 @@ pub type Doc = yrs::Doc;
 /// the same branch may result in undefined behavior.
 pub type Branch = yrs::types::Branch;
 
+/// Subscription to any kind of observable events, like `ymap_observe`, `ydoc_observe_updates_v1` etc.
+/// This subscription can be destroyed by calling `yunobserve` function, which will cause to unsubscribe
+/// correlated callback.
+pub type Subscription = yrs::Subscription;
+
 /// Iterator structure used by shared array data type.
 #[repr(transparent)]
 pub struct ArrayIter(NativeArrayIter<&'static Transaction, Transaction>);
@@ -462,17 +467,16 @@ pub unsafe extern "C" fn ydoc_observe_updates_v1(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, u32, *const c_char),
-) -> u32 {
+) -> *mut Subscription {
     let doc = doc.as_ref().unwrap();
-    let observer = doc
+    let subscription = doc
         .observe_update_v1(move |_, e| {
             let bytes = &e.update;
             let len = bytes.len() as u32;
             cb(state, len, bytes.as_ptr() as *const c_char)
         })
         .unwrap();
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 #[no_mangle]
@@ -480,29 +484,16 @@ pub unsafe extern "C" fn ydoc_observe_updates_v2(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, u32, *const c_char),
-) -> u32 {
+) -> *mut Subscription {
     let doc = doc.as_ref().unwrap();
-    let observer = doc
+    let subscription = doc
         .observe_update_v2(move |_, e| {
             let bytes = &e.update;
             let len = bytes.len() as u32;
             cb(state, len, bytes.as_ptr() as *const c_char)
         })
         .unwrap();
-    let subscription_id: u32 = observer.into();
-    subscription_id
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_updates_v1(doc: *mut Doc, subscription_id: u32) {
-    let doc = doc.as_ref().unwrap();
-    doc.unobserve_update_v1(subscription_id as SubscriptionId);
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_updates_v2(doc: *mut Doc, subscription_id: u32) {
-    let doc = doc.as_ref().unwrap();
-    doc.unobserve_update_v2(subscription_id as SubscriptionId);
+    Box::into_raw(Box::new(subscription))
 }
 
 #[no_mangle]
@@ -510,22 +501,15 @@ pub unsafe extern "C" fn ydoc_observe_after_transaction(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *mut YAfterTransactionEvent),
-) -> u32 {
+) -> *mut Subscription {
     let doc = doc.as_ref().unwrap();
-    let observer = doc
+    let subscription = doc
         .observe_transaction_cleanup(move |_, e| {
             let mut event = YAfterTransactionEvent::new(e);
             cb(state, (&mut event) as *mut _);
         })
         .unwrap();
-    let subscription_id: u32 = observer.into();
-    subscription_id
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_after_transaction(doc: *mut Doc, subscription_id: u32) {
-    let doc = doc.as_ref().unwrap();
-    doc.unobserve_transaction_cleanup(subscription_id as SubscriptionId);
+    Box::into_raw(Box::new(subscription))
 }
 
 #[no_mangle]
@@ -533,22 +517,15 @@ pub unsafe extern "C" fn ydoc_observe_subdocs(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *mut YSubdocsEvent),
-) -> u32 {
+) -> *mut Subscription {
     let doc = doc.as_mut().unwrap();
-    let observer = doc
+    let subscription = doc
         .observe_subdocs(move |_, e| {
             let mut event = YSubdocsEvent::new(e);
             cb(state, (&mut event) as *mut _);
         })
         .unwrap();
-    let subscription_id: u32 = observer.into();
-    subscription_id
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_subdocs(doc: *mut Doc, subscription_id: u32) {
-    let doc = doc.as_ref().unwrap();
-    doc.unobserve_subdocs(subscription_id as SubscriptionId);
+    Box::into_raw(Box::new(subscription))
 }
 
 #[no_mangle]
@@ -556,19 +533,12 @@ pub unsafe extern "C" fn ydoc_observe_clear(
     doc: *mut Doc,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *mut Doc),
-) -> u32 {
+) -> *mut Subscription {
     let doc = doc.as_mut().unwrap();
-    let observer = doc
+    let subscription = doc
         .observe_destroy(move |_, e| cb(state, e as *const Doc as *mut _))
         .unwrap();
-    let subscription_id: u32 = observer.into();
-    subscription_id
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn ydoc_unobserve_clear(doc: *mut Doc, subscription_id: u32) {
-    let doc = doc.as_ref().unwrap();
-    doc.unobserve_destroy(subscription_id as SubscriptionId);
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Manually send a load request to a parent document of this subdoc.
@@ -3419,109 +3389,110 @@ pub unsafe extern "C" fn youtput_read_yweak(val: *const YOutput) -> *mut Branch 
     }
 }
 
+/// Unsubscribe callback from the oberver event it was previously subscribed to.
+#[no_mangle]
+pub unsafe extern "C" fn yunobserve(subscription: *mut Subscription) {
+    drop(unsafe { Box::from_raw(subscription) })
+}
+
 /// Subscribes a given callback function `cb` to changes made by this `YText` instance. Callbacks
 /// are triggered whenever a `ytransaction_commit` is called.
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `ytext_unobserve` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn ytext_observe(
     txt: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YTextEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!txt.is_null());
 
     let txt = TextRef::from_raw_branch(txt);
-    let observer = txt.observe(move |txn, e| {
+    let subscription = txt.observe(move |txn, e| {
         let e = YTextEvent::new(e, txn);
         cb(state, &e as *const YTextEvent);
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YMap` instance. Callbacks
 /// are triggered whenever a `ytransaction_commit` is called.
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `ymap_unobserve` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn ymap_observe(
     map: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YMapEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!map.is_null());
 
     let map = MapRef::from_raw_branch(map);
-    let observer = map.observe(move |txn, e| {
+    let subscription = map.observe(move |txn, e| {
         let e = YMapEvent::new(e, txn);
         cb(state, &e as *const YMapEvent);
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YArray` instance. Callbacks
 /// are triggered whenever a `ytransaction_commit` is called.
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `yarray_unobserve` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn yarray_observe(
     array: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YArrayEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!array.is_null());
 
     let array = ArrayRef::from_raw_branch(array);
-    let observer = array.observe(move |txn, e| {
+    let subscription = array.observe(move |txn, e| {
         let e = YArrayEvent::new(e, txn);
         cb(state, &e as *const YArrayEvent);
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YXmlElement` instance.
 /// Callbacks are triggered whenever a `ytransaction_commit` is called.
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `yxmlelem_unobserve` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn yxmlelem_observe(
     xml: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YXmlEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!xml.is_null());
 
     let xml = XmlElementRef::from_raw_branch(xml);
-    let observer = xml.observe(move |txn, e| {
+    let subscription = xml.observe(move |txn, e| {
         let e = YXmlEvent::new(e, txn);
         cb(state, &e as *const YXmlEvent);
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Subscribes a given callback function `cb` to changes made by this `YXmlText` instance. Callbacks
 /// are triggered whenever a `ytransaction_commit` is called.
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `yxmltext_unobserve` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn yxmltext_observe(
     xml: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YXmlTextEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!xml.is_null());
 
     let xml = XmlTextRef::from_raw_branch(xml);
-    let observer = xml.observe(move |txn, e| {
+    let subscription = xml.observe(move |txn, e| {
         let e = YXmlTextEvent::new(e, txn);
         cb(state, &e as *const YXmlTextEvent);
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Subscribes a given callback function `cb` to changes made by this shared type instance as well
@@ -3529,23 +3500,22 @@ pub unsafe extern "C" fn yxmltext_observe(
 /// `ytransaction_commit` is called.
 ///
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `yunobserve_deep` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn yobserve_deep(
     ytype: *mut Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, u32, *const YEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!ytype.is_null());
 
     let branch = ytype.as_mut().unwrap();
-    let observer = branch.observe_deep(move |txn, events| {
+    let subscription = branch.observe_deep(move |txn, events| {
         let events: Vec<_> = events.iter().map(|e| YEvent::new(txn, e)).collect();
         let len = events.len() as u32;
         cb(state, len, events.as_ptr());
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 /// Event generated for callbacks subscribed using `ydoc_observe_after_transaction`. It contains
@@ -3999,63 +3969,6 @@ impl Deref for YWeakLinkEvent {
     }
 }
 
-/// Releases a callback subscribed via `yweak_observe` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn yweak_unobserve(txt: *const Branch, subscription_id: u32) {
-    let weak: WeakRef<BranchPtr> = WeakRef::from_raw_branch(txt);
-    weak.unobserve(subscription_id as SubscriptionId);
-}
-
-/// Releases a callback subscribed via `ytext_observe` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn ytext_unobserve(txt: *const Branch, subscription_id: u32) {
-    let txt = TextRef::from_raw_branch(txt);
-    txt.unobserve(subscription_id as SubscriptionId);
-}
-
-/// Releases a callback subscribed via `yarray_observe` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn yarray_unobserve(array: *const Branch, subscription_id: u32) {
-    let txt = ArrayRef::from_raw_branch(array);
-    txt.unobserve(subscription_id as SubscriptionId);
-}
-
-/// Releases a callback subscribed via `ymap_observe` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn ymap_unobserve(map: *const Branch, subscription_id: u32) {
-    let map = MapRef::from_raw_branch(map);
-    map.unobserve(subscription_id as SubscriptionId);
-}
-
-/// Releases a callback subscribed via `yxmlelem_observe` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn yxmlelem_unobserve(xml: *const Branch, subscription_id: u32) {
-    let xml = XmlElementRef::from_raw_branch(xml);
-    xml.unobserve(subscription_id as SubscriptionId);
-}
-
-/// Releases a callback subscribed via `yxmltext_observe` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn yxmltext_unobserve(xml: *const Branch, subscription_id: u32) {
-    let xml = XmlTextRef::from_raw_branch(xml);
-    xml.unobserve(subscription_id as SubscriptionId);
-}
-
-/// Releases a callback subscribed via `yobserve_deep` function represented by passed
-/// observer parameter.
-#[no_mangle]
-pub unsafe extern "C" fn yunobserve_deep(ytype: *mut Branch, subscription_id: u32) {
-    assert!(!ytype.is_null());
-    let branch = ytype.as_mut().unwrap();
-    branch.unobserve_deep(subscription_id as SubscriptionId);
-}
-
 /// Returns a pointer to a shared collection, which triggered passed event `e`.
 #[no_mangle]
 pub unsafe extern "C" fn ytext_event_target(e: *const YTextEvent) -> *mut Branch {
@@ -4505,28 +4418,17 @@ pub unsafe extern "C" fn yundo_manager_observe_added(
     mgr: *mut YUndoManager,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YUndoEvent),
-) -> u32 {
+) -> *mut Subscription {
     let mgr = mgr.as_mut().unwrap();
-    let subscription_id: SubscriptionId = mgr
-        .observe_item_added(move |_, e| {
-            let meta_ptr = {
-                let event = YUndoEvent::new(e);
-                cb(state, &event as *const YUndoEvent);
-                event.meta
-            };
-            e.item.meta.store(meta_ptr, Ordering::Release);
-        })
-        .into();
-    subscription_id
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn yundo_manager_unobserve_added(
-    mgr: *mut YUndoManager,
-    subscription_id: u32,
-) {
-    let mgr = mgr.as_mut().unwrap();
-    mgr.unobserve_item_added(subscription_id as SubscriptionId);
+    let subscription = mgr.observe_item_added(move |_, e| {
+        let meta_ptr = {
+            let event = YUndoEvent::new(e);
+            cb(state, &event as *const YUndoEvent);
+            event.meta
+        };
+        e.meta().store(meta_ptr, Ordering::Release);
+    });
+    Box::into_raw(Box::new(subscription))
 }
 
 #[no_mangle]
@@ -4534,28 +4436,19 @@ pub unsafe extern "C" fn yundo_manager_observe_popped(
     mgr: *mut YUndoManager,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YUndoEvent),
-) -> u32 {
+) -> *mut Subscription {
     let mgr = mgr.as_mut().unwrap();
-    let subscription_id: SubscriptionId = mgr
+    let subscription = mgr
         .observe_item_popped(move |_, e| {
             let meta_ptr = {
                 let event = YUndoEvent::new(e);
                 cb(state, &event as *const YUndoEvent);
                 event.meta
             };
-            e.item.meta.store(meta_ptr, Ordering::Release);
+            e.meta().store(meta_ptr, Ordering::Release);
         })
         .into();
-    subscription_id
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn yundo_manager_unobserve_popped(
-    mgr: *mut YUndoManager,
-    subscription_id: u32,
-) {
-    let mgr = mgr.as_mut().unwrap();
-    mgr.unobserve_item_popped(subscription_id as SubscriptionId);
+    Box::into_raw(Box::new(subscription))
 }
 
 pub const Y_KIND_UNDO: c_char = 0;
@@ -4576,12 +4469,6 @@ pub struct YUndoEvent {
     /// being executed.
     /// Transaction origin is specified via `ydoc_write_transaction(doc, origin_len, origin)`.
     pub origin_len: u32,
-    /// Set of identifiers of all insert operations that happened in a scope of a current undo/redo
-    /// operation.
-    pub insertions: YDeleteSet,
-    /// Set of identifiers of all remove operations that happened in a scope of a current undo/redo
-    /// operation.
-    pub deletions: YDeleteSet,
     /// Pointer to a custom metadata object that can be passed between
     /// `yundo_manager_observe_popped` and `yundo_manager_observe_added`. It's useful for passing
     /// around custom user data ie. cursor position, that needs to be remembered and restored as
@@ -4611,9 +4498,7 @@ impl YUndoEvent {
             },
             origin,
             origin_len,
-            insertions: YDeleteSet::new(e.item.insertions()),
-            deletions: YDeleteSet::new(e.item.deletions()),
-            meta: e.item.meta.load(Ordering::Acquire),
+            meta: e.meta().load(Ordering::Acquire),
         }
     }
 }
@@ -5257,22 +5142,21 @@ pub unsafe extern "C" fn yweak_xml_string(
 /// Subscribes a given callback function `cb` to changes made by this `YText` instance. Callbacks
 /// are triggered whenever a `ytransaction_commit` is called.
 /// Returns a subscription ID which can be then used to unsubscribe this callback by using
-/// `yweak_unobserve` function.
+/// `yunobserve` function.
 #[no_mangle]
 pub unsafe extern "C" fn yweak_observe(
     weak: *const Branch,
     state: *mut c_void,
     cb: extern "C" fn(*mut c_void, *const YWeakLinkEvent),
-) -> u32 {
+) -> *mut Subscription {
     assert!(!weak.is_null());
 
     let txt: WeakRef<BranchPtr> = WeakRef::from_raw_branch(weak);
-    let observer = txt.observe(move |txn, e| {
+    let subscription = txt.observe(move |txn, e| {
         let e = YWeakLinkEvent::new(e, txn);
         cb(state, &e as *const YWeakLinkEvent);
     });
-    let subscription_id: u32 = observer.into();
-    subscription_id
+    Box::into_raw(Box::new(subscription))
 }
 
 #[no_mangle]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -19,6 +19,7 @@ rand = { version = "0.7.0", features = ["wasm-bindgen"] }
 smallstr = { version = "0.3", features = ["union"]}
 smallvec = { version = "1.11", features = ["union", "const_generics", "const_new"]}
 atomic_refcell = "0.1"
+arc-swap = "1.6"
 serde = { version = "1.0" }
 serde_json = "1.0"
 

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,4 +1,5 @@
 use crate::block::{BlockCell, BlockRange, ClientID, Item, ItemPtr, GC, ID};
+use crate::encoding::read::Error;
 use crate::slice::ItemSlice;
 use crate::types::TypePtr;
 use crate::utils::client_hasher::ClientHasher;
@@ -8,7 +9,6 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::ops::{Index, IndexMut};
 use std::vec::Vec;
-use crate::encoding::read::Error;
 
 /// A resizable list of blocks inserted by a single client.
 #[derive(PartialEq, Default)]
@@ -45,9 +45,7 @@ impl ClientBlockList {
     pub fn with_capacity(capacity: usize) -> Result<ClientBlockList, Error> {
         let mut list = Vec::new();
         list.try_reserve(capacity)?;
-        Ok(ClientBlockList {
-            list
-        })
+        Ok(ClientBlockList { list })
     }
 
     pub fn clock(&self) -> u32 {
@@ -217,7 +215,7 @@ impl BlockStore {
                 let list = e.get_mut();
                 list.push(block.into());
             }
-            Entry::Vacant(mut e) => {
+            Entry::Vacant(e) => {
                 let list = e.insert(ClientBlockList::default());
                 list.push(block.into());
             }
@@ -340,7 +338,6 @@ impl BlockStore {
                 Ok(e.insert(list))
             }
         }
-
     }
 
     /// Given block pointer, tries to split it, returning a true, if block was split in result of

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -230,7 +230,7 @@ impl BlockStore {
                 let list = e.get_mut();
                 list.push(gc);
             }
-            Entry::Vacant(mut e) => {
+            Entry::Vacant(e) => {
                 let list = e.insert(ClientBlockList::default());
                 list.push(gc);
             }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -448,10 +448,8 @@ impl Doc {
         }
         // super.destroy(): cleanup the events
         if let Some(events) = txn.store_mut().events.take() {
-            if let Some(handler) = events.destroy_events.as_ref() {
-                for cb in handler.callbacks() {
-                    cb(&txn, self)
-                }
+            for cb in events.destroy_events.callbacks() {
+                cb(&txn, self)
             }
         }
     }

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, ClientID, ItemContent, GC};
+use crate::block::{BlockCell, ClientID, GC};
 use crate::{TransactionMut, ID};
 use std::collections::HashMap;
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -911,7 +911,7 @@ mod test {
         let txt = doc.get_or_insert_text("test");
         txt.push(&mut doc.transact_mut(), "testab");
         ds.insert(ID::new(1, 5), 1);
-        let mut txn = doc.transact_mut();
+        let txn = doc.transact_mut();
         let mut i = ds.deleted_blocks();
         let ptr = i.next(&txn).unwrap();
         let start = ptr.clock_start();

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -538,7 +538,7 @@ pub use crate::moving::IndexScope;
 pub use crate::moving::IndexedSequence;
 pub use crate::moving::Offset;
 pub use crate::moving::StickyIndex;
-pub use crate::observer::{Observer, Subscription, SubscriptionId};
+pub use crate::observer::{Observer, SharedRefObserver, Subscription, SubscriptionId};
 pub use crate::state_vector::Snapshot;
 pub use crate::state_vector::StateVector;
 pub use crate::store::Store;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -527,10 +527,6 @@ pub use crate::doc::Doc;
 pub use crate::doc::OffsetKind;
 pub use crate::doc::Options;
 pub use crate::doc::Transact;
-pub use crate::doc::{
-    AfterTransactionSubscription, DestroySubscription, SubdocsSubscription,
-    TransactionCleanupSubscription, UpdateSubscription,
-};
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
 pub use crate::moving::Assoc;
@@ -538,7 +534,7 @@ pub use crate::moving::IndexScope;
 pub use crate::moving::IndexedSequence;
 pub use crate::moving::Offset;
 pub use crate::moving::StickyIndex;
-pub use crate::observer::{Observer, SharedRefObserver, Subscription, SubscriptionId};
+pub use crate::observer::{Observer, ObserverMut, Subscription};
 pub use crate::state_vector::Snapshot;
 pub use crate::state_vector::StateVector;
 pub use crate::store::Store;

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -1,53 +1,24 @@
-use crate::types::Event;
 use crate::TransactionMut;
-use arc_swap::{ArcSwapOption, Guard, RefCnt};
+use arc_swap::ArcSwapOption;
 use smallvec::{smallvec, SmallVec};
 use std::fmt::Debug;
 use std::sync::{Arc, Weak};
 
-pub type SubscriptionId = usize;
-
-pub trait Func: RefCnt + Sized {
-    type Weak;
-    fn weak(this: &Self) -> Self::Weak;
-}
-
-impl<T> Func for Arc<T> {
-    type Weak = Weak<T>;
-
-    fn weak(this: &Self) -> Self::Weak {
-        Arc::downgrade(this)
-    }
-}
-
-type WeakCallbacks<F> = SmallVec<[F; 1]>;
+pub type Callback<E> = Arc<dyn Fn(&TransactionMut, &E) + 'static>;
+type WeakCallback<E> = Weak<dyn Fn(&TransactionMut, &E) + 'static>;
+type WeakCallbacks<E> = SmallVec<[WeakCallback<E>; 1]>;
 
 /// Data structure used to handle publish/subscribe callbacks of specific type. Observers perform
 /// subscriber changes in thread-safe manner, using atomic hardware intrinsics.
-///
-/// # Example
-///
-/// ```rust
-/// use std::sync::Arc;
-/// use yrs::Observer;
-///
-/// let observer: Observer<Arc<dyn Fn(u32)->()>> = Observer::new();
-/// let a = observer.subscribe(Arc::new(|arg| println!("A: {}", arg)));
-/// let b = observer.subscribe(Arc::new(|arg| println!("B: {}", arg)));
-///
-/// // get snapshot of all active callbacks
-/// for cb in observer.callbacks() {
-///     cb(1);
-/// }
-///
-/// drop(a); // unsubscribe callback
-/// ```
 #[derive(Debug)]
-pub struct Observer<F: Func> {
-    inner: ArcSwapOption<WeakCallbacks<F::Weak>>,
+pub struct Observer<E> {
+    inner: ArcSwapOption<WeakCallbacks<E>>,
 }
 
-impl<F: Func> Observer<F> {
+unsafe impl<E: Send> Send for Observer<E> {}
+unsafe impl<E: Sync> Sync for Observer<E> {}
+
+impl<E> Observer<E> {
     /// Creates a new [Observer] with no active callbacks.
     pub fn new() -> Self {
         Observer {
@@ -55,21 +26,38 @@ impl<F: Func> Observer<F> {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
-        let guard = self.inner.load();
-        if let Some(callbacks) = guard.as_ref() {
-            callbacks.is_empty()
-        } else {
-            true
-        }
+    /// Cleanup already released subscriptions. Whenever a [Subscription] is dropped, the callback is released. However,
+    /// the weak reference to callback may still be kept around until it becomes touched by operations such as
+    /// [Observer::subscribe] or [Observer::callbacks].
+    ///
+    /// This method allows to perform stale callback cleanup without waiting for callbacks to be visited.
+    pub fn clean(&self) {
+        self.inner.rcu(|callbacks| match callbacks {
+            None => None,
+            Some(links) => {
+                let mut res = WeakCallbacks::with_capacity(links.len() - 1);
+                for l in links.iter() {
+                    if Weak::strong_count(l) != 0 {
+                        res.push(l.clone());
+                    }
+                }
+                Some(Arc::new(res))
+            }
+        });
     }
 
     /// Subscribes a callback parameter to a current [Observer].
     /// Returns a subscription object which - when dropped - will unsubscribe current callback.
-    pub fn subscribe(&self, callback: F) -> Subscription<F> {
-        let link = F::weak(callback);
+    pub fn subscribe<F>(&self, callback: F) -> Subscription
+    where
+        F: Fn(&TransactionMut, &E) -> () + 'static,
+    {
+        let strong = Arc::new(callback);
+        let subscription: Arc<dyn std::any::Any> = strong.clone();
+        let generic: Callback<E> = strong;
+        let weak = Arc::downgrade(&generic);
         self.inner.rcu(|callbacks| match callbacks {
-            None => Arc::new(smallvec![link]),
+            None => Arc::new(smallvec![weak.clone()]),
             Some(links) => {
                 let mut res = WeakCallbacks::with_capacity(links.len() + 1);
                 for l in links.iter() {
@@ -77,22 +65,24 @@ impl<F: Func> Observer<F> {
                         res.push(l.clone());
                     }
                 }
-                res.push(link);
+                res.push(weak.clone());
                 Arc::new(res)
             }
         });
-        Subscription::new(callback)
+        Subscription {
+            callback: subscription,
+        }
     }
 
     /// Returns a snapshot of callbacks subscribed to this observer at the moment when this method
     /// has been called. This snapshot can be iterated over to get access to individual callbacks
     /// and trigger them.
-    pub fn callbacks(&self) -> Callbacks<F> {
+    pub fn callbacks(&self) -> Option<Callbacks<E>> {
         Callbacks::new(self)
     }
 }
 
-impl<F: Func> Default for Observer<F> {
+impl<E> Default for Observer<E> {
     fn default() -> Self {
         Observer {
             inner: ArcSwapOption::from(None),
@@ -101,61 +91,196 @@ impl<F: Func> Default for Observer<F> {
 }
 
 #[derive(Debug)]
-pub struct Callbacks<F: Func> {
-    inner: Guard<Option<Arc<WeakCallbacks<F>>>>,
+pub struct Callbacks<'a, E> {
+    observer: &'a Observer<E>,
+    callbacks: Arc<WeakCallbacks<E>>,
     index: usize,
     should_cleanup: bool,
 }
 
-impl<F: Func> Callbacks<F> {
-    fn new(o: &Observer<F>) -> Self {
-        let inner = o.inner.load();
-        Callbacks {
-            inner,
+unsafe impl<'a, E: Send> Send for Callbacks<'a, E> {}
+unsafe impl<'a, E: Sync> Sync for Callbacks<'a, E> {}
+
+impl<'a, E> Callbacks<'a, E> {
+    fn new(observer: &'a Observer<E>) -> Option<Self> {
+        let callbacks = observer.inner.load_full()?;
+        Some(Callbacks {
+            observer,
+            callbacks,
             index: 0,
             should_cleanup: false,
+        })
+    }
+
+    pub fn trigger(&mut self, txn: &TransactionMut, e: &E) {
+        for cb in self {
+            cb(txn, e);
         }
     }
 }
 
-impl<F: Func> Iterator for Callbacks<F> {
-    type Item = Arc<F>;
+impl<'a, E> Iterator for Callbacks<'a, E> {
+    type Item = Callback<E>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(callbacks) = self.inner.as_deref() {
-            while callbacks.len() < self.index {
-                let next = &callbacks[self.index];
-                self.index += 1;
-                if let Some(next) = next.upgrade() {
-                    return Some(next);
-                } else {
-                    self.should_cleanup = true;
-                }
+        let callbacks = &*self.callbacks;
+        while self.index < callbacks.len() {
+            let weak = &callbacks[self.index];
+            self.index += 1;
+            if let Some(strong) = weak.upgrade() {
+                return Some(strong);
             }
         }
         None
     }
 }
 
-impl<F> Drop for Callbacks<F> {
+impl<'a, E> Drop for Callbacks<'a, E> {
     fn drop(&mut self) {
         if self.should_cleanup {
-            if let Some(callbacks) = self.inner.as_deref_mut() {
-                let mut i = 0;
-                while i < callbacks.len() {
-                    let cb = &callbacks[i];
-                    if Weak::strong_count(cb) == 0 {
-                        callbacks.swap_remove(i);
-                    } else {
-                        i += 1;
-                    }
-                }
-            }
+            self.observer.clean();
         }
     }
 }
 
-pub type SharedRefObserver = Subscription<Arc<dyn Fn(&TransactionMut, &Event) -> () + 'static>>;
+pub type CallbackMut<E> = Arc<dyn Fn(&mut TransactionMut, &mut E) + 'static>;
+type WeakCallbackMut<E> = Weak<dyn Fn(&mut TransactionMut, &mut E) + 'static>;
+type WeakCallbacksMut<E> = SmallVec<[WeakCallbackMut<E>; 1]>;
+
+/// Data structure used to handle publish/subscribe callbacks of specific type. Observers perform
+/// subscriber changes in thread-safe manner, using atomic hardware intrinsics.
+#[derive(Debug)]
+pub struct ObserverMut<E> {
+    inner: ArcSwapOption<WeakCallbacksMut<E>>,
+}
+
+unsafe impl<E: Send> Send for ObserverMut<E> {}
+unsafe impl<E: Sync> Sync for ObserverMut<E> {}
+
+impl<E> ObserverMut<E> {
+    /// Creates a new [ObserverMut with no active callbacks.
+    pub fn new() -> Self {
+        ObserverMut {
+            inner: ArcSwapOption::new(None),
+        }
+    }
+
+    /// Cleanup already released subscriptions. Whenever a [Subscription] is dropped, the callback is released. However,
+    /// the weak reference to callback may still be kept around until it becomes touched by operations such as
+    /// [Observer::subscribe] or [Observer::callbacks].
+    ///
+    /// This method allows to perform stale callback cleanup without waiting for callbacks to be visited.
+    pub fn clean(&self) {
+        self.inner.rcu(|callbacks| match callbacks {
+            None => None,
+            Some(links) => {
+                let mut res = WeakCallbacksMut::with_capacity(links.len() - 1);
+                for l in links.iter() {
+                    if Weak::strong_count(l) != 0 {
+                        res.push(l.clone());
+                    }
+                }
+                Some(Arc::new(res))
+            }
+        });
+    }
+
+    /// Subscribes a callback parameter to a current [Observer].
+    /// Returns a subscription object which - when dropped - will unsubscribe current callback.
+    pub fn subscribe<F>(&self, callback: F) -> Subscription
+    where
+        F: Fn(&mut TransactionMut, &mut E) + 'static,
+    {
+        let strong = Arc::new(callback);
+        let subscription: Arc<dyn std::any::Any> = strong.clone();
+        let generic: CallbackMut<E> = strong;
+        let weak = Arc::downgrade(&generic);
+        self.inner.rcu(|callbacks| match callbacks {
+            None => Arc::new(smallvec![weak.clone()]),
+            Some(links) => {
+                let mut res = WeakCallbacksMut::with_capacity(links.len() + 1);
+                for l in links.iter() {
+                    if Weak::strong_count(l) != 0 {
+                        res.push(l.clone());
+                    }
+                }
+                res.push(weak.clone());
+                Arc::new(res)
+            }
+        });
+        Subscription {
+            callback: subscription,
+        }
+    }
+
+    /// Returns a snapshot of callbacks subscribed to this observer at the moment when this method
+    /// has been called. This snapshot can be iterated over to get access to individual callbacks
+    /// and trigger them.
+    pub fn callbacks(&self) -> Option<CallbacksMut<E>> {
+        CallbacksMut::new(self)
+    }
+}
+
+impl<E> Default for ObserverMut<E> {
+    fn default() -> Self {
+        ObserverMut {
+            inner: ArcSwapOption::from(None),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CallbacksMut<'a, E> {
+    observer: &'a ObserverMut<E>,
+    callbacks: Arc<WeakCallbacksMut<E>>,
+    index: usize,
+    should_cleanup: bool,
+}
+
+unsafe impl<'a, E: Send> Send for CallbacksMut<'a, E> {}
+unsafe impl<'a, E: Sync> Sync for CallbacksMut<'a, E> {}
+
+impl<'a, E> CallbacksMut<'a, E> {
+    fn new(observer: &'a ObserverMut<E>) -> Option<Self> {
+        let callbacks = observer.inner.load_full()?;
+        Some(CallbacksMut {
+            observer,
+            callbacks,
+            index: 0,
+            should_cleanup: false,
+        })
+    }
+
+    pub fn trigger(&mut self, txn: &mut TransactionMut, e: &mut E) {
+        for cb in self {
+            cb(txn, e);
+        }
+    }
+}
+
+impl<'a, E> Iterator for CallbacksMut<'a, E> {
+    type Item = CallbackMut<E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let callbacks = &*self.callbacks;
+        while self.index < callbacks.len() {
+            let weak = &callbacks[self.index];
+            self.index += 1;
+            if let Some(strong) = weak.upgrade() {
+                return Some(strong);
+            }
+        }
+        None
+    }
+}
+
+impl<'a, E> Drop for CallbacksMut<'a, E> {
+    fn drop(&mut self) {
+        if self.should_cleanup {
+            self.observer.clean();
+        }
+    }
+}
 
 /// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
 /// callback when dropped.
@@ -163,37 +288,27 @@ pub type SharedRefObserver = Subscription<Arc<dyn Fn(&TransactionMut, &Event) ->
 /// If implicit callback unsubscribe on drop is undesired, this structure can be cast [into](Subscription::into)
 /// [SubscriptionId] which is an identifier of the same subscription, which in turn must be used
 /// manually via [Observer::unsubscribe] to perform usubscribe.
-#[repr(transparent)]
-#[derive(Debug, Clone)]
-pub struct Subscription<F> {
-    inner: Arc<F>,
+#[repr(C)]
+pub struct Subscription {
+    callback: Arc<dyn std::any::Any>,
 }
 
-impl<F> Subscription<F> {
-    fn new(inner: Arc<F>) -> Self {
-        Subscription { inner }
-    }
-}
-
-impl<F> Into<SubscriptionId> for Subscription<F> {
-    fn into(self) -> SubscriptionId {
-        let ptr = Arc::as_ptr(&self.inner);
-        ptr as SubscriptionId
-    }
-}
+unsafe impl Send for Subscription {}
+unsafe impl Sync for Subscription {}
 
 #[cfg(test)]
 mod test {
     use crate::observer::Observer;
-    use std::cell::Cell;
-    use std::rc::Rc;
+    use crate::Transact;
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::thread::spawn;
 
     #[test]
     fn subscription() {
-        let o: Observer<dyn Fn(u32) -> ()> = Observer::new();
+        let doc = crate::Doc::new();
+        let txn = doc.transact_mut();
+        let o: Observer<u32> = Observer::new();
         let s1_state = Arc::new(AtomicU32::new(0));
         let s2_state = Arc::new(AtomicU32::new(0));
 
@@ -201,25 +316,25 @@ mod test {
             let a = s1_state.clone();
             let b = s2_state.clone();
 
-            let _s1 = o.subscribe(Arc::new(move |value| a.store(value, Ordering::Release)));
-            let _s2 = o.subscribe(Arc::new(move |value| b.store(value * 2, Ordering::Release)));
+            let _s1 = o.subscribe(move |_, &value| a.store(value, Ordering::Release));
+            let _s2 = o.subscribe(move |_, &value| b.store(value * 2, Ordering::Release));
 
-            for fun in o.callbacks() {
-                fun(1)
+            for fun in o.callbacks().unwrap() {
+                fun(&txn, &1)
             }
             assert_eq!(s1_state.load(Ordering::Acquire), 1);
             assert_eq!(s2_state.load(Ordering::Acquire), 2);
 
-            for fun in o.callbacks() {
-                fun(2)
+            for fun in o.callbacks().unwrap() {
+                fun(&txn, &2)
             }
             assert_eq!(s1_state.load(Ordering::Acquire), 2);
             assert_eq!(s2_state.load(Ordering::Acquire), 4);
         }
 
         // subscriptions were dropped, we don't expect updates to be propagated
-        for fun in o.callbacks() {
-            fun(3)
+        for fun in o.callbacks().unwrap() {
+            fun(&txn, &3)
         }
         assert_eq!(s1_state.load(Ordering::Acquire), 2);
         assert_eq!(s2_state.load(Ordering::Acquire), 4);
@@ -227,19 +342,21 @@ mod test {
 
     #[test]
     fn multi_threading() {
-        let o: Observer<Arc<dyn Fn(u32) -> ()>> = Observer::new();
+        let o: Observer<u32> = Observer::new();
 
         let s1_state = Arc::new(AtomicU32::new(0));
         let a = s1_state.clone();
-        let sub1 = o.subscribe(Arc::new(move |value| a.store(value, Ordering::Release)));
+        let sub1 = o.subscribe(move |_, &value| a.store(value, Ordering::Release));
 
         let s2_state = Arc::new(AtomicU32::new(0));
         let b = s2_state.clone();
-        let sub2 = o.subscribe(Arc::new(move |value| b.store(value, Ordering::Release)));
+        let sub2 = o.subscribe(move |_, &value| b.store(value, Ordering::Release));
 
         let handle = spawn(move || {
-            for fun in o.callbacks() {
-                fun(1)
+            let doc = crate::Doc::new();
+            let txn = doc.transact_mut();
+            for fun in o.callbacks().unwrap() {
+                fun(&txn, &1)
             }
             drop(sub1);
             drop(sub2);
@@ -252,23 +369,24 @@ mod test {
     }
 
     #[test]
-    fn multi_param() {
-        struct Wrapper {
-            observer: Observer<Arc<dyn Fn(&u32, &u32) -> ()>>,
-        }
-        let o = Wrapper {
-            observer: Observer::new(),
+    fn unsubscribe_calls_drop() {
+        let o: Observer<()> = Observer::new();
+        let c = Arc::new(());
+        let subscription = {
+            let inner = c.clone();
+            o.subscribe(move |_, _| {
+                let count = Arc::strong_count(&inner);
+                assert_eq!(count, 2);
+            })
         };
-        let state = Rc::new(Cell::new(0));
-        let s = state.clone();
-        let _sub = o.observer.subscribe(Arc::new(move |a, b| {
-            let cell = s.as_ref();
-            cell.set(*a + *b);
-        }));
-
-        for fun in o.observer.callbacks() {
-            fun(&1, &2)
+        let doc = crate::Doc::new();
+        let txn = doc.transact_mut();
+        for cb in o.callbacks().unwrap() {
+            cb(&txn, &());
         }
-        assert_eq!(state.get(), 3);
+        drop(subscription);
+
+        let count = Arc::strong_count(&c);
+        assert_eq!(count, 1);
     }
 }

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -1,4 +1,6 @@
 use crate::atomic::AtomicRef;
+use crate::types::Event;
+use crate::TransactionMut;
 use std::fmt::{Debug, Formatter};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -118,6 +120,7 @@ impl<F: Clone> Iterator for Callbacks<F> {
         }
     }
 }
+pub type SharedRefObserver = Subscription<Arc<dyn Fn(&TransactionMut, &Event) -> () + 'static>>;
 
 /// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
 /// callback when dropped.

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -492,24 +492,24 @@ pub(crate) struct StoreEvents {
     /// Handles subscriptions for the transaction cleanup event. Events are called with the
     /// newest updates once they are committed and compacted.
     pub(crate) transaction_cleanup_events:
-        Option<Observer<Arc<dyn Fn(&TransactionMut, &TransactionCleanupEvent) -> ()>>>,
+        Observer<Arc<dyn Fn(&TransactionMut, &TransactionCleanupEvent) -> ()>>,
 
     /// Handles subscriptions for the `afterTransactionCleanup` event. Events are called with the
     /// newest updates once they are committed and compacted.
-    pub(crate) after_transaction_events: Option<Observer<Arc<dyn Fn(&mut TransactionMut) -> ()>>>,
+    pub(crate) after_transaction_events: Observer<Arc<dyn Fn(&mut TransactionMut) -> ()>>,
 
     /// A subscription handler. It contains all callbacks with registered by user functions that
     /// are supposed to be called, once a new update arrives.
-    pub(crate) update_v1_events: Option<Observer<Arc<dyn Fn(&TransactionMut, &UpdateEvent) -> ()>>>,
+    pub(crate) update_v1_events: Observer<Arc<dyn Fn(&TransactionMut, &UpdateEvent) -> ()>>,
 
     /// A subscription handler. It contains all callbacks with registered by user functions that
     /// are supposed to be called, once a new update arrives.
-    pub(crate) update_v2_events: Option<Observer<Arc<dyn Fn(&TransactionMut, &UpdateEvent) -> ()>>>,
+    pub(crate) update_v2_events: Observer<Arc<dyn Fn(&TransactionMut, &UpdateEvent) -> ()>>,
 
     /// Handles subscriptions for subdocs events.
-    pub(crate) subdocs_events: Option<Observer<Arc<dyn Fn(&TransactionMut, &SubdocsEvent) -> ()>>>,
+    pub(crate) subdocs_events: Observer<Arc<dyn Fn(&TransactionMut, &SubdocsEvent) -> ()>>,
 
-    pub(crate) destroy_events: Option<Observer<Arc<dyn Fn(&TransactionMut, &Doc) -> ()>>>,
+    pub(crate) destroy_events: Observer<Arc<dyn Fn(&TransactionMut, &Doc) -> ()>>,
 }
 
 impl StoreEvents {
@@ -523,7 +523,7 @@ impl StoreEvents {
     where
         F: Fn(&TransactionMut, &UpdateEvent) -> () + 'static,
     {
-        let eh = self.update_v1_events.get_or_insert_with(Observer::new);
+        let eh = self.update_v1_events.subscribe();
         Ok(eh.subscribe(Arc::new(f)))
     }
 

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -1,8 +1,6 @@
 use crate::block::{BlockCell, ClientID, ItemContent, ItemPtr};
 use crate::block_store::BlockStore;
-use crate::doc::{
-    AfterTransactionSubscription, DestroySubscription, DocAddr, Options, SubdocsSubscription,
-};
+use crate::doc::{DocAddr, Options};
 use crate::error::Error;
 use crate::event::SubdocsEvent;
 use crate::id_set::DeleteSet;
@@ -10,11 +8,11 @@ use crate::slice::ItemSlice;
 use crate::types::{Branch, BranchPtr, Path, PathSegment, TypeRef};
 use crate::update::PendingUpdate;
 use crate::updates::encoder::{Encode, Encoder};
-use crate::StateVector;
 use crate::{
-    Doc, Observer, OffsetKind, Snapshot, SubscriptionId, TransactionCleanupEvent,
-    TransactionCleanupSubscription, TransactionMut, UpdateEvent, UpdateSubscription, Uuid, ID,
+    Doc, Observer, ObserverMut, OffsetKind, Snapshot, TransactionCleanupEvent, TransactionMut,
+    UpdateEvent, Uuid, ID,
 };
+use crate::{StateVector, Subscription};
 use atomic_refcell::{AtomicRef, AtomicRefCell, AtomicRefMut, BorrowError, BorrowMutError};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -491,25 +489,24 @@ impl<'doc> Iterator for SubdocGuids<'doc> {
 pub(crate) struct StoreEvents {
     /// Handles subscriptions for the transaction cleanup event. Events are called with the
     /// newest updates once they are committed and compacted.
-    pub(crate) transaction_cleanup_events:
-        Observer<Arc<dyn Fn(&TransactionMut, &TransactionCleanupEvent) -> ()>>,
+    pub(crate) transaction_cleanup_events: Observer<TransactionCleanupEvent>,
 
     /// Handles subscriptions for the `afterTransactionCleanup` event. Events are called with the
     /// newest updates once they are committed and compacted.
-    pub(crate) after_transaction_events: Observer<Arc<dyn Fn(&mut TransactionMut) -> ()>>,
+    pub(crate) after_transaction_events: ObserverMut<()>,
 
     /// A subscription handler. It contains all callbacks with registered by user functions that
     /// are supposed to be called, once a new update arrives.
-    pub(crate) update_v1_events: Observer<Arc<dyn Fn(&TransactionMut, &UpdateEvent) -> ()>>,
+    pub(crate) update_v1_events: Observer<UpdateEvent>,
 
     /// A subscription handler. It contains all callbacks with registered by user functions that
     /// are supposed to be called, once a new update arrives.
-    pub(crate) update_v2_events: Observer<Arc<dyn Fn(&TransactionMut, &UpdateEvent) -> ()>>,
+    pub(crate) update_v2_events: Observer<UpdateEvent>,
 
     /// Handles subscriptions for subdocs events.
-    pub(crate) subdocs_events: Observer<Arc<dyn Fn(&TransactionMut, &SubdocsEvent) -> ()>>,
+    pub(crate) subdocs_events: Observer<SubdocsEvent>,
 
-    pub(crate) destroy_events: Observer<Arc<dyn Fn(&TransactionMut, &Doc) -> ()>>,
+    pub(crate) destroy_events: Observer<Doc>,
 }
 
 impl StoreEvents {
@@ -519,29 +516,19 @@ impl StoreEvents {
     /// commit.
     ///
     /// Returns a subscription, which will unsubscribe function when dropped.
-    pub fn observe_update_v1<F>(&mut self, f: F) -> Result<UpdateSubscription, BorrowMutError>
+    pub fn observe_update_v1<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &UpdateEvent) -> () + 'static,
     {
-        let eh = self.update_v1_events.subscribe();
-        Ok(eh.subscribe(Arc::new(f)))
-    }
-
-    /// Manually unsubscribes from a callback used in [Doc::observe_update_v1] method.
-    pub fn unobserve_update_v1(&self, subscription_id: SubscriptionId) {
-        if let Some(handler) = self.update_v1_events.as_ref() {
-            handler.unsubscribe(subscription_id);
-        }
+        self.update_v1_events.subscribe(f)
     }
 
     pub fn emit_update_v1(&self, txn: &TransactionMut) {
-        if let Some(eh) = self.update_v1_events.as_ref() {
+        if let Some(mut callbacks) = self.update_v1_events.callbacks() {
             if !txn.delete_set.is_empty() || txn.after_state != txn.before_state {
                 // produce update only if anything changed
                 let update = UpdateEvent::new_v1(txn);
-                for fun in eh.callbacks() {
-                    fun(txn, &update);
-                }
+                callbacks.trigger(txn, &update);
             }
         }
     }
@@ -552,132 +539,69 @@ impl StoreEvents {
     /// commit.
     ///
     /// Returns a subscription, which will unsubscribe function when dropped.
-    pub fn observe_update_v2<F>(&mut self, f: F) -> Result<UpdateSubscription, BorrowMutError>
+    pub fn observe_update_v2<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &UpdateEvent) -> () + 'static,
     {
-        let eh = self.update_v2_events.get_or_insert_with(Observer::new);
-        Ok(eh.subscribe(Arc::new(f)))
-    }
-
-    /// Manually unsubscribes from a callback used in [Doc::observe_update_v1] method.
-    pub fn unobserve_update_v2(&self, subscription_id: SubscriptionId) {
-        if let Some(handler) = self.update_v2_events.as_ref() {
-            handler.unsubscribe(subscription_id);
-        }
+        self.update_v2_events.subscribe(f)
     }
 
     pub fn emit_update_v2(&self, txn: &TransactionMut) {
-        if let Some(eh) = self.update_v2_events.as_ref() {
+        if let Some(mut callbacks) = self.update_v2_events.callbacks() {
             if !txn.delete_set.is_empty() || txn.after_state != txn.before_state {
                 // produce update only if anything changed
                 let update = UpdateEvent::new_v2(txn);
-                for fun in eh.callbacks() {
-                    fun(txn, &update);
-                }
+                callbacks.trigger(txn, &update);
             }
         }
     }
 
     /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
     /// deletions when a document transaction is committed.
-    pub fn observe_after_transaction<F>(
-        &mut self,
-        f: F,
-    ) -> Result<AfterTransactionSubscription, BorrowMutError>
+    pub fn observe_after_transaction<F>(&self, f: F) -> Subscription
     where
         F: Fn(&mut TransactionMut) -> () + 'static,
     {
-        let subscription = self
-            .after_transaction_events
-            .get_or_insert_with(Observer::new)
-            .subscribe(Arc::new(f));
-        Ok(subscription)
-    }
-
-    /// Cancels the transaction cleanup callback associated with the `subscription_id`
-    pub fn unobserve_after_transaction(&self, subscription_id: SubscriptionId) {
-        if let Some(handler) = self.after_transaction_events.as_ref() {
-            (*handler).unsubscribe(subscription_id);
-        }
+        self.after_transaction_events
+            .subscribe(move |txn, _| f(txn))
     }
 
     pub fn emit_after_transaction(&self, txn: &mut TransactionMut) {
-        if let Some(eh) = self.after_transaction_events.as_ref() {
-            for cb in eh.callbacks() {
-                cb(txn);
-            }
+        if let Some(mut callbacks) = self.after_transaction_events.callbacks() {
+            callbacks.trigger(txn, &mut ());
         }
     }
 
     /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
     /// deletions when a document transaction is committed.
-    pub fn observe_transaction_cleanup<F>(
-        &mut self,
-        f: F,
-    ) -> Result<TransactionCleanupSubscription, BorrowMutError>
+    pub fn observe_transaction_cleanup<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &TransactionCleanupEvent) -> () + 'static,
     {
-        let subscription = self
-            .transaction_cleanup_events
-            .get_or_insert_with(Observer::new)
-            .subscribe(Arc::new(f));
-        Ok(subscription)
-    }
-
-    /// Cancels the transaction cleanup callback associated with the `subscription_id`
-    pub fn unobserve_transaction_cleanup(&self, subscription_id: SubscriptionId) {
-        if let Some(handler) = self.transaction_cleanup_events.as_ref() {
-            (*handler).unsubscribe(subscription_id);
-        }
+        self.transaction_cleanup_events.subscribe(f)
     }
 
     pub fn emit_transaction_cleanup(&self, txn: &TransactionMut) {
-        if let Some(eh) = self.transaction_cleanup_events.as_ref() {
+        if let Some(mut callbacks) = self.transaction_cleanup_events.callbacks() {
             let event = TransactionCleanupEvent::new(txn);
-            for fun in eh.callbacks() {
-                fun(txn, &event);
-            }
+            callbacks.trigger(txn, &event);
         }
     }
 
     /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
     /// [Doc] will request a load.
-    pub fn observe_subdocs<F>(&mut self, f: F) -> Result<SubdocsSubscription, BorrowMutError>
+    pub fn observe_subdocs<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &SubdocsEvent) -> () + 'static,
     {
-        let subscription = self
-            .subdocs_events
-            .get_or_insert_with(Observer::new)
-            .subscribe(Arc::new(f));
-        Ok(subscription)
-    }
-
-    /// Cancels the subscription created previously using [Doc::observe_subdocs].
-    pub fn unobserve_subdocs(&self, subscription_id: SubscriptionId) {
-        if let Some(handler) = self.subdocs_events.as_ref() {
-            (*handler).unsubscribe(subscription_id);
-        }
+        self.subdocs_events.subscribe(f)
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    pub fn observe_destroy<F>(&mut self, f: F) -> Result<DestroySubscription, BorrowMutError>
+    pub fn observe_destroy<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Doc) -> () + 'static,
     {
-        let subscription = self
-            .destroy_events
-            .get_or_insert_with(Observer::new)
-            .subscribe(Arc::new(f));
-        Ok(subscription)
-    }
-
-    /// Cancels the subscription created previously using [Doc::observe_destroy].
-    pub fn unobserve_destroy(&self, subscription_id: SubscriptionId) {
-        if let Some(handler) = self.destroy_events.as_ref() {
-            (*handler).unsubscribe(subscription_id);
-        }
+        self.destroy_events.subscribe(f)
     }
 }

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -1,4 +1,5 @@
 use crate::block::ClientID;
+use crate::encoding::read::{Cursor, Read};
 use crate::transaction::ReadTxn;
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::{Encode, Encoder, EncoderV1};
@@ -9,7 +10,6 @@ use rand::{random, Rng, RngCore, SeedableRng};
 use std::cell::{RefCell, RefMut};
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
-use crate::encoding::read::{Cursor, Read};
 
 pub const EXCHANGE_UPDATES_ORIGIN: &str = "exchange_updates";
 
@@ -475,10 +475,6 @@ impl TestPeer {
 
     pub fn doc(&self) -> &Doc {
         &self.doc
-    }
-
-    pub fn doc_mut(&mut self) -> &mut Doc {
-        &mut self.doc
     }
 
     /// Receive a message from another client. This message is only appended to the list of

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -707,7 +707,7 @@ impl<'doc> TransactionMut<'doc> {
         let mut current = branch;
         loop {
             changed_parent_types.push(current);
-            if current.deep_observers.is_some() {
+            if !current.deep_observers.is_empty() {
                 let entries = changed_parents.entry(current).or_default();
                 entries.push(event_cache.len() - 1);
             }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -701,7 +701,7 @@ impl<'doc> TransactionMut<'doc> {
         all_links: &HashMap<ItemPtr, HashSet<BranchPtr>>,
         branch: BranchPtr,
         changed_parents: &mut HashMap<BranchPtr, Vec<usize>>,
-        event_cache: &mut Vec<Event>,
+        event_cache: &Vec<Event>,
         visited: &mut HashSet<BranchPtr>,
     ) {
         let mut current = branch;
@@ -770,7 +770,7 @@ impl<'doc> TransactionMut<'doc> {
                             &self.store.linked_by,
                             *branch,
                             &mut changed_parents,
-                            &mut event_cache,
+                            &event_cache,
                             &mut HashSet::default(),
                         );
                     }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -965,7 +965,7 @@ impl<'doc> TransactionMut<'doc> {
 }
 
 /// Iterator struct used to traverse over all of the root level types defined in a corresponding [Doc].
-pub struct RootRefs<'doc>(std::collections::hash_map::Iter<'doc, Arc<str>, Box<Branch>>);
+pub struct RootRefs<'doc>(std::collections::hash_map::Iter<'doc, Arc<str>, Arc<Branch>>);
 
 impl<'doc> Iterator for RootRefs<'doc> {
     type Item = (&'doc str, Value);

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -120,14 +120,6 @@ impl Observable for ArrayRef {
             None
         }
     }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        if let Observers::Array(eh) = self.0.observers.get_or_insert_with(Observers::array) {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl TryFrom<ItemPtr> for ArrayRef {
@@ -884,7 +876,7 @@ mod test {
     #[test]
     fn insert_and_remove_events() {
         let d = Doc::with_client_id(1);
-        let mut array = d.get_or_insert_array("array");
+        let array = d.get_or_insert_array("array");
         let happened = Rc::new(Cell::new(false));
         let happened_clone = happened.clone();
         let _sub = array.observe(move |_, _| {
@@ -925,7 +917,7 @@ mod test {
     #[test]
     fn insert_and_remove_event_changes() {
         let d1 = Doc::with_client_id(1);
-        let mut array = d1.get_or_insert_array("array");
+        let array = d1.get_or_insert_array("array");
         let added = Rc::new(RefCell::new(None));
         let removed = Rc::new(RefCell::new(None));
         let delta = Rc::new(RefCell::new(None));
@@ -985,7 +977,7 @@ mod test {
         );
 
         let d2 = Doc::with_client_id(2);
-        let mut array2 = d2.get_or_insert_array("array");
+        let array2 = d2.get_or_insert_array("array");
         let (added_c, removed_c, delta_c) = (added.clone(), removed.clone(), delta.clone());
         let _sub = array2.observe(move |txn, e| {
             *added_c.borrow_mut() = Some(e.inserts(txn).clone());
@@ -1021,8 +1013,8 @@ mod test {
     fn target_on_local_and_remote() {
         let d1 = Doc::with_client_id(1);
         let d2 = Doc::with_client_id(2);
-        let mut a1 = d1.get_or_insert_array("array");
-        let mut a2 = d2.get_or_insert_array("array");
+        let a1 = d1.get_or_insert_array("array");
+        let a2 = d2.get_or_insert_array("array");
 
         let c1 = Rc::new(RefCell::new(None));
         let c1c = c1.clone();
@@ -1224,10 +1216,10 @@ mod test {
     #[test]
     fn move_1() {
         let d1 = Doc::with_client_id(1);
-        let mut a1 = d1.get_or_insert_array("array");
+        let a1 = d1.get_or_insert_array("array");
 
         let d2 = Doc::with_client_id(2);
-        let mut a2 = d2.get_or_insert_array("array");
+        let a2 = d2.get_or_insert_array("array");
 
         let e1: Rc<RefCell<Vec<Change>>> = Rc::new(RefCell::new(Vec::default()));
         let inner = e1.clone();
@@ -1276,10 +1268,10 @@ mod test {
     #[test]
     fn move_2() {
         let d1 = Doc::with_client_id(1);
-        let mut a1 = d1.get_or_insert_array("array");
+        let a1 = d1.get_or_insert_array("array");
 
         let d2 = Doc::with_client_id(2);
-        let mut a2 = d2.get_or_insert_array("array");
+        let a2 = d2.get_or_insert_array("array");
 
         let e1: Rc<RefCell<Vec<Change>>> = Rc::new(RefCell::new(Vec::default()));
         let inner = e1.clone();

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -3,8 +3,7 @@ use crate::block_iter::BlockIter;
 use crate::moving::StickyIndex;
 use crate::transaction::TransactionMut;
 use crate::types::{
-    event_change_set, Branch, BranchPtr, Change, ChangeSet, EventHandler, Observers, Path,
-    SharedRef, ToJson, TypeRef, Value,
+    event_change_set, Branch, BranchPtr, Change, ChangeSet, Path, SharedRef, ToJson, TypeRef, Value,
 };
 use crate::{Any, Assoc, IndexedSequence, Observable, ReadTxn, ID};
 use std::borrow::Borrow;
@@ -112,14 +111,6 @@ impl AsMut<Branch> for ArrayRef {
 
 impl Observable for ArrayRef {
     type Event = ArrayEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        if let Some(Observers::Array(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl TryFrom<ItemPtr> for ArrayRef {

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -12,7 +12,6 @@ use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
 
 /// A collection used to store data in an indexed sequence structure. This type is internally
 /// implemented as a double linked list, which may squash values inserted directly one after another
@@ -319,8 +318,6 @@ pub trait Array: AsRef<Branch> + Sized {
         ArrayIter::from_ref(self.as_ref(), txn)
     }
 }
-
-pub type ArraySubscription = crate::Subscription<Arc<dyn Fn(&TransactionMut, &ArrayEvent) -> ()>>;
 
 pub struct ArrayIter<B, T>
 where

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -70,14 +70,6 @@ impl Observable for MapRef {
             None
         }
     }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        if let Observers::Map(eh) = self.0.observers.get_or_insert_with(Observers::map) {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl ToJson for MapRef {
@@ -774,7 +766,7 @@ mod test {
     #[test]
     fn insert_and_remove_events() {
         let d1 = Doc::with_client_id(1);
-        let mut m1 = d1.get_or_insert_map("map");
+        let m1 = d1.get_or_insert_map("map");
 
         let entries = Rc::new(RefCell::new(None));
         let entries_c = entries.clone();
@@ -861,7 +853,7 @@ mod test {
 
         // copy updates over
         let d2 = Doc::with_client_id(2);
-        let mut m2 = d2.get_or_insert_map("map");
+        let m2 = d2.get_or_insert_map("map");
 
         let entries = Rc::new(RefCell::new(None));
         let entries_c = entries.clone();

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -1,8 +1,7 @@
 use crate::block::{EmbedPrelim, ItemContent, ItemPosition, ItemPtr, Prelim};
 use crate::transaction::TransactionMut;
 use crate::types::{
-    event_keys, Branch, BranchPtr, Entries, EntryChange, EventHandler, Observers, Path, SharedRef,
-    ToJson, TypeRef, Value,
+    event_keys, Branch, BranchPtr, Entries, EntryChange, Path, SharedRef, ToJson, TypeRef, Value,
 };
 use crate::*;
 use std::borrow::Borrow;
@@ -62,14 +61,6 @@ impl Map for MapRef {}
 
 impl Observable for MapRef {
     type Event = MapEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        if let Some(Observers::Map(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl ToJson for MapRef {

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -422,9 +422,9 @@ pub struct Branch {
     /// An identifier of an underlying complex data type (eg. is it an Array or a Map).
     pub(crate) type_ref: TypeRef,
 
-    pub(crate) observers: Option<Observer<Arc<dyn Fn(&TransactionMut, &Event)>>>,
+    pub(crate) observers: Observer<Arc<dyn Fn(&TransactionMut, &Event)>>,
 
-    pub(crate) deep_observers: Option<Observer<Arc<dyn Fn(&TransactionMut, &Events)>>>,
+    pub(crate) deep_observers: Observer<Arc<dyn Fn(&TransactionMut, &Events)>>,
 }
 
 impl std::fmt::Debug for Branch {

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -320,15 +320,15 @@ impl DerefMut for BranchPtr {
     }
 }
 
-impl<'a> From<&'a mut Box<Branch>> for BranchPtr {
-    fn from(branch: &'a mut Box<Branch>) -> Self {
-        let ptr = NonNull::from(branch.as_mut());
+impl<'a> From<&'a mut Arc<Branch>> for BranchPtr {
+    fn from(branch: &'a mut Arc<Branch>) -> Self {
+        let ptr = NonNull::from(branch.as_ref());
         BranchPtr(ptr)
     }
 }
 
-impl<'a> From<&'a Box<Branch>> for BranchPtr {
-    fn from(branch: &'a Box<Branch>) -> Self {
+impl<'a> From<&'a Arc<Branch>> for BranchPtr {
+    fn from(branch: &'a Arc<Branch>) -> Self {
         let b: &Branch = &*branch;
 
         let ptr = unsafe { NonNull::new_unchecked(b as *const Branch as *mut Branch) };
@@ -455,8 +455,8 @@ impl PartialEq for Branch {
 }
 
 impl Branch {
-    pub fn new(type_ref: TypeRef) -> Box<Self> {
-        Box::new(Self {
+    pub fn new(type_ref: TypeRef) -> Arc<Self> {
+        Arc::new(Self {
             start: None,
             map: HashMap::default(),
             block_len: 0,

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -203,7 +203,6 @@ pub trait Observable: AsMut<Branch> {
     type Event;
 
     fn try_observer(&self) -> Option<&EventHandler<Self::Event>>;
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>>;
 
     /// Subscribes a given callback to be triggered whenever current y-type is changed.
     /// A callback is triggered whenever a transaction gets committed. This function does not
@@ -214,11 +213,11 @@ pub trait Observable: AsMut<Branch> {
     /// All text-like event changes can be tracked by using [TextEvent::delta] method.
     ///
     /// Returns a [Subscription] which, when dropped, will unsubscribe current callback.
-    fn observe<F>(&mut self, f: F) -> Subscription<Arc<dyn Fn(&TransactionMut, &Self::Event) -> ()>>
+    fn observe<F>(&self, f: F) -> Subscription<Arc<dyn Fn(&TransactionMut, &Self::Event) -> ()>>
     where
         F: Fn(&TransactionMut, &Self::Event) -> () + 'static,
     {
-        if let Some(eh) = self.try_observer_mut() {
+        if let Some(eh) = self.try_observer() {
             eh.subscribe(Arc::new(f))
         } else {
             panic!("Observed collection is of different type") //TODO: this should be Result::Err

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1,8 +1,6 @@
 use crate::block::{EmbedPrelim, Item, ItemContent, ItemPosition, ItemPtr, Prelim};
 use crate::transaction::TransactionMut;
-use crate::types::{
-    Attrs, Branch, BranchPtr, Delta, EventHandler, Observers, Path, SharedRef, TypeRef, Value,
-};
+use crate::types::{Attrs, Branch, BranchPtr, Delta, Path, SharedRef, TypeRef, Value};
 use crate::utils::OptionExt;
 use crate::*;
 use std::borrow::Borrow;
@@ -104,14 +102,6 @@ impl Into<XmlTextRef> for TextRef {
 
 impl Observable for TextRef {
     type Event = TextEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        if let Some(Observers::Text(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl GetString for TextRef {
@@ -1352,8 +1342,7 @@ mod test {
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{
-        any, Any, ArrayPrelim, Doc, GetString, Observable, StateVector, Text, Transact, Update,
-        XmlTextRef, ID,
+        any, Any, ArrayPrelim, Doc, GetString, Observable, StateVector, Text, Transact, Update, ID,
     };
     use rand::prelude::StdRng;
     use rand::Rng;
@@ -1698,7 +1687,7 @@ mod test {
     #[test]
     fn observer() {
         let doc = Doc::with_client_id(1);
-        let txt: XmlTextRef = doc.get_or_insert_text("text").into();
+        let txt = doc.get_or_insert_text("text");
         let delta = Rc::new(RefCell::new(None));
         let delta_c = delta.clone();
         let sub = txt.observe(move |txn, e| {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -112,14 +112,6 @@ impl Observable for TextRef {
             None
         }
     }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        if let Observers::Text(eh) = self.0.observers.get_or_insert_with(Observers::text) {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl GetString for TextRef {
@@ -663,7 +655,7 @@ fn find_position(this: BranchPtr, txn: &mut TransactionMut, index: u32) -> Optio
     let store = txn.store_mut();
     let encoding = store.options.offset_kind;
     let mut remaining = index;
-    while let Some(mut right) = pos.right {
+    while let Some(right) = pos.right {
         if remaining == 0 {
             break;
         }
@@ -1706,7 +1698,7 @@ mod test {
     #[test]
     fn observer() {
         let doc = Doc::with_client_id(1);
-        let mut txt: XmlTextRef = doc.get_or_insert_text("text").into();
+        let txt: XmlTextRef = doc.get_or_insert_text("text").into();
         let delta = Rc::new(RefCell::new(None));
         let delta_c = delta.clone();
         let sub = txt.observe(move |txn, e| {
@@ -1758,7 +1750,7 @@ mod test {
     #[test]
     fn insert_and_remove_event_changes() {
         let d1 = Doc::with_client_id(1);
-        let mut txt = d1.get_or_insert_text("text");
+        let txt = d1.get_or_insert_text("text");
         let delta = Rc::new(RefCell::new(None));
         let delta_c = delta.clone();
         let _sub = txt.observe(move |txn, e| {
@@ -1800,7 +1792,7 @@ mod test {
 
         // replicate data to another peer
         let d2 = Doc::with_client_id(2);
-        let mut txt = d2.get_or_insert_text("text");
+        let txt = d2.get_or_insert_text("text");
         let delta_c = delta.clone();
         let _sub = txt.observe(move |txn, e| {
             *delta_c.borrow_mut() = Some(e.delta(txn).to_vec());
@@ -1857,7 +1849,7 @@ mod test {
     #[test]
     fn basic_format() {
         let d1 = Doc::with_client_id(1);
-        let mut txt1 = d1.get_or_insert_text("text");
+        let txt1 = d1.get_or_insert_text("text");
 
         let delta1 = Rc::new(RefCell::new(None));
         let delta_clone = delta1.clone();
@@ -1866,7 +1858,7 @@ mod test {
         });
 
         let d2 = Doc::with_client_id(2);
-        let mut txt2 = d2.get_or_insert_text("text");
+        let txt2 = d2.get_or_insert_text("text");
 
         let delta2 = Rc::new(RefCell::new(None));
         let delta_clone = delta2.clone();
@@ -2037,7 +2029,7 @@ mod test {
     #[test]
     fn embed_with_attributes() {
         let d1 = Doc::with_client_id(1);
-        let mut txt1 = d1.get_or_insert_text("text");
+        let txt1 = d1.get_or_insert_text("text");
 
         let delta1 = Rc::new(RefCell::new(None));
         let delta_clone = delta1.clone();
@@ -2116,7 +2108,7 @@ mod test {
     #[test]
     fn issue_101() {
         let d1 = Doc::with_client_id(1);
-        let mut txt1 = d1.get_or_insert_text("text");
+        let txt1 = d1.get_or_insert_text("text");
         let delta = Rc::new(RefCell::new(None));
         let delta_copy = delta.clone();
 
@@ -2168,7 +2160,7 @@ mod test {
         }
 
         {
-            let mut text = doc.get_or_insert_text("content");
+            let text = doc.get_or_insert_text("content");
             let mut txn = doc.transact_mut();
 
             let c1 = text1.chars().count();

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -171,15 +171,6 @@ where
             None
         }
     }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        let branch = self.0.as_mut();
-        if let Observers::Weak(eh) = branch.observers.get_or_insert_with(Observers::weak) {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl GetString for WeakRef<TextRef> {
@@ -1178,7 +1169,7 @@ mod test {
         let d2 = Doc::new();
         let m2 = d2.get_or_insert_map("map");
 
-        let mut link1 = {
+        let link1 = {
             let mut txn = d1.transact_mut();
             m1.insert(&mut txn, "a", "value");
             let link1 = m1.link(&txn, "a").unwrap();
@@ -1195,7 +1186,7 @@ mod test {
 
         exchange_updates(&[&d1, &d2]);
 
-        let mut link2 = m2
+        let link2 = m2
             .get(&d2.transact(), "b")
             .unwrap()
             .cast::<WeakRef<MapRef>>()
@@ -1224,7 +1215,7 @@ mod test {
         let d2 = Doc::new();
         let m2 = d2.get_or_insert_map("map");
 
-        let mut link1 = {
+        let link1 = {
             let mut txn = d1.transact_mut();
             m1.insert(&mut txn, "a", "value");
             let link1 = m1.link(&txn, "a").unwrap();
@@ -1241,7 +1232,7 @@ mod test {
 
         exchange_updates(&[&d1, &d2]);
 
-        let mut link2 = m2
+        let link2 = m2
             .get(&d2.transact(), "b")
             .unwrap()
             .cast::<WeakRef<MapRef>>()
@@ -1272,7 +1263,7 @@ mod test {
         let d2 = Doc::with_client_id(2);
         let a2 = d2.get_or_insert_array("array");
 
-        let mut link1 = {
+        let link1 = {
             let mut txn = d1.transact_mut();
             a1.insert_range(&mut txn, 0, ["A", "B", "C"]);
             let link1 = a1.quote(&txn, 1..=2).unwrap();
@@ -1289,7 +1280,7 @@ mod test {
 
         exchange_updates(&[&d1, &d2]);
 
-        let mut link2 = a2
+        let link2 = a2
             .get(&d2.transact(), 0)
             .unwrap()
             .cast::<WeakRef<ArrayRef>>()
@@ -2043,7 +2034,7 @@ mod test {
         }
 
         let d2 = Doc::with_client_id(2);
-        let arr2 = d2.get_or_insert_array("array");
+        let _arr2 = d2.get_or_insert_array("array");
         let txt2 = d2.get_or_insert_text("text");
 
         exchange_updates(&[&d1, &d2]);
@@ -2109,7 +2100,7 @@ mod test {
         }
 
         let d2 = Doc::with_client_id(2);
-        let arr2 = d2.get_or_insert_array("array");
+        let _arr2 = d2.get_or_insert_array("array");
         let txt2 = d2.get_or_insert_text("text");
 
         exchange_updates(&[&d1, &d2]);

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -4,7 +4,7 @@ use crate::iter::{
     AsIter, BlockIterator, BlockSliceIterator, IntoBlockIter, MoveIter, RangeIter, TxnIterator,
     Values,
 };
-use crate::types::{Branch, BranchPtr, EventHandler, Observers, Path, SharedRef, TypeRef, Value};
+use crate::types::{Branch, BranchPtr, Path, SharedRef, TypeRef, Value};
 use crate::{
     Array, Assoc, GetString, Map, Observable, ReadTxn, StickyIndex, TextRef, TransactionMut,
     XmlTextRef, ID,
@@ -162,15 +162,6 @@ where
     P: AsRef<Branch> + AsMut<Branch>,
 {
     type Event = WeakEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        let branch = self.0.as_ref();
-        if let Some(Observers::Weak(eh)) = branch.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl GetString for WeakRef<TextRef> {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -4,7 +4,7 @@ use crate::transaction::TransactionMut;
 use crate::types::text::{diff_between, TextEvent, YChange};
 use crate::types::{
     event_change_set, event_keys, Branch, BranchPtr, Change, ChangeSet, Delta, Entries,
-    EntryChange, EventHandler, MapRef, Observers, Path, SharedRef, ToJson, TypePtr, TypeRef, Value,
+    EntryChange, MapRef, Path, SharedRef, ToJson, TypePtr, TypeRef, Value,
 };
 use crate::{
     Any, ArrayRef, GetString, IndexedSequence, Map, Observable, ReadTxn, StickyIndex, Text,
@@ -196,14 +196,6 @@ impl GetString for XmlElementRef {
 
 impl Observable for XmlElementRef {
     type Event = XmlEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        if let Some(Observers::XmlFragment(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl AsRef<Branch> for XmlElementRef {
@@ -437,14 +429,6 @@ impl Into<TextRef> for XmlTextRef {
 
 impl Observable for XmlTextRef {
     type Event = XmlTextEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        if let Some(Observers::XmlText(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl GetString for XmlTextRef {
@@ -568,14 +552,6 @@ impl GetString for XmlFragmentRef {
 
 impl Observable for XmlFragmentRef {
     type Event = XmlEvent;
-
-    fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
-        if let Some(Observers::XmlFragment(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl AsRef<Branch> for XmlFragmentRef {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -204,16 +204,6 @@ impl Observable for XmlElementRef {
             None
         }
     }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        if let Observers::XmlFragment(eh) =
-            self.0.observers.get_or_insert_with(Observers::xml_fragment)
-        {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl AsRef<Branch> for XmlElementRef {
@@ -455,14 +445,6 @@ impl Observable for XmlTextRef {
             None
         }
     }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        if let Observers::XmlText(eh) = self.0.observers.get_or_insert_with(Observers::xml_text) {
-            Some(eh)
-        } else {
-            None
-        }
-    }
 }
 
 impl GetString for XmlTextRef {
@@ -589,16 +571,6 @@ impl Observable for XmlFragmentRef {
 
     fn try_observer(&self) -> Option<&EventHandler<Self::Event>> {
         if let Some(Observers::XmlFragment(eh)) = self.0.observers.as_ref() {
-            Some(eh)
-        } else {
-            None
-        }
-    }
-
-    fn try_observer_mut(&mut self) -> Option<&mut EventHandler<Self::Event>> {
-        if let Observers::XmlFragment(eh) =
-            self.0.observers.get_or_insert_with(Observers::xml_fragment)
-        {
             Some(eh)
         } else {
             None
@@ -1403,7 +1375,7 @@ mod test {
     #[test]
     fn event_observers() {
         let d1 = Doc::with_client_id(1);
-        let mut xml = d1.get_or_insert_xml_element("test");
+        let xml = d1.get_or_insert_xml_element("test");
 
         let attributes = Rc::new(RefCell::new(None));
         let nodes = Rc::new(RefCell::new(None));
@@ -1493,7 +1465,7 @@ mod test {
 
         // copy updates over
         let d2 = Doc::with_client_id(2);
-        let mut xml2 = d2.get_or_insert_xml_element("test");
+        let xml2 = d2.get_or_insert_xml_element("test");
 
         let attributes = Rc::new(RefCell::new(None));
         let nodes = Rc::new(RefCell::new(None));

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -8,7 +8,7 @@ use crate::slice::ItemSlice;
 #[cfg(test)]
 use crate::store::Store;
 use crate::transaction::TransactionMut;
-use crate::types::{TypePtr, TypeRef};
+use crate::types::TypePtr;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::client_hasher::ClientHasher;
@@ -344,10 +344,9 @@ impl Update {
                         }
                     }
                 }
-                ItemContent::Type(branch) =>
-                {
+                ItemContent::Type(branch) => {
                     #[cfg(feature = "weak")]
-                    if let TypeRef::WeakLink(source) = &branch.type_ref {
+                    if let crate::types::TypeRef::WeakLink(source) = &branch.type_ref {
                         let start = source.quote_start.id();
                         let end = source.quote_end.id();
                         if let Some(start) = start {

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -4588,7 +4588,7 @@ impl<'a> Shared<'a> {
         }
     }
 
-    fn as_branch(&self) -> Box<Branch> {
+    fn as_branch(&self) -> Arc<Branch> {
         let type_ref = match self {
             Shared::Text(_) => TypeRef::Text,
             Shared::Array(_) => TypeRef::Array,

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -4091,11 +4091,9 @@ impl YUndoManager {
                 let event: JsValue = YUndoEvent::new(e).into();
                 let txn: JsValue = YTransaction::from(txn).into();
                 callback.call2(&JsValue::UNDEFINED, &event, &txn).unwrap();
-                if let Ok(stack_item) = Reflect::get(&event, &JsValue::from_str("stackItem")) {
-                    if let Ok(meta) = Reflect::get(&stack_item, &JsValue::from_str("meta")) {
-                        *e.meta_mut() = meta;
-                    }
-                }
+                let meta =
+                    Reflect::get(&event, &JsValue::from_str("meta")).unwrap_or(JsValue::UNDEFINED);
+                *e.meta_mut() = meta;
             })
             .into()
     }
@@ -4107,11 +4105,9 @@ impl YUndoManager {
                 let event: JsValue = YUndoEvent::new(e).into();
                 let txn: JsValue = YTransaction::from(txn).into();
                 callback.call2(&JsValue::UNDEFINED, &event, &txn).unwrap();
-                if let Ok(stack_item) = Reflect::get(&event, &JsValue::from_str("stackItem")) {
-                    if let Ok(meta) = Reflect::get(&stack_item, &JsValue::from_str("meta")) {
-                        *e.meta_mut() = meta;
-                    }
-                }
+                let meta =
+                    Reflect::get(&event, &JsValue::from_str("meta")).unwrap_or(JsValue::UNDEFINED);
+                *e.meta_mut() = meta;
             })
             .into()
     }
@@ -4134,9 +4130,15 @@ impl YUndoEvent {
     pub fn kind(&self) -> JsValue {
         self.kind.clone()
     }
+
     #[wasm_bindgen(getter, js_name = meta)]
     pub fn meta(&self) -> JsValue {
         self.meta.clone()
+    }
+
+    #[wasm_bindgen(setter, js_name = meta)]
+    pub fn set_meta(&mut self, value: &JsValue) {
+        self.meta = value.clone();
     }
 
     fn new(e: &yrs::undo::Event<JsValue>) -> Self {

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -1850,6 +1850,8 @@ impl YAfterTransactionEvent {
     }
 }
 
+/// Subscription handle received after subscribing an event callback.
+/// Calling `yobserver.free()` will cause to registered callback to be unsubscribed.
 #[wasm_bindgen]
 pub struct YObserver(Subscription);
 

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -440,7 +440,7 @@ impl YDoc {
     /// ```
     #[wasm_bindgen(js_name=roots)]
     pub fn roots(&self, txn: &ImplicitTransaction) -> js_sys::Array {
-        let mut res = js_sys::Array::new();
+        let res = js_sys::Array::new();
         if let Some(txn) = get_txn(txn) {
             for (k, v) in txn.root_refs() {
                 let pair = js_sys::Array::new_with_length(2);


### PR DESCRIPTION
This PR introduces a new way to work with events and observers. There's a lot of simplifications inside but most notable ones are:
1. More strict callback function type definitions - previously it was `Observer<Arc<dyn Fn(&TransactionMut, &E) -> ()>>`. Now it's just `Observer<E>` or `ObserverMut<E>` depending if we want to pass readonly or mutable references.
2. All different kinds of subscriptions ie. `UpdateSubscription = Subscription<Arc<dyn Fn(&TransactionMut, &UpdateEvent>>` are now conflated into one: `yrs::Subscription`.
3. No more `SubscriptionId` - just use `Subscription` and drop it if it's no longer needed.
4. No more dozens of `unsubscribe` methods. Either `drop` (yrs), `free` (ywasm) or `yunobserve` (yffi) is all you need.

This PR includes new mechanics like delayed cleanup of resources so while dropping the subscription causes correlated callback to be unsubscribed from event, small parts of the callback object allocated on heap may still hang around. These will be removed automatically once the unregistered callbacks are visited ie. as part of `observe` methods or when events are being triggered during `transaction.commit()`.