### PR TITLE
add AwarenessUpdate as part of the awareness::Event

### DIFF
--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -725,7 +725,6 @@ mod test {
     };
     use std::cell::{Cell, RefCell, RefMut};
     use std::collections::BTreeSet;
-    use std::convert::TryInto;
 
     use std::rc::Rc;
 


### PR DESCRIPTION
This PR includes `AwarenessUpdate` changes as part of the `awareness::Event`. There's no reason not to do that, since basically the main rationale behind having observer on awareness changes is to produce that payload.