### PR TITLE
fix: Text::insert_with_attributes should not generate empty blocks

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -1218,6 +1218,7 @@ impl Item {
             0
         });
         let len = content.len(OffsetKind::Utf16);
+        debug_assert!(len > 0, "Defect: block length is zero");
         let root_name = if let TypePtr::Named(root) = &parent {
             Some(root.clone())
         } else {


### PR DESCRIPTION
There's a missing case where `Text::insert` checks for empty strings and produces a no-op. However the same should apply to `Text::insert_with_attributes` (yes, in such case attributes are not inserted which is a compatible behaviour to Yjs). Otherwise we would produce an empty block, which in turn would cause encoding (and potentially many other operations) to panic.