### PR TITLE
release v0.18.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,14 +1067,14 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "yffi"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "yrs",
 ]
 
 [[package]]
 name = "yrs"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "arc-swap",
  "atomic_refcell",
@@ -1093,7 +1093,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "console_error_panic_hook",
  "gloo-utils",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.18.5",
+      "version": "0.18.7",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.18.6"
+version = "0.18.7"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.18.6", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.18.7", features = ["weak"] }
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.18.6"
+version = "0.18.7"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.18.6"
+version = "0.18.7"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"


### PR DESCRIPTION
- enable decoding 0-length blocks from pre-v0.18 encoded yrs documents: #428 