### PR TITLE
Compiled out time from the awareness MetaClientState

### DIFF
--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -469,11 +469,7 @@ impl AwarenessState {
         match self.meta.entry(client_id) {
             Entry::Occupied(mut e) => {
                 let clock = e.get().clock + 1;
-                let meta = if cfg!(all(target_arch = "wasm32", target_os = "unknown")) {
-                    MetaClientState::new(clock)
-                } else {
-                    MetaClientState::new(clock)
-                };
+                let meta = MetaClientState::new(clock);
                 e.insert(meta);
             }
             Entry::Vacant(e) => {


### PR DESCRIPTION
Fixes #442. I'm not sure if this is an appropriate fix, but the alternative seemed to be to change the signature or to add a dependency on something like web_time which would drag in js_sys and so on. 