### PR TITLE
rlib crate type for yffi

### DIFF
--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -15,5 +15,5 @@ description = "Bindings for the Yrs native C foreign function interface"
 yrs = { path = "../yrs", version = "0.18.8", features = ["weak"] }
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["rlib", "staticlib", "cdylib"]
 name = "yrs"


### PR DESCRIPTION
Hi guys!

This PR allows `yffi` to be built as a Rust library.

Linking several Rust-produced static libs to a single executable is problematic, so it has to be done via an umbrella crate that reexports the APIs and is linked as a big single static lib. Enabling `rlib` for `yffi` allows to do just that.

This PR should not affect any other functionality.

