### PR TITLE
release v0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
 ]
 
 [[package]]
@@ -292,17 +292,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
@@ -310,7 +299,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -524,8 +513,8 @@ dependencies = [
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -561,36 +550,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -600,16 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -618,16 +575,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -636,7 +584,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -899,12 +847,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -1121,15 +1063,14 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "yffi"
-version = "0.17.4"
+version = "0.18.0"
 dependencies = [
- "rand 0.7.3",
  "yrs",
 ]
 
 [[package]]
 name = "yrs"
-version = "0.17.4"
+version = "0.18.0"
 dependencies = [
  "arc-swap",
  "atomic_refcell",
@@ -1148,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.17.4"
+version = "0.18.0"
 dependencies = [
  "console_error_panic_hook",
  "gloo-utils",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.17.4",
+      "version": "0.18.0",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "yffi"
-version = "0.17.4"
-authors = ["Kevin Jahns <kevin.jahns@protonmail.com>","Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
+version = "0.18.0"
+authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
 license = "MIT"
@@ -12,8 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.17.4", features = ["weak"] }
-rand = "0.7.0"
+yrs = { path = "../yrs", version = "0.18", features = ["weak"] }
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.17.4"
+version = "0.18.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.17.4"
+version = "0.18.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.17.3", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.18", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 gloo-utils = { version = "0.2.0", features = ["serde"] }


### PR DESCRIPTION
# Yrs

- New Observer API (#385): all subscription types now are described as a single `yrs::Subscription` type. `observe` methods no longer require `mut ref` to shared collection or document.
- `Hook` and `BranchID` logical pointers (#393): collection refs such as `ArrayRef`, `TextRef`, `MapRef` now expose `root` and `hook` methods, that can be used to get a logical reference to a given type. This reference can later on be used to try to obtain an actual ref (it could also possibly return `None` if reference was already garbage collected).
- Removed `Doc::get_or_insert_xml_element` and `Doc::get_or_insert_xml_text` - these types are not meant to be used as root level types and doing so may cause data loss due to limitations on how root-level types are represented in lib0 encoding.
- Replaced `rand` crate with `fastrand`(#394): smaller binary size and better support for Web Assembly.
- Moved `Awareness` and y-sync protocol into `yrs::sync` module (#395).
- Changes in the internal representation of Doc updates (#365) - this should result in better performance and less memory used.

# Ywasm

- Rewritten the library. Shared types are now using logical pointer in order to avoid possible segfaults in WASM VM.
- Removed `Doc.getXmlText` and `Doc.getXmlElement`- these types are not meant to be used as root level types and doing so may cause data loss due to limitations on how root-level types are represented in lib0 encoding. Use `Doc.getXmlFragment` instead and insert XML nodes into it.
- `YXmlText` and `YXmlElements` can now be used as prelim types.
- Removed `xmlElement.insertXmlText`/`xmlElement.insertXmlElement`: now there's a single `xmlElement.insert` method that can accept prelim versions of `YXmlText` and `YXmlElement`.
- Logical pointers can now be accessed via `ref.id` property of shared collection types. They can be materialised back into refs via `YTransaction.get` method.

# Yffi

- Removed `yxmlelem` and `yxmltext` functions - these types are not meant to be used as root level types and doing so may cause data loss due to limitations on how root-level types are represented in lib0 encoding. Use `yxmlfragment` instead and insert XML nodes into it.
- Replaced `ytransaction_alive` with `ybranch_alive`.
- Exposed logical collection pointers via `YBranchId` - now `Branch*` can mapped back and forth to `YBranchId` through `ybranch_id` and `ybranch_get` functions. In case when `Branch*` has already been garbage collected and is no longer valid, `ybranch_get` will return NULL.