### PR TITLE
fixed: integrating update block without parent causes panic on subsequent encode

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -515,7 +515,7 @@ impl ItemPtr {
                     None
                 }
             }
-            _ => None,
+            TypePtr::Unknown => return true,
         };
 
         let left: Option<&Item> = this.left.as_deref();

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -227,7 +227,14 @@ impl Update {
                         };
                         store = txn.store_mut();
                         match block {
-                            BlockCarrier::Item(item) => store.blocks.push_block(item),
+                            BlockCarrier::Item(item) => {
+                                if item.parent != TypePtr::Unknown {
+                                    store.blocks.push_block(item)
+                                } else {
+                                    // parent is not defined. Integrate GC struct instead
+                                    store.blocks.push_gc(BlockRange::new(item.id, item.len))
+                                }
+                            }
                             BlockCarrier::GC(gc) => store.blocks.push_gc(gc),
                             BlockCarrier::Skip(_) => { /* do nothing */ }
                         }


### PR DESCRIPTION
Fixes #391

The reason for original panic was that deleted block sent in a 2nd update didn't have a parent specified - such block should be replaced by GC placeholder instead. However it didn't, and the corresponding parent haven't been defined, which caused errors during document state encoding.