### PR TITLE
Awareness on_update: provide awareness state in the event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Y CRDT
+
 <p align="center">
   <img src="logo-yrs.svg" width="200"/>
 </p>
 
-A collection of Rust libraries oriented around implementing [Yjs](https://yjs.dev/) algorithm and protocol with cross-language and cross-platform support in mind. It aims to maintain behavior and binary protocol compatibility with Yjs, therefore projects using Yjs/Yrs should be able to interoperate with each other.
+A collection of Rust libraries oriented around implementing [Yjs](https://yjs.dev/) algorithm and protocol with
+cross-language and cross-platform support in mind. It aims to maintain behavior and binary protocol compatibility with
+Yjs, therefore projects using Yjs/Yrs should be able to interoperate with each other.
 
 Project organization:
 
 - **lib0** is a serialization library used for efficient (and fairly fast) data exchange.
 - **yrs** (read: *wires*) is a core Rust library, a foundation stone for other projects.
-- **yffi** (read: *wifi*) is a wrapper around *yrs* used to provide a native C foreign function interface. See also: [C header file](https://github.com/y-crdt/y-crdt/blob/main/tests-ffi/include/libyrs.h).
+- **yffi** (read: *wifi*) is a wrapper around *yrs* used to provide a native C foreign function interface. See
+  also: [C header file](https://github.com/y-crdt/y-crdt/blob/main/tests-ffi/include/libyrs.h).
 - **ywasm** is a wrapper around *yrs* that targets WebAssembly and JavaScript API.
 
 Other projects using *yrs*:
@@ -20,7 +24,7 @@ Other projects using *yrs*:
 ## Feature parity among projects
 
 |                                         |                  yjs <br/>(13.6)                  |               yrs<br/>(0.18)               |                   ywasm<br/>(0.18)                    | yffi<br/>(0.18) |                  y-rb<br/>(0.5)                  |                y-py<br/>(0.6)                | ydotnet<br/>(0.4) | yswift<br/>(0.2) |
-| --------------------------------------- | :-----------------------------------------------: | :----------------------------------------: | :---------------------------------------------------: | :-------------: | :----------------------------------------------: | :------------------------------------------: | :---------------: | :--------------: |
+|-----------------------------------------|:-------------------------------------------------:|:------------------------------------------:|:-----------------------------------------------------:|:---------------:|:------------------------------------------------:|:--------------------------------------------:|:-----------------:|:----------------:|
 | YText: insert/delete                    |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x2705;     |                     &#x2705;                     |                   &#x2705;                   |     &#x2705;      |     &#x2705;     |
 | YText: formatting attributes and deltas |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x2705;     |                     &#x2705;                     |                   &#x2705;                   |     &#x2705;      |     &#x2705;     |
 | YText: embeded elements                 |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x2705;     |                     &#x2705;                     |                   &#x2705;                   |     &#x2705;      |     &#x2705;     |
@@ -38,7 +42,7 @@ Other projects using *yrs*:
 | Snapshots                               |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x2705;     |                     &#x274C;                     |                   &#x274C;                   |     &#x274C;      |     &#x274C;     |
 | Sticky indexes                          |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x2705;     |                     &#x274C;                     |                   &#x274C;                   |     &#x2705;      |     &#x274C;     |
 | Undo Manager                            |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x2705;     |                     &#x274C;                     |                   &#x274C;                   |     &#x2705;      |     &#x2705;     |
-| Awareness                               |                     &#x2705;                      |                  &#x2705;                  |                       &#x2705;                        |    &#x274C;     |                     &#x2705;                     |                   &#x274C;                   |     &#x2705;      |     &#x274C;     |
+| Awareness                               |                     &#x2705;                      |                  &#x2705;                  |                       &#x274C;                        |    &#x274C;     |                     &#x2705;                     |                   &#x274C;                   |     &#x2705;      |     &#x274C;     |
 | Network provider: WebSockets            |    &#x2705; <br/> <small>(y-websocket)</small>    |  &#x2705; <br/> <small>(yrs-warp)</small>  |                       &#x274C;                        |    &#x274C;     | &#x2705; <br/> <small>(y-rb_actioncable)</small> | &#x2705; <br/><small>(ypy-websocket)</small> |     &#x2705;      |     &#x274C;     |
 | Network provider: WebRTC                |     &#x2705; <br/> <small>(y-webrtc)</small>      | &#x2705; <br/> <small>(yrs-webrtc)</small> |                       &#x274C;                        |    &#x274C;     |                     &#x274C;                     |                   &#x274C;                   |     &#x274C;      |     &#x274C;     |
 

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -1,14 +1,16 @@
-use crate::block::ClientID;
-use crate::updates::decoder::{Decode, Decoder};
-use crate::updates::encoder::{Encode, Encoder};
-use crate::{Doc, Observer, Subscription};
-use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::mem::MaybeUninit;
 use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+use crate::block::ClientID;
+use crate::updates::decoder::{Decode, Decoder};
+use crate::updates::encoder::{Encode, Encoder};
+use crate::{Doc, Observer, Subscription};
 
 const NULL_STR: &str = "null";
 
@@ -26,8 +28,7 @@ const NULL_STR: &str = "null";
 /// Before a client disconnects, it should propagate a `null` state with an updated clock.
 pub struct Awareness {
     doc: Doc,
-    states: HashMap<ClientID, String>,
-    meta: HashMap<ClientID, MetaClientState>,
+    state: Option<AwarenessState>,
     on_update: Observer<Event>,
 }
 
@@ -42,8 +43,7 @@ impl Awareness {
         Awareness {
             doc,
             on_update: Observer::new(),
-            states: HashMap::new(),
-            meta: HashMap::new(),
+            state: Some(AwarenessState::new()),
         }
     }
 
@@ -52,7 +52,7 @@ impl Awareness {
     where
         F: Fn(&Event) -> () + 'static,
     {
-        self.on_update.subscribe(move |txn, e| f(e))
+        self.on_update.subscribe(move |_, e| f(e))
     }
 
     /// Returns a read-only reference to an underlying [Doc].
@@ -74,12 +74,12 @@ impl Awareness {
     /// states are identified by their corresponding [ClientID]s. The associated state is
     /// represented and replicated to other clients as a JSON string.
     pub fn clients(&self) -> &HashMap<ClientID, String> {
-        &self.states
+        &self.state.as_ref().unwrap().states
     }
 
     /// Returns a JSON string state representation of a current [Awareness] instance.
     pub fn local_state(&self) -> Option<&str> {
-        Some(self.states.get(&self.doc.client_id())?.as_str())
+        Some(self.state().states.get(&self.doc.client_id())?.as_str())
     }
 
     /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
@@ -88,40 +88,39 @@ impl Awareness {
     ///
     pub fn set_local_state<S: Into<String>>(&mut self, json: S) {
         let client_id = self.doc.client_id();
-        self.update_meta(client_id);
-        let new: String = json.into();
-        match self.states.entry(client_id) {
-            Entry::Occupied(mut e) => {
-                e.insert(new);
-                if let Some(mut callbacks) = self.on_update.callbacks() {
-                    let update = self.update_with_clients([client_id]).ok();
-                    let e = Event::new(vec![], vec![client_id], vec![], update);
-                    // artificial transaction for the same of Observer signature, it will never be reached
-                    callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
-                }
+        let is_new = self.state_mut().set_state(client_id, json.into());
+        if let Some(mut callbacks) = self.on_update.callbacks() {
+            let mut added = vec![];
+            let mut updated = vec![];
+            if is_new {
+                added.push(client_id);
+            } else {
+                updated.push(client_id);
             }
-            Entry::Vacant(e) => {
-                e.insert(new);
-                if let Some(mut callbacks) = self.on_update.callbacks() {
-                    let update = self.update_with_clients([client_id]).ok();
-                    let e = Event::new(vec![client_id], vec![], vec![], update);
-                    // artificial transaction for the same of Observer signature, it will never be reached
-                    callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
-                }
-            }
+            let state = self.state.take().unwrap();
+            let e = Event::new(added, updated, Vec::default(), state, self.doc.clone());
+            // artificial transaction for the same of Observer signature, it will never be reached
+            callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
+            self.state = Some(e.awareness_state);
         }
     }
 
     /// Clears out a state of a given client, effectively marking it as disconnected.
     pub fn remove_state(&mut self, client_id: ClientID) {
-        let prev_state = self.states.remove(&client_id);
-        self.update_meta(client_id);
+        let is_removed = self.state_mut().remove_state(client_id);
         if let Some(mut callbacks) = self.on_update.callbacks() {
-            if prev_state.is_some() {
+            if is_removed {
                 // artificial transaction for the same of Observer signature, it will never be reached
-                let update = self.update_with_clients([client_id]).ok();
-                let e = Event::new(Vec::default(), Vec::default(), vec![client_id], update);
+                let state = self.state.take().unwrap();
+                let e = Event::new(
+                    Vec::default(),
+                    Vec::default(),
+                    vec![client_id],
+                    state,
+                    self.doc.clone(),
+                );
                 callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
+                self.state = Some(e.awareness_state);
             }
         }
     }
@@ -133,48 +132,20 @@ impl Awareness {
         self.remove_state(client_id);
     }
 
-    fn update_meta(&mut self, client_id: ClientID) {
-        match self.meta.entry(client_id) {
-            Entry::Occupied(mut e) => {
-                let clock = e.get().clock + 1;
-                let meta = MetaClientState::new(clock, Instant::now());
-                e.insert(meta);
-            }
-            Entry::Vacant(e) => {
-                e.insert(MetaClientState::new(1, Instant::now()));
-            }
-        }
-    }
-
     /// Returns a serializable update object which is representation of a current Awareness state.
     pub fn update(&self) -> Result<AwarenessUpdate, Error> {
-        let clients = self.states.keys().cloned();
-        self.update_with_clients(clients)
+        self.state().update()
     }
 
     /// Returns a serializable update object which is representation of a current Awareness state.
     /// Unlike [Awareness::update], this method variant allows to prepare update only for a subset
     /// of known clients. These clients must all be known to a current [Awareness] instance,
     /// otherwise a [Error::ClientNotFound] error will be returned.
-    pub fn update_with_clients<I: IntoIterator<Item = ClientID>>(
-        &self,
-        clients: I,
-    ) -> Result<AwarenessUpdate, Error> {
-        let mut res = HashMap::new();
-        for client_id in clients {
-            let clock = if let Some(meta) = self.meta.get(&client_id) {
-                meta.clock
-            } else {
-                return Err(Error::ClientNotFound(client_id));
-            };
-            let json = if let Some(json) = self.states.get(&client_id) {
-                json.clone()
-            } else {
-                String::from(NULL_STR)
-            };
-            res.insert(client_id, AwarenessUpdateEntry { clock, json });
-        }
-        Ok(AwarenessUpdate { clients: res })
+    pub fn update_with_clients<I>(&self, clients: I) -> Result<AwarenessUpdate, Error>
+    where
+        I: IntoIterator<Item = ClientID>,
+    {
+        self.state().update_with_clients(clients)
     }
 
     /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
@@ -200,6 +171,14 @@ impl Awareness {
         self.apply_update_internal(update, true)
     }
 
+    fn state(&self) -> &AwarenessState {
+        self.state.as_ref().unwrap()
+    }
+
+    fn state_mut(&mut self) -> &mut AwarenessState {
+        self.state.as_mut().unwrap()
+    }
+
     fn apply_update_internal(
         &mut self,
         update: AwarenessUpdate,
@@ -211,32 +190,33 @@ impl Awareness {
         let mut updated = Vec::new();
         let mut removed = Vec::new();
 
+        let state = self.state.as_mut().unwrap();
         for (client_id, entry) in update.clients {
             let mut clock = entry.clock;
             let is_null = entry.json.as_str() == NULL_STR;
-            match self.meta.entry(client_id) {
+            match state.meta.entry(client_id) {
                 Entry::Occupied(mut e) => {
                     let prev = e.get();
                     let is_removed =
-                        prev.clock == clock && is_null && self.states.contains_key(&client_id);
+                        prev.clock == clock && is_null && state.states.contains_key(&client_id);
                     let is_new = prev.clock < clock;
                     if is_new || is_removed {
                         if is_null {
                             // never let a remote client remove this local state
                             if client_id == self.doc.client_id()
-                                && self.states.get(&client_id).is_some()
+                                && state.states.get(&client_id).is_some()
                             {
                                 // remote client removed the local state. Do not remote state. Broadcast a message indicating
                                 // that this client still exists by increasing the clock
                                 clock += 1;
                             } else {
-                                self.states.remove(&client_id);
+                                state.states.remove(&client_id);
                                 if generate_summary {
                                     removed.push(client_id);
                                 }
                             }
                         } else {
-                            match self.states.entry(client_id) {
+                            match state.states.entry(client_id) {
                                 Entry::Occupied(mut e) => {
                                     if generate_summary {
                                         updated.push(client_id);
@@ -259,7 +239,7 @@ impl Awareness {
                 }
                 Entry::Vacant(e) => {
                     e.insert(MetaClientState::new(clock, now));
-                    self.states.insert(client_id, entry.json);
+                    state.states.insert(client_id, entry.json);
                     if generate_summary {
                         added.push(client_id);
                     }
@@ -270,21 +250,12 @@ impl Awareness {
 
         if !added.is_empty() || !updated.is_empty() || !removed.is_empty() {
             let summary = if let Some(mut callbacks) = self.on_update.callbacks() {
-                let mut changed = Vec::with_capacity(added.len() + updated.len() + removed.len());
-                changed.extend_from_slice(&*added);
-                changed.extend_from_slice(&*updated);
-                changed.extend_from_slice(&*removed);
-                let update = self.update_with_clients(changed)?;
-
-                let e = Event::new(added, updated, removed, Some(update));
+                let state = self.state.take().unwrap();
+                let e = Event::new(added, updated, removed, state, self.doc.clone());
                 // artificial transaction for the same of Observer signature, it will never be reached
                 callbacks.trigger(unsafe { MaybeUninit::uninit().assume_init_ref() }, &e);
-
-                AwarenessUpdateSummary {
-                    added: e.added,
-                    updated: e.updated,
-                    removed: e.removed,
-                }
+                self.state = Some(e.awareness_state);
+                e.summary
             } else {
                 AwarenessUpdateSummary {
                     added,
@@ -308,8 +279,7 @@ impl Default for Awareness {
 impl std::fmt::Debug for Awareness {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Awareness")
-            .field("state", &self.states)
-            .field("meta", &self.meta)
+            .field("state", &self.state)
             .field("doc", &self.doc)
             .finish()
     }
@@ -404,13 +374,93 @@ impl MetaClientState {
     }
 }
 
+/// An [Awareness] client state representation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwarenessState {
+    states: HashMap<ClientID, String>,
+    meta: HashMap<ClientID, MetaClientState>,
+}
+
+impl AwarenessState {
+    fn new() -> Self {
+        AwarenessState {
+            states: HashMap::new(),
+            meta: HashMap::new(),
+        }
+    }
+
+    fn set_state<S: Into<String>>(&mut self, client_id: ClientID, json: S) -> bool {
+        self.update_meta(client_id);
+        let new: String = json.into();
+        match self.states.entry(client_id) {
+            Entry::Occupied(mut e) => {
+                e.insert(new);
+                false
+            }
+            Entry::Vacant(e) => {
+                e.insert(new);
+                true
+            }
+        }
+    }
+
+    fn remove_state(&mut self, client_id: ClientID) -> bool {
+        let prev_state = self.states.remove(&client_id);
+        self.update_meta(client_id);
+        prev_state.is_some()
+    }
+
+    /// Returns a serializable update object which is representation of a current Awareness state.
+    pub fn update(&self) -> Result<AwarenessUpdate, Error> {
+        let clients = self.states.keys().cloned();
+        self.update_with_clients(clients)
+    }
+
+    /// Returns a serializable update object which is representation of a current Awareness state.
+    /// Unlike [Awareness::update], this method variant allows to prepare update only for a subset
+    /// of known clients. These clients must all be known to a current [Awareness] instance,
+    /// otherwise a [Error::ClientNotFound] error will be returned.
+    pub fn update_with_clients<I: IntoIterator<Item = ClientID>>(
+        &self,
+        clients: I,
+    ) -> Result<AwarenessUpdate, Error> {
+        let mut res = HashMap::new();
+        for client_id in clients {
+            let clock = if let Some(meta) = self.meta.get(&client_id) {
+                meta.clock
+            } else {
+                return Err(Error::ClientNotFound(client_id));
+            };
+            let json = if let Some(json) = self.states.get(&client_id) {
+                json.clone()
+            } else {
+                String::from(NULL_STR)
+            };
+            res.insert(client_id, AwarenessUpdateEntry { clock, json });
+        }
+        Ok(AwarenessUpdate { clients: res })
+    }
+
+    fn update_meta(&mut self, client_id: ClientID) {
+        match self.meta.entry(client_id) {
+            Entry::Occupied(mut e) => {
+                let clock = e.get().clock + 1;
+                let meta = MetaClientState::new(clock, Instant::now());
+                e.insert(meta);
+            }
+            Entry::Vacant(e) => {
+                e.insert(MetaClientState::new(1, Instant::now()));
+            }
+        }
+    }
+}
+
 /// Event type emitted by an [Awareness] struct.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Event {
-    added: Vec<ClientID>,
-    updated: Vec<ClientID>,
-    removed: Vec<ClientID>,
-    update: Option<AwarenessUpdate>,
+    summary: AwarenessUpdateSummary,
+    awareness_state: AwarenessState,
+    doc: Doc,
 }
 
 impl Event {
@@ -418,47 +468,68 @@ impl Event {
         added: Vec<ClientID>,
         updated: Vec<ClientID>,
         removed: Vec<ClientID>,
-        update: Option<AwarenessUpdate>,
+        awareness_state: AwarenessState,
+        doc: Doc,
     ) -> Self {
         Event {
-            added,
-            updated,
-            removed,
-            update,
+            summary: AwarenessUpdateSummary {
+                added,
+                updated,
+                removed,
+            },
+            awareness_state,
+            doc,
         }
     }
 
-    /// Returns an awareness update object, which contains only the data of modified clients.
-    pub fn awareness_update(&self) -> Option<&AwarenessUpdate> {
-        self.update.as_ref()
+    /// Returns an awareness update object, which contains ONLY the data of modified clients.
+    pub fn awareness_update(&self) -> Option<AwarenessUpdate> {
+        self.awareness_state
+            .update_with_clients(self.summary.all_changes())
+            .ok()
+    }
+
+    /// Returns an awareness state object, which contains the full state of all clients.
+    pub fn awareness_state(&self) -> &AwarenessState {
+        &self.awareness_state
+    }
+
+    /// Returns an underlying awareness [Doc] instance.
+    pub fn doc(&self) -> &Doc {
+        &self.doc
     }
 
     /// Collection of new clients that have been added to an [Awareness] struct, that was not known
     /// before. Actual client state can be accessed via `awareness.clients().get(client_id)`.
     pub fn added(&self) -> &[ClientID] {
-        &self.added
+        &self.summary.added
     }
 
     /// Collection of new clients that have been updated within an [Awareness] struct since the last
     /// update. Actual client state can be accessed via `awareness.clients().get(client_id)`.
     pub fn updated(&self) -> &[ClientID] {
-        &self.updated
+        &self.summary.updated
     }
 
     /// Collection of new clients that have been removed from [Awareness] struct since the last
     /// update.
     pub fn removed(&self) -> &[ClientID] {
-        &self.removed
+        &self.summary.removed
+    }
+
+    /// Returns all the changed client IDs (added, updated and removed) combined.
+    pub fn all_changes(&self) -> Vec<ClientID> {
+        self.summary.all_changes()
     }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::sync::awareness::{AwarenessUpdateEntry, AwarenessUpdateSummary, Event};
-    use crate::sync::{Awareness, AwarenessUpdate};
-    use crate::Doc;
-    use std::collections::HashMap;
     use std::sync::mpsc::{channel, Receiver};
+
+    use crate::sync::awareness::{AwarenessUpdateSummary, Event};
+    use crate::sync::Awareness;
+    use crate::Doc;
 
     #[test]
     fn awareness() -> Result<(), Box<dyn std::error::Error>> {
@@ -488,38 +559,33 @@ mod test {
         local.set_local_state("{x:3}");
         let _e_local = update(&mut o_local, &local, &mut remote)?;
         assert_eq!(remote.clients()[&1], "{x:3}");
-        assert_eq!(remote.meta[&1].clock, 1);
-        assert_eq!(o_remote.try_recv()?.added, &[1]);
+        assert_eq!(remote.state().meta[&1].clock, 1);
+        assert_eq!(o_remote.try_recv()?.added(), &[1]);
 
         local.set_local_state("{x:4}");
         let e_local = update(&mut o_local, &local, &mut remote)?;
         let e_remote = o_remote.try_recv()?;
         assert_eq!(remote.clients()[&1], "{x:4}");
         assert_eq!(
-            e_remote,
-            Event::new(
-                vec![],
-                vec![1],
-                vec![],
-                Some(AwarenessUpdate {
-                    clients: HashMap::from([(
-                        1,
-                        AwarenessUpdateEntry {
-                            clock: 2,
-                            json: "{x:4}".to_string(),
-                        }
-                    )])
-                })
-            )
+            e_remote.summary,
+            AwarenessUpdateSummary {
+                added: vec![],
+                updated: vec![1],
+                removed: vec![]
+            }
         );
-        assert_eq!(e_remote, e_local);
+        assert_eq!(e_remote.summary, e_local.summary);
 
         local.clean_local_state();
         let e_local = update(&mut o_local, &local, &mut remote)?;
         let e_remote = o_remote.try_recv()?;
-        assert_eq!(e_remote.removed.len(), 1);
+        assert_eq!(e_remote.removed().len(), 1);
         assert_eq!(local.clients().get(&1), None);
         assert_eq!(e_remote, e_local);
+        assert_eq!(
+            e_remote.awareness_state().update().unwrap(),
+            e_local.awareness_state().update().unwrap()
+        );
         Ok(())
     }
 
@@ -532,7 +598,7 @@ mod test {
         let update = local.update_with_clients([local.client_id()])?;
         let summary = remote.apply_update_summary(update)?;
         assert_eq!(remote.clients()[&1], "{x:3}");
-        assert_eq!(remote.meta[&1].clock, 1);
+        assert_eq!(remote.state().meta[&1].clock, 1);
         assert_eq!(
             summary,
             Some(AwarenessUpdateSummary {
@@ -554,7 +620,7 @@ mod test {
                 removed: vec![]
             })
         );
-        assert_eq!(local.states, remote.states);
+        assert_eq!(local.state().states, remote.state().states);
 
         local.clean_local_state();
         let update = local.update_with_clients([local.client_id()])?;
@@ -568,7 +634,7 @@ mod test {
             })
         );
         assert_eq!(local.clients().get(&1), None);
-        assert_eq!(local.states, remote.states);
+        assert_eq!(local.state().states, remote.state().states);
         Ok(())
     }
 }


### PR DESCRIPTION
Since v0.18 `Awareness` is no longer provided as part of the `Awareness::on_update` callback. Quite often however we want to have an access to its internal functions: ability to serialise on_update changes, full awareness state, introspection of specific clients etc.

This PR adds more of these capabilities into awareness `Event` object.