### PR TITLE
moved ysync protocol into yrs

### DIFF
--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -546,14 +546,13 @@
 //! necessary:
 //!
 //! ```rust
-//! use yrs::encoding::read::Error;
-//! use yrs::sync::{Awareness, Message, Protocol};
+//! use yrs::sync::{Awareness, Message, Protocol, Error};
 //!
 //! struct MyProtocol;
 //! impl Protocol for MyProtocol {
 //!     fn missing_handle(&self, awareness: &mut Awareness, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
 //!         // you can not only override existing message handlers but also define your own
-//!         todo!()
+//!         Ok(Some(Message::Custom(tag, data))) // echo
 //!     }
 //! }
 //! ```

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -412,7 +412,7 @@
 //!
 //! # Other shared types
 //!
-//! So far we only discussed rich text oriented capabilities of Yrs. However it's possible to make
+//! So far we only discussed rich text oriented capabilities of Yrs. However, it's possible to make
 //! use of Yrs to represent any tree-like object:
 //!
 //! - [ArrayRef] can be used to represent any indexable sequence of values. If there are multiple
@@ -495,7 +495,7 @@
 //! # Transaction event lifecycle
 //!
 //! Yrs provides a variety of lifecycle events, which enable users to react on various situations
-//! and changes performed. Some of these events are used by Yrs own features (eg. [UndoManager]).
+//! and changes performed. Some of these events are used by Yrs own features (e.g. [UndoManager]).
 //! They are always triggered once performed update is committed by dropping or
 //! [committing](TransactionMut::commit) a read-write transaction.
 //!
@@ -521,9 +521,42 @@
 //!
 //! V1 encoding is the default one and should be preferred most of the time. V2 encoding aims to
 //! perform payload size optimizations whenever multiple updates are being encoded and passed
-//! together (eg. when you want to serialize an entire document state), however for small updates
-//! (eg. sending individual user key strokes) V2 may turn out to be less optimal than its V1
+//! together (e.g. when you want to serialize an entire document state), however for small updates
+//! (e.g. sending individual user keystrokes) V2 may turn out to be less optimal than its V1
 //! equivalent.
+//!
+//! # Awareness and y-sync protocol
+//!
+//! Sometimes it's not always feasible to keep all state changes related to a document within a
+//! document update history - especially if they are notifications bound to a single user or session.
+//! For this reason most of the editor bindings using Yjs supplement the document state with
+//! [sync::Awareness] - it's a separate entity that keeps user related data such as username
+//! or cursor position, but without the overhead of keeping metadata necessary for conflict
+//! resolution.
+//!
+//! [sync::Awareness] together with [Doc] updates combined create basis of y-sync [sync::Protocol].
+//! It's used by most of the network providers in Yjs/Yrs ecosystem and enables universal way of
+//! communicating between different systems.
+//!
+//! In its core y-sync protocol can operate as a simple state machine that serves exchanging and
+//! responding to different message types described by the protocol. The [sync::DefaultProtocol]
+//! provides all the message handlers necessary to make basic communication possible.
+//!
+//! y-sync protocol is extensible leaves a space for the users to define their own messages if
+//! necessary:
+//!
+//! ```rust
+//! use yrs::encoding::read::Error;
+//! use yrs::sync::{Awareness, Message, Protocol};
+//!
+//! struct MyProtocol;
+//! impl Protocol for MyProtocol {
+//!     fn missing_handle(&self, awareness: &mut Awareness, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
+//!         // you can not only override existing message handlers but also define your own
+//!         todo!()
+//!     }
+//! }
+//! ```
 //!
 //! # External learning materials
 //!
@@ -557,6 +590,7 @@ mod moving;
 pub mod observer;
 mod slice;
 mod state_vector;
+pub mod sync;
 #[cfg(test)]
 mod test_utils;
 #[cfg(test)]

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -26,6 +26,15 @@ impl<E> Observer<E> {
         }
     }
 
+    pub fn has_subscribers(&self) -> bool {
+        let callbacks = self.inner.load();
+        if let Some(callbacks) = &*callbacks {
+            callbacks.is_empty()
+        } else {
+            false
+        }
+    }
+
     /// Cleanup already released subscriptions. Whenever a [Subscription] is dropped, the callback is released. However,
     /// the weak reference to callback may still be kept around until it becomes touched by operations such as
     /// [Observer::subscribe] or [Observer::callbacks].

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -1,0 +1,425 @@
+use crate::block::ClientID;
+use crate::updates::decoder::{Decode, Decoder};
+use crate::updates::encoder::{Encode, Encoder};
+use crate::{Doc, Observer, Subscription};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt::Formatter;
+use std::mem::MaybeUninit;
+use std::time::Instant;
+use thiserror::Error;
+
+const NULL_STR: &str = "null";
+
+/// The Awareness class implements a simple shared state protocol that can be used for non-persistent
+/// data like awareness information (cursor, username, status, ..). Each client can update its own
+/// local state and listen to state changes of remote clients.
+///
+/// Each client is identified by a unique client id (something we borrow from `doc.clientID`).
+/// A client can override its own state by propagating a message with an increasing timestamp
+/// (`clock`). If such a message is received, it is applied if the known state of that client is
+/// older than the new state (`clock < new_clock`). If a client thinks that a remote client is
+/// offline, it may propagate a message with `{ clock, state: null, client }`. If such a message is
+/// received, and the known clock of that client equals the received clock, it will clean the state.
+///
+/// Before a client disconnects, it should propagate a `null` state with an updated clock.
+pub struct Awareness {
+    doc: Doc,
+    states: HashMap<ClientID, String>,
+    meta: HashMap<ClientID, MetaClientState>,
+    on_update: Observer<Event>,
+}
+
+unsafe impl Send for Awareness {}
+unsafe impl Sync for Awareness {}
+
+impl Awareness {
+    /// Creates a new instance of [Awareness] struct, which operates over a given document.
+    /// Awareness instance has full ownership of that document. If necessary it can be accessed
+    /// using either [Awareness::doc] or [Awareness::doc_mut] methods.
+    pub fn new(doc: Doc) -> Self {
+        Awareness {
+            doc,
+            on_update: Observer::new(),
+            states: HashMap::new(),
+            meta: HashMap::new(),
+        }
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    pub fn on_update<F>(&self, f: F) -> Subscription
+    where
+        F: Fn(&Event) -> () + 'static,
+    {
+        self.on_update.subscribe(move |txn, e| f(e))
+    }
+
+    /// Returns a read-only reference to an underlying [Doc].
+    pub fn doc(&self) -> &Doc {
+        &self.doc
+    }
+
+    /// Returns a read-write reference to an underlying [Doc].
+    pub fn doc_mut(&mut self) -> &mut Doc {
+        &mut self.doc
+    }
+
+    /// Returns a globally unique client ID of an underlying [Doc].
+    pub fn client_id(&self) -> ClientID {
+        self.doc.client_id()
+    }
+
+    /// Returns a state map of all of the clients tracked by current [Awareness] instance. Those
+    /// states are identified by their corresponding [ClientID]s. The associated state is
+    /// represented and replicated to other clients as a JSON string.
+    pub fn clients(&self) -> &HashMap<ClientID, String> {
+        &self.states
+    }
+
+    /// Returns a JSON string state representation of a current [Awareness] instance.
+    pub fn local_state(&self) -> Option<&str> {
+        Some(self.states.get(&self.doc.client_id())?.as_str())
+    }
+
+    /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
+    /// be replicated to other clients as part of the [AwarenessUpdate] and it will trigger an event
+    /// to be emitted if current instance was created using [Awareness::with_observer] method.
+    ///
+    pub fn set_local_state<S: Into<String>>(&mut self, json: S) {
+        let client_id = self.doc.client_id();
+        self.update_meta(client_id);
+        let new: String = json.into();
+        match self.states.entry(client_id) {
+            Entry::Occupied(mut e) => {
+                e.insert(new);
+                if let Some(mut callbacks) = self.on_update.callbacks() {
+                    let e = Event::new(vec![], vec![client_id], vec![]);
+                    // artificial transaction for the same of Observer signature, it will never be reached
+                    callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
+                }
+            }
+            Entry::Vacant(e) => {
+                e.insert(new);
+                if let Some(mut callbacks) = self.on_update.callbacks() {
+                    let e = Event::new(vec![client_id], vec![], vec![]);
+                    // artificial transaction for the same of Observer signature, it will never be reached
+                    callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
+                }
+            }
+        }
+    }
+
+    /// Clears out a state of a given client, effectively marking it as disconnected.
+    pub fn remove_state(&mut self, client_id: ClientID) {
+        let prev_state = self.states.remove(&client_id);
+        self.update_meta(client_id);
+        if let Some(mut callbacks) = self.on_update.callbacks() {
+            if prev_state.is_some() {
+                // artificial transaction for the same of Observer signature, it will never be reached
+                let e = Event::new(Vec::default(), Vec::default(), vec![client_id]);
+                callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
+            }
+        }
+    }
+
+    /// Clears out a state of a current client (see: [Awareness::client_id]),
+    /// effectively marking it as disconnected.
+    pub fn clean_local_state(&mut self) {
+        let client_id = self.doc.client_id();
+        self.remove_state(client_id);
+    }
+
+    fn update_meta(&mut self, client_id: ClientID) {
+        match self.meta.entry(client_id) {
+            Entry::Occupied(mut e) => {
+                let clock = e.get().clock + 1;
+                let meta = MetaClientState::new(clock, Instant::now());
+                e.insert(meta);
+            }
+            Entry::Vacant(e) => {
+                e.insert(MetaClientState::new(1, Instant::now()));
+            }
+        }
+    }
+
+    /// Returns a serializable update object which is representation of a current Awareness state.
+    pub fn update(&self) -> Result<AwarenessUpdate, Error> {
+        let clients = self.states.keys().cloned();
+        self.update_with_clients(clients)
+    }
+
+    /// Returns a serializable update object which is representation of a current Awareness state.
+    /// Unlike [Awareness::update], this method variant allows to prepare update only for a subset
+    /// of known clients. These clients must all be known to a current [Awareness] instance,
+    /// otherwise a [Error::ClientNotFound] error will be returned.
+    pub fn update_with_clients<I: IntoIterator<Item = ClientID>>(
+        &self,
+        clients: I,
+    ) -> Result<AwarenessUpdate, Error> {
+        let mut res = HashMap::new();
+        for client_id in clients {
+            let clock = if let Some(meta) = self.meta.get(&client_id) {
+                meta.clock
+            } else {
+                return Err(Error::ClientNotFound(client_id));
+            };
+            let json = if let Some(json) = self.states.get(&client_id) {
+                json.clone()
+            } else {
+                String::from(NULL_STR)
+            };
+            res.insert(client_id, AwarenessUpdateEntry { clock, json });
+        }
+        Ok(AwarenessUpdate { clients: res })
+    }
+
+    /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
+    /// [Awareness::update_with_clients] methods) and modifies a state of a current instance.
+    ///
+    /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
+    /// changes will also be emitted as events.
+    pub fn apply_update(&mut self, update: AwarenessUpdate) -> Result<(), Error> {
+        let now = Instant::now();
+
+        let mut added = Vec::new();
+        let mut updated = Vec::new();
+        let mut removed = Vec::new();
+
+        for (client_id, entry) in update.clients {
+            let mut clock = entry.clock;
+            let is_null = entry.json.as_str() == NULL_STR;
+            match self.meta.entry(client_id) {
+                Entry::Occupied(mut e) => {
+                    let prev = e.get();
+                    let is_removed =
+                        prev.clock == clock && is_null && self.states.contains_key(&client_id);
+                    let is_new = prev.clock < clock;
+                    if is_new || is_removed {
+                        if is_null {
+                            // never let a remote client remove this local state
+                            if client_id == self.doc.client_id()
+                                && self.states.get(&client_id).is_some()
+                            {
+                                // remote client removed the local state. Do not remote state. Broadcast a message indicating
+                                // that this client still exists by increasing the clock
+                                clock += 1;
+                            } else {
+                                self.states.remove(&client_id);
+                                if self.on_update.has_subscribers() {
+                                    removed.push(client_id);
+                                }
+                            }
+                        } else {
+                            match self.states.entry(client_id) {
+                                Entry::Occupied(mut e) => {
+                                    if self.on_update.has_subscribers() {
+                                        updated.push(client_id);
+                                    }
+                                    e.insert(entry.json);
+                                }
+                                Entry::Vacant(e) => {
+                                    e.insert(entry.json);
+                                    if self.on_update.has_subscribers() {
+                                        updated.push(client_id);
+                                    }
+                                }
+                            }
+                        }
+                        e.insert(MetaClientState::new(clock, now));
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Entry::Vacant(e) => {
+                    e.insert(MetaClientState::new(clock, now));
+                    self.states.insert(client_id, entry.json);
+                    if self.on_update.has_subscribers() {
+                        added.push(client_id);
+                    }
+                    true
+                }
+            };
+        }
+
+        if let Some(mut callbacks) = self.on_update.callbacks() {
+            if !added.is_empty() || !updated.is_empty() || !removed.is_empty() {
+                // artificial transaction for the same of Observer signature, it will never be reached
+                let e = Event::new(added, updated, removed);
+                callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for Awareness {
+    fn default() -> Self {
+        Awareness::new(Doc::new())
+    }
+}
+
+impl std::fmt::Debug for Awareness {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Awareness")
+            .field("state", &self.states)
+            .field("meta", &self.meta)
+            .field("doc", &self.doc)
+            .finish()
+    }
+}
+
+/// A structure that represents an encodable state of an [Awareness] struct.
+#[derive(Debug, Eq, PartialEq)]
+pub struct AwarenessUpdate {
+    pub(crate) clients: HashMap<ClientID, AwarenessUpdateEntry>,
+}
+
+impl Encode for AwarenessUpdate {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        encoder.write_var(self.clients.len());
+        for (&client_id, e) in self.clients.iter() {
+            encoder.write_var(client_id);
+            encoder.write_var(e.clock);
+            encoder.write_string(&e.json);
+        }
+    }
+}
+
+impl Decode for AwarenessUpdate {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, crate::encoding::read::Error> {
+        let len: usize = decoder.read_var()?;
+        let mut clients = HashMap::with_capacity(len);
+        for _ in 0..len {
+            let client_id: ClientID = decoder.read_var()?;
+            let clock: u32 = decoder.read_var()?;
+            let json = decoder.read_string()?.to_string();
+            clients.insert(client_id, AwarenessUpdateEntry { clock, json });
+        }
+
+        Ok(AwarenessUpdate { clients })
+    }
+}
+
+/// A single client entry of an [AwarenessUpdate]. It consists of logical clock and JSON client
+/// state represented as a string.
+#[derive(Debug, Eq, PartialEq)]
+pub struct AwarenessUpdateEntry {
+    pub(crate) clock: u32,
+    pub(crate) json: String,
+}
+
+/// Errors generated by an [Awareness] struct methods.
+#[derive(Error, Debug)]
+pub enum Error {
+    /// Client ID was not found in [Awareness] metadata.
+    #[error("client ID `{0}` not found")]
+    ClientNotFound(ClientID),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MetaClientState {
+    clock: u32,
+    last_updated: Instant,
+}
+
+impl MetaClientState {
+    fn new(clock: u32, last_updated: Instant) -> Self {
+        MetaClientState {
+            clock,
+            last_updated,
+        }
+    }
+}
+
+/// Event type emitted by an [Awareness] struct.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub struct Event {
+    added: Vec<ClientID>,
+    updated: Vec<ClientID>,
+    removed: Vec<ClientID>,
+}
+
+impl Event {
+    pub fn new(added: Vec<ClientID>, updated: Vec<ClientID>, removed: Vec<ClientID>) -> Self {
+        Event {
+            added,
+            updated,
+            removed,
+        }
+    }
+
+    /// Collection of new clients that have been added to an [Awareness] struct, that was not known
+    /// before. Actual client state can be accessed via `awareness.clients().get(client_id)`.
+    pub fn added(&self) -> &[ClientID] {
+        &self.added
+    }
+
+    /// Collection of new clients that have been updated within an [Awareness] struct since the last
+    /// update. Actual client state can be accessed via `awareness.clients().get(client_id)`.
+    pub fn updated(&self) -> &[ClientID] {
+        &self.updated
+    }
+
+    /// Collection of new clients that have been removed from [Awareness] struct since the last
+    /// update.
+    pub fn removed(&self) -> &[ClientID] {
+        &self.removed
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::sync::awareness::Event;
+    use crate::sync::Awareness;
+    use crate::Doc;
+    use std::sync::mpsc::{channel, Receiver};
+
+    fn update(
+        recv: &mut Receiver<Event>,
+        from: &Awareness,
+        to: &mut Awareness,
+    ) -> Result<Event, Box<dyn std::error::Error>> {
+        let e = recv.try_recv()?;
+        let u = from.update_with_clients([e.added(), e.updated(), e.removed()].concat())?;
+        to.apply_update(u)?;
+        Ok(e)
+    }
+
+    #[test]
+    fn awareness() -> Result<(), Box<dyn std::error::Error>> {
+        let (s1, mut o_local) = channel();
+        let mut local = Awareness::new(Doc::with_client_id(1));
+        let _sub_local = local.on_update(move |e| {
+            s1.send(e.clone()).unwrap();
+        });
+
+        let (s2, o_remote) = channel();
+        let mut remote = Awareness::new(Doc::with_client_id(2));
+        let _sub_remote = local.on_update(move |e| {
+            s2.send(e.clone()).unwrap();
+        });
+
+        local.set_local_state("{x:3}");
+        let _e_local = update(&mut o_local, &local, &mut remote)?;
+        assert_eq!(remote.clients()[&1], "{x:3}");
+        assert_eq!(remote.meta[&1].clock, 1);
+        assert_eq!(o_remote.try_recv()?.added, &[1]);
+
+        local.set_local_state("{x:4}");
+        let e_local = update(&mut o_local, &local, &mut remote)?;
+        let e_remote = o_remote.try_recv()?;
+        assert_eq!(remote.clients()[&1], "{x:4}");
+        assert_eq!(e_remote, Event::new(vec![], vec![1], vec![]));
+        assert_eq!(e_remote, e_local);
+
+        local.clean_local_state();
+        let e_local = update(&mut o_local, &local, &mut remote)?;
+        let e_remote = o_remote.try_recv()?;
+        assert_eq!(e_remote.removed.len(), 1);
+        assert_eq!(local.clients().get(&1), None);
+        assert_eq!(e_remote, e_local);
+        Ok(())
+    }
+}

--- a/yrs/src/sync/mod.rs
+++ b/yrs/src/sync/mod.rs
@@ -1,0 +1,11 @@
+pub mod awareness;
+mod protocol;
+
+pub use crate::sync::awareness::Awareness;
+pub use crate::sync::awareness::AwarenessUpdate;
+pub use crate::sync::protocol::DefaultProtocol;
+pub use crate::sync::protocol::Error;
+pub use crate::sync::protocol::Message;
+pub use crate::sync::protocol::MessageReader;
+pub use crate::sync::protocol::Protocol;
+pub use crate::sync::protocol::SyncMessage;

--- a/yrs/src/sync/protocol.rs
+++ b/yrs/src/sync/protocol.rs
@@ -1,0 +1,475 @@
+use crate::encoding::read;
+use crate::sync::{awareness, Awareness, AwarenessUpdate};
+use crate::updates::decoder::{Decode, Decoder};
+use crate::updates::encoder::{Encode, Encoder};
+use crate::{ReadTxn, StateVector, Transact, Update};
+use thiserror::Error;
+
+/*
+ Core Yjs defines two message types:
+ • YjsSyncStep1: Includes the State Set of the sending client. When received, the client should reply with YjsSyncStep2.
+ • YjsSyncStep2: Includes all missing structs and the complete delete set. When received, the client is assured that it
+   received all information from the remote client.
+
+ In a peer-to-peer network, you may want to introduce a SyncDone message type. Both parties should initiate the connection
+ with SyncStep1. When a client received SyncStep2, it should reply with SyncDone. When the local client received both
+ SyncStep2 and SyncDone, it is assured that it is synced to the remote client.
+
+ In a client-server model, you want to handle this differently: The client should initiate the connection with SyncStep1.
+ When the server receives SyncStep1, it should reply with SyncStep2 immediately followed by SyncStep1. The client replies
+ with SyncStep2 when it receives SyncStep1. Optionally the server may send a SyncDone after it received SyncStep2, so the
+ client knows that the sync is finished.  There are two reasons for this more elaborated sync model: 1. This protocol can
+ easily be implemented on top of http and websockets. 2. The server should only reply to requests, and not initiate them.
+ Therefore, it is necessary that the client initiates the sync.
+
+ Construction of a message:
+ [messageType : varUint, message definition..]
+
+ Note: A message does not include information about the room name. This must be handled by the upper layer protocol!
+
+ stringify[messageType] stringifies a message definition (messageType is already read from the buffer)
+*/
+
+/// A default implementation of y-sync [Protocol].
+pub struct DefaultProtocol;
+
+impl Protocol for DefaultProtocol {}
+
+/// Trait implementing a y-sync protocol. The default implementation can be found in
+/// [DefaultProtocol], but its implementation steps can be potentially changed by the user if
+/// necessary.
+pub trait Protocol {
+    /// To be called whenever a new connection has been accepted. Returns an encoded list of
+    /// messages to be send back to initiator. This binary may contain multiple messages inside,
+    /// stored one after another.
+    fn start<E: Encoder>(&self, awareness: &Awareness, encoder: &mut E) -> Result<(), Error> {
+        let (sv, update) = {
+            let sv = awareness.doc().transact().state_vector();
+            let update = awareness.update()?;
+            (sv, update)
+        };
+        Message::Sync(SyncMessage::SyncStep1(sv)).encode(encoder);
+        Message::Awareness(update).encode(encoder);
+        Ok(())
+    }
+
+    /// Y-sync protocol sync-step-1 - given a [StateVector] of a remote side, calculate missing
+    /// updates. Returns a sync-step-2 message containing a calculated update.
+    fn handle_sync_step1(
+        &self,
+        awareness: &Awareness,
+        sv: StateVector,
+    ) -> Result<Option<Message>, Error> {
+        let update = awareness.doc().transact().encode_state_as_update_v1(&sv);
+        Ok(Some(Message::Sync(SyncMessage::SyncStep2(update))))
+    }
+
+    /// Handle reply for a sync-step-1 send from this replica previously. By default just apply
+    /// an update to current `awareness` document instance.
+    fn handle_sync_step2(
+        &self,
+        awareness: &mut Awareness,
+        update: Update,
+    ) -> Result<Option<Message>, Error> {
+        let mut txn = awareness.doc().transact_mut();
+        txn.apply_update(update);
+        Ok(None)
+    }
+
+    /// Handle continuous update send from the client. By default just apply an update to a current
+    /// `awareness` document instance.
+    fn handle_update(
+        &self,
+        awareness: &mut Awareness,
+        update: Update,
+    ) -> Result<Option<Message>, Error> {
+        self.handle_sync_step2(awareness, update)
+    }
+
+    /// Handle authorization message. By default if reason for auth denial has been provided,
+    /// send back [Error::PermissionDenied].
+    fn handle_auth(
+        &self,
+        _awareness: &Awareness,
+        deny_reason: Option<String>,
+    ) -> Result<Option<Message>, Error> {
+        if let Some(reason) = deny_reason {
+            Err(Error::PermissionDenied { reason })
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns an [AwarenessUpdate] which is a serializable representation of a current `awareness`
+    /// instance.
+    fn handle_awareness_query(&self, awareness: &Awareness) -> Result<Option<Message>, Error> {
+        let update = awareness.update()?;
+        Ok(Some(Message::Awareness(update)))
+    }
+
+    /// Reply to awareness query or just incoming [AwarenessUpdate], where current `awareness`
+    /// instance is being updated with incoming data.
+    fn handle_awareness_update(
+        &self,
+        awareness: &mut Awareness,
+        update: AwarenessUpdate,
+    ) -> Result<Option<Message>, Error> {
+        awareness.apply_update(update)?;
+        Ok(None)
+    }
+
+    /// Y-sync protocol enables to extend its own settings with custom handles. These can be
+    /// implemented here. By default it returns an [Error::Unsupported].
+    fn missing_handle(
+        &self,
+        _awareness: &mut Awareness,
+        tag: u8,
+        _data: Vec<u8>,
+    ) -> Result<Option<Message>, Error> {
+        Err(Error::Unsupported(tag))
+    }
+}
+
+/// Tag id for [Message::Sync].
+pub const MSG_SYNC: u8 = 0;
+/// Tag id for [Message::Awareness].
+pub const MSG_AWARENESS: u8 = 1;
+/// Tag id for [Message::Auth].
+pub const MSG_AUTH: u8 = 2;
+/// Tag id for [Message::AwarenessQuery].
+pub const MSG_QUERY_AWARENESS: u8 = 3;
+
+pub const PERMISSION_DENIED: u8 = 0;
+pub const PERMISSION_GRANTED: u8 = 1;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Message {
+    Sync(SyncMessage),
+    Auth(Option<String>),
+    AwarenessQuery,
+    Awareness(AwarenessUpdate),
+    Custom(u8, Vec<u8>),
+}
+
+impl Encode for Message {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        match self {
+            Message::Sync(msg) => {
+                encoder.write_var(MSG_SYNC);
+                msg.encode(encoder);
+            }
+            Message::Auth(reason) => {
+                encoder.write_var(MSG_AUTH);
+                if let Some(reason) = reason {
+                    encoder.write_var(PERMISSION_DENIED);
+                    encoder.write_string(&reason);
+                } else {
+                    encoder.write_var(PERMISSION_GRANTED);
+                }
+            }
+            Message::AwarenessQuery => {
+                encoder.write_var(MSG_QUERY_AWARENESS);
+            }
+            Message::Awareness(update) => {
+                encoder.write_var(MSG_AWARENESS);
+                encoder.write_buf(&update.encode_v1())
+            }
+            Message::Custom(tag, data) => {
+                encoder.write_u8(*tag);
+                encoder.write_buf(&data);
+            }
+        }
+    }
+}
+
+impl Decode for Message {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, read::Error> {
+        let tag: u8 = decoder.read_var()?;
+        match tag {
+            MSG_SYNC => {
+                let msg = SyncMessage::decode(decoder)?;
+                Ok(Message::Sync(msg))
+            }
+            MSG_AWARENESS => {
+                let data = decoder.read_buf()?;
+                let update = AwarenessUpdate::decode_v1(data)?;
+                Ok(Message::Awareness(update))
+            }
+            MSG_AUTH => {
+                let reason = if decoder.read_var::<u8>()? == PERMISSION_DENIED {
+                    Some(decoder.read_string()?.to_string())
+                } else {
+                    None
+                };
+                Ok(Message::Auth(reason))
+            }
+            MSG_QUERY_AWARENESS => Ok(Message::AwarenessQuery),
+            tag => {
+                let data = decoder.read_buf()?;
+                Ok(Message::Custom(tag, data.to_vec()))
+            }
+        }
+    }
+}
+
+/// Tag id for [SyncMessage::SyncStep1].
+pub const MSG_SYNC_STEP_1: u8 = 0;
+/// Tag id for [SyncMessage::SyncStep2].
+pub const MSG_SYNC_STEP_2: u8 = 1;
+/// Tag id for [SyncMessage::Update].
+pub const MSG_SYNC_UPDATE: u8 = 2;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum SyncMessage {
+    SyncStep1(StateVector),
+    SyncStep2(Vec<u8>),
+    Update(Vec<u8>),
+}
+
+impl Encode for SyncMessage {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        match self {
+            SyncMessage::SyncStep1(sv) => {
+                encoder.write_var(MSG_SYNC_STEP_1);
+                encoder.write_buf(sv.encode_v1());
+            }
+            SyncMessage::SyncStep2(u) => {
+                encoder.write_var(MSG_SYNC_STEP_2);
+                encoder.write_buf(u);
+            }
+            SyncMessage::Update(u) => {
+                encoder.write_var(MSG_SYNC_UPDATE);
+                encoder.write_buf(u);
+            }
+        }
+    }
+}
+
+impl Decode for SyncMessage {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, read::Error> {
+        let tag: u8 = decoder.read_var()?;
+        match tag {
+            MSG_SYNC_STEP_1 => {
+                let buf = decoder.read_buf()?;
+                let sv = StateVector::decode_v1(buf)?;
+                Ok(SyncMessage::SyncStep1(sv))
+            }
+            MSG_SYNC_STEP_2 => {
+                let buf = decoder.read_buf()?;
+                Ok(SyncMessage::SyncStep2(buf.into()))
+            }
+            MSG_SYNC_UPDATE => {
+                let buf = decoder.read_buf()?;
+                Ok(SyncMessage::Update(buf.into()))
+            }
+            _ => Err(read::Error::UnexpectedValue),
+        }
+    }
+}
+
+/// An error type returned in response from y-sync [Protocol].
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Incoming Y-protocol message couldn't be deserialized.
+    #[error("failed to deserialize message: {0}")]
+    DecodingError(#[from] read::Error),
+
+    /// Applying incoming Y-protocol awareness update has failed.
+    #[error("failed to process awareness update: {0}")]
+    AwarenessEncoding(#[from] awareness::Error),
+
+    /// An incoming Y-protocol authorization request has been denied.
+    #[error("permission denied to access: {reason}")]
+    PermissionDenied { reason: String },
+
+    /// Thrown whenever an unknown message tag has been sent.
+    #[error("unsupported message tag identifier: {0}")]
+    Unsupported(u8),
+
+    /// Thrown in case of I/O errors.
+    #[error("IO error: {0}")]
+    IO(#[from] std::io::Error),
+
+    /// Custom dynamic kind of error, usually related to a warp internal error messages.
+    #[error("internal failure: {0}")]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[cfg(feature = "net")]
+impl From<tokio::task::JoinError> for Error {
+    fn from(value: tokio::task::JoinError) -> Self {
+        Error::Other(value.into())
+    }
+}
+
+/// Since y-sync protocol enables for a multiple messages to be packed into a singe byte payload,
+/// [MessageReader] can be used over the decoder to read these messages one by one in iterable
+/// fashion.
+pub struct MessageReader<'a, D: Decoder>(&'a mut D);
+
+impl<'a, D: Decoder> MessageReader<'a, D> {
+    pub fn new(decoder: &'a mut D) -> Self {
+        MessageReader(decoder)
+    }
+}
+
+impl<'a, D: Decoder> Iterator for MessageReader<'a, D> {
+    type Item = Result<Message, read::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match Message::decode(self.0) {
+            Ok(msg) => Some(Ok(msg)),
+            Err(read::Error::EndOfBuffer(_)) => None,
+            Err(error) => Some(Err(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::encoding::read::Cursor;
+    use crate::sync::protocol::MessageReader;
+    use crate::sync::{Awareness, Protocol};
+    use crate::updates::decoder::{Decode, DecoderV1};
+    use crate::updates::encoder::{Encode, Encoder, EncoderV1};
+    use crate::{Doc, GetString, ReadTxn, StateVector, Text, Transact, Update};
+    use std::collections::HashMap;
+
+    #[test]
+    fn message_encoding() {
+        let doc = Doc::new();
+        let txt = doc.get_or_insert_text("text");
+        txt.push(&mut doc.transact_mut(), "hello world");
+        let mut awareness = Awareness::new(doc);
+        awareness.set_local_state("{\"user\":{\"name\":\"Anonymous 50\",\"color\":\"#30bced\",\"colorLight\":\"#30bced33\"}}");
+
+        let messages = [
+            crate::sync::Message::Sync(crate::sync::SyncMessage::SyncStep1(
+                awareness.doc().transact().state_vector(),
+            )),
+            crate::sync::Message::Sync(crate::sync::SyncMessage::SyncStep2(
+                awareness
+                    .doc()
+                    .transact()
+                    .encode_state_as_update_v1(&StateVector::default()),
+            )),
+            crate::sync::Message::Awareness(awareness.update().unwrap()),
+            crate::sync::Message::Auth(Some("reason".to_string())),
+            crate::sync::Message::AwarenessQuery,
+        ];
+
+        for msg in messages {
+            let encoded = msg.encode_v1();
+            let decoded = crate::sync::Message::decode_v1(&encoded)
+                .expect(&format!("failed to decode {:?}", msg));
+            assert_eq!(decoded, msg);
+        }
+    }
+
+    #[test]
+    fn protocol_init() {
+        let awareness = Awareness::default();
+        let protocol = crate::sync::DefaultProtocol;
+        let mut encoder = EncoderV1::new();
+        protocol.start(&awareness, &mut encoder).unwrap();
+        let data = encoder.to_vec();
+        let mut decoder = DecoderV1::new(Cursor::new(&data));
+        let mut reader = MessageReader::new(&mut decoder);
+
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            crate::sync::Message::Sync(crate::sync::SyncMessage::SyncStep1(StateVector::default()))
+        );
+
+        assert_eq!(
+            reader.next().unwrap().unwrap(),
+            crate::sync::Message::Awareness(awareness.update().unwrap())
+        );
+
+        assert!(reader.next().is_none());
+    }
+
+    #[test]
+    fn protocol_sync_steps() {
+        let protocol = crate::sync::DefaultProtocol;
+
+        let mut a1 = Awareness::new(Doc::with_client_id(1));
+        let mut a2 = Awareness::new(Doc::with_client_id(2));
+
+        let expected = {
+            let txt = a1.doc_mut().get_or_insert_text("test");
+            let mut txn = a1.doc_mut().transact_mut();
+            txt.push(&mut txn, "hello");
+            txn.encode_state_as_update_v1(&StateVector::default())
+        };
+
+        let result = protocol
+            .handle_sync_step1(&a1, a2.doc().transact().state_vector())
+            .unwrap();
+
+        assert_eq!(
+            result,
+            Some(crate::sync::Message::Sync(
+                crate::sync::SyncMessage::SyncStep2(expected)
+            ))
+        );
+
+        if let Some(crate::sync::Message::Sync(crate::sync::SyncMessage::SyncStep2(u))) = result {
+            let result2 = protocol
+                .handle_sync_step2(&mut a2, Update::decode_v1(&u).unwrap())
+                .unwrap();
+
+            assert!(result2.is_none());
+        }
+
+        let txt = a2.doc().transact().get_text("test").unwrap();
+        assert_eq!(txt.get_string(&a2.doc().transact()), "hello".to_owned());
+    }
+
+    #[test]
+    fn protocol_sync_step_update() {
+        let protocol = crate::sync::DefaultProtocol;
+
+        let mut a1 = Awareness::new(Doc::with_client_id(1));
+        let mut a2 = Awareness::new(Doc::with_client_id(2));
+
+        let data = {
+            let txt = a1.doc_mut().get_or_insert_text("test");
+            let mut txn = a1.doc_mut().transact_mut();
+            txt.push(&mut txn, "hello");
+            txn.encode_update_v1()
+        };
+
+        let result = protocol
+            .handle_update(&mut a2, Update::decode_v1(&data).unwrap())
+            .unwrap();
+
+        assert!(result.is_none());
+
+        let txt = a2.doc().transact().get_text("test").unwrap();
+        assert_eq!(txt.get_string(&a2.doc().transact()), "hello".to_owned());
+    }
+
+    #[test]
+    fn protocol_awareness_sync() {
+        let protocol = crate::sync::DefaultProtocol;
+
+        let mut a1 = Awareness::new(Doc::with_client_id(1));
+        let mut a2 = Awareness::new(Doc::with_client_id(2));
+
+        a1.set_local_state("{x:3}");
+        let result = protocol.handle_awareness_query(&a1).unwrap();
+
+        assert_eq!(
+            result,
+            Some(crate::sync::Message::Awareness(a1.update().unwrap()))
+        );
+
+        if let Some(crate::sync::Message::Awareness(u)) = result {
+            let result = protocol.handle_awareness_update(&mut a2, u).unwrap();
+            assert!(result.is_none());
+        }
+
+        assert_eq!(a2.clients(), &HashMap::from([(1, "{x:3}".to_owned())]));
+    }
+}


### PR DESCRIPTION
This PR moves [y-sync]() protocol crate features directly into yrs. The reason is that these features are very closely related to the core crate, while they don't introduce any new dependencies.