### PR TITLE
ywasm: awareness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "flate2",
  "proptest",
  "proptest-derive",
+ "rand",
  "ropey",
  "serde",
  "serde_json",

--- a/tests-wasm/awareness.tests.js
+++ b/tests-wasm/awareness.tests.js
@@ -1,0 +1,49 @@
+import * as Y from 'ywasm'
+import * as t from 'lib0/testing'
+
+/**
+ * @param {t.TestCase} tc
+ */
+const testAwareness = tc => {
+    const doc1 = new Y.YDoc({clientID: 0})
+    const doc2 = new Y.YDoc({clientID: 1})
+    const aw1 = new Y.Awareness(doc1)
+    const aw2 = new Y.Awareness(doc2)
+    aw1.onUpdate(/** @param {any} p */({added, updated, removed}) => {
+        const enc = Y.encodeAwarenessUpdate(aw1, added.concat(updated).concat(removed))
+        Y.applyAwarenessUpdate(aw2, enc, 'custom')
+    })
+    let lastChangeLocal = /** @type {any} */ (null)
+    aw1.onUpdate(change => {
+        lastChangeLocal = change
+    })
+    let lastChange = /** @type {any} */ (null)
+    aw2.onUpdate(change => {
+        lastChange = change
+    })
+    aw1.setLocalState({x: 3})
+    t.compare(aw2.getStates().get(0), {x: 3})
+    t.assert(/** @type {any} */ (aw2.meta.get(0)).clock === 1)
+    t.compare(lastChange.added, [0])
+    // When creating an Awareness instance, the the local client is already marked as available, so it is not updated.
+    t.compare(lastChangeLocal, {added: [], updated: [0], removed: []})
+
+    // update state
+    lastChange = null
+    lastChangeLocal = null
+    aw1.setLocalState({x: 4})
+    t.compare(aw2.getStates().get(0), {x: 4})
+    t.compare(lastChangeLocal, {added: [], updated: [0], removed: []})
+    t.compare(lastChangeLocal, lastChange)
+
+    lastChange = null
+    lastChangeLocal = null
+    aw1.setLocalState({x: 4})
+    t.assert(lastChange === null)
+    t.assert(/** @type {any} */ (aw2.meta.get(0)).clock === 3)
+    t.compare(lastChangeLocal, lastChange)
+    aw1.setLocalState(null)
+    t.assert(lastChange.removed.length === 1)
+    t.compare(aw1.getStates().get(0), undefined)
+    t.compare(lastChangeLocal, lastChange)
+}

--- a/tests-wasm/index.js
+++ b/tests-wasm/index.js
@@ -6,6 +6,7 @@ import * as weak from './y-weak-link.tests.js'
 import * as doc from './y-doc.tests.js'
 import * as undo from './y-undo.tests.js'
 import * as stickyIndex from './sticky-index.tests.js'
+import * as awareness from './awareness.tests.js'
 import * as editingTraces from './editing-traces.tests.js'
 
 import {runTests} from 'lib0/testing'
@@ -18,7 +19,7 @@ if (isBrowser) {
     log.createVConsole(document.body)
 }
 runTests({
-    array, text, map, xml, weak, doc, undo, stickyIndex, editingTraces
+    array, text, map, xml, weak, doc, undo, stickyIndex, awareness, editingTraces
 }).then(success => {
     /* istanbul ignore next */
     if (isNode) {

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -29,6 +29,7 @@ flate2 = { version = "1", features = ["zlib-ng-compat"], default-features = fals
 ropey = "1.6.0"
 proptest = "1.2"
 proptest-derive = "0.4.0"
+rand = "0.8.5"
 
 [[bench]]
 name = "benches"

--- a/yrs/benches/benches.rs
+++ b/yrs/benches/benches.rs
@@ -37,7 +37,11 @@ fn b1_1<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
 }
 
 fn b1_2<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
-    let s: String = rng.sample_iter(&Alphanumeric).take(size as usize).collect();
+    let s: String = rng
+        .sample_iter(&Alphanumeric)
+        .take(size)
+        .map(|c| c as char)
+        .collect();
     vec![TextOp::Insert(0, s)]
 }
 
@@ -66,15 +70,18 @@ fn b1_4<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
         .into_iter()
         .zip(sample)
         .map(|(i, str)| {
-            let idx = rng.gen_range(0, i.max(1));
+            let idx = rng.gen_range(0..i.max(1));
             TextOp::Insert(idx, str)
         })
         .collect()
 }
 
 fn gen_string<R: RngCore>(rng: &mut R, min: usize, max: usize) -> String {
-    let len = rng.gen_range(min, max);
-    rng.sample_iter(&Alphanumeric).take(len).collect()
+    let len = rng.gen_range(min..max);
+    rng.sample_iter(&Alphanumeric)
+        .take(len)
+        .map(|x| x as char)
+        .collect()
 }
 
 fn b1_5<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
@@ -82,14 +89,18 @@ fn b1_5<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
         .into_iter()
         .map(|i| {
             let str = gen_string(rng, 2, 10);
-            let idx = rng.gen_range(0, i.max(1));
+            let idx = rng.gen_range(0..i.max(1));
             TextOp::Insert(idx, str)
         })
         .collect()
 }
 
 fn b1_6<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
-    let s: String = rng.sample_iter(&Alphanumeric).take(size as usize).collect();
+    let s: String = rng
+        .sample_iter(&Alphanumeric)
+        .take(size)
+        .map(|x| x as char)
+        .collect();
     let len = s.len() as u32;
     vec![TextOp::Insert(0, s), TextOp::Delete(0, len)]
 }
@@ -103,18 +114,21 @@ fn b1_7<R: RngCore>(rng: &mut R, size: usize) -> Vec<TextOp> {
             let idx = if total == 0 {
                 0
             } else {
-                rng.gen_range(0, total)
+                rng.gen_range(0..total)
             };
             if total == idx || rng.gen_bool(0.5) {
                 let str = {
-                    let len = rng.gen_range(2, 10);
+                    let len = rng.gen_range(2..10);
                     total_len.set(total + len);
-                    rng.sample_iter(&Alphanumeric).take(len as usize).collect()
+                    rng.sample_iter(&Alphanumeric)
+                        .take(len as usize)
+                        .map(|x| x as char)
+                        .collect()
                 };
                 TextOp::Insert(idx, str)
             } else {
                 let hi = (total - idx).min(9);
-                let len = if hi == 1 { 1 } else { rng.gen_range(1, hi) };
+                let len = if hi == 1 { 1 } else { rng.gen_range(1..hi) };
                 total_len.set(total - len);
                 TextOp::Delete(idx, len)
             }
@@ -143,7 +157,7 @@ fn b1_10<R: RngCore>(rng: &mut R, size: usize) -> Vec<ArrayOp> {
 fn b1_11<R: RngCore>(rng: &mut R, size: usize) -> Vec<ArrayOp> {
     (0..size)
         .map(|i| {
-            let idx = rng.gen_range(0, (i as u32).max(1));
+            let idx = rng.gen_range(0..(i as u32).max(1));
             let values = vec![rng.gen()];
             ArrayOp::Insert(idx, values)
         })
@@ -256,8 +270,16 @@ where
 }
 
 fn b2_1<R: RngCore>(rng: &mut R, size: usize) -> Vec<(TextOp, TextOp)> {
-    let s1 = rng.sample_iter(&Alphanumeric).take(size as usize).collect();
-    let s2 = rng.sample_iter(&Alphanumeric).take(size as usize).collect();
+    let s1 = rng
+        .sample_iter(&Alphanumeric)
+        .take(size)
+        .map(|x| x as char)
+        .collect();
+    let s2 = rng
+        .sample_iter(&Alphanumeric)
+        .take(size)
+        .map(|x| x as char)
+        .collect();
     let a = TextOp::Insert(0, s1);
     let b = TextOp::Insert(0, s2);
     vec![(a, b)]
@@ -267,11 +289,11 @@ fn b2_2<R: RngCore>(rng: &mut R, size: usize) -> Vec<(TextOp, TextOp)> {
     (0..size as u32)
         .into_iter()
         .map(|i| {
-            let ca: char = rng.sample_iter(&Alphanumeric).next().unwrap();
-            let ia = rng.gen_range(0, i.max(1));
+            let ca: char = rng.sample_iter(&Alphanumeric).next().unwrap() as char;
+            let ia = rng.gen_range(0..i.max(1));
 
-            let cb: char = rng.sample_iter(&Alphanumeric).next().unwrap();
-            let ib = rng.gen_range(0, i.max(1));
+            let cb: char = rng.sample_iter(&Alphanumeric).next().unwrap() as char;
+            let ib = rng.gen_range(0..i.max(1));
 
             (
                 TextOp::Insert(ia, ca.to_string()),
@@ -288,12 +310,12 @@ fn b2_3<R: RngCore>(rng: &mut R, size: usize) -> Vec<(TextOp, TextOp)> {
         .into_iter()
         .map(|_| {
             let t1 = total_len1.get();
-            let i1 = rng.gen_range(0, t1.max(1));
+            let i1 = rng.gen_range(0..t1.max(1));
             let s1 = gen_string(rng, 3, 9);
             total_len1.set(t1 + s1.len() as u32);
 
             let t2 = total_len2.get();
-            let i2 = rng.gen_range(0, t2.max(1));
+            let i2 = rng.gen_range(0..t2.max(1));
             let s2 = gen_string(rng, 3, 9);
             total_len2.set(t2 + s2.len() as u32);
 
@@ -308,14 +330,14 @@ fn b2_4<R: RngCore>(rng: &mut R, size: usize) -> Vec<(TextOp, TextOp)> {
 
     fn make_op<R: RngCore>(rng: &mut R, total: &mut Cell<u32>) -> TextOp {
         let t = total.get();
-        let idx = rng.gen_range(0, t.max(1));
+        let idx = rng.gen_range(0..t.max(1));
         if t == idx || rng.gen_bool(0.5) {
             let str = gen_string(rng, 3, 9);
             total.set(t + str.len() as u32);
             TextOp::Insert(idx, str)
         } else {
             let hi = (t - idx).min(9);
-            let len = if hi == 1 { 1 } else { rng.gen_range(1, hi) };
+            let len = if hi == 1 { 1 } else { rng.gen_range(1..hi) };
             total.set(t - len);
             TextOp::Delete(idx, len)
         }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -711,7 +711,7 @@ impl DocAddr {
 
 #[cfg(test)]
 mod test {
-    use crate::block::ItemContent;
+    use crate::block::{Item, ItemContent};
     use crate::test_utils::exchange_updates;
     use crate::transaction::{ReadTxn, TransactionMut};
     use crate::types::ToJson;

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -82,11 +82,17 @@ impl Awareness {
         self.doc.client_id()
     }
 
-    /// Returns a state map of all of the clients tracked by current [Awareness] instance. Those
+    /// Returns a state map of all the clients tracked by current [Awareness] instance. Those
     /// states are identified by their corresponding [ClientID]s. The associated state is
     /// represented and replicated to other clients as a JSON string.
     pub fn clients(&self) -> &HashMap<ClientID, String> {
         &self.state.as_ref().unwrap().states
+    }
+
+    /// Returns a state map of all the clients metadata tracked by current [Awareness] instance.
+    /// That metadata is identified by their corresponding [ClientID]s.
+    pub fn meta(&self) -> &HashMap<ClientID, MetaClientState> {
+        &self.state.as_ref().unwrap().meta
     }
 
     /// Returns a JSON string state representation of a current [Awareness] instance.
@@ -377,7 +383,7 @@ pub enum Error {
     ClientNotFound(ClientID),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MetaClientState {
     pub clock: u32,
     pub last_updated: Timestamp,

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -282,6 +282,7 @@ impl Awareness {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Default for Awareness {
     fn default() -> Self {
         Awareness::new(Doc::new())

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -2,12 +2,13 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::mem::MaybeUninit;
-use std::time::Instant;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::block::ClientID;
+use crate::sync::{Clock, Timestamp};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::{Doc, Observer, Subscription};
@@ -39,11 +40,22 @@ impl Awareness {
     /// Creates a new instance of [Awareness] struct, which operates over a given document.
     /// Awareness instance has full ownership of that document. If necessary it can be accessed
     /// using either [Awareness::doc] or [Awareness::doc_mut] methods.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(doc: Doc) -> Self {
+        Self::with_clock(doc, crate::sync::time::SystemClock)
+    }
+
+    /// Creates a new instance of [Awareness] struct, which operates over a given document.
+    /// Awareness instance has full ownership of that document. If necessary it can be accessed
+    /// using either [Awareness::doc] or [Awareness::doc_mut] methods.
+    pub fn with_clock<C>(doc: Doc, clock: C) -> Self
+    where
+        C: Clock + 'static,
+    {
         Awareness {
             doc,
             on_update: Observer::new(),
-            state: Some(AwarenessState::new()),
+            state: Some(AwarenessState::new(Arc::new(clock))),
         }
     }
 
@@ -184,7 +196,7 @@ impl Awareness {
         update: AwarenessUpdate,
         generate_summary: bool,
     ) -> Result<Option<AwarenessUpdateSummary>, Error> {
-        let now = Instant::now();
+        let now = self.state().clock.now();
 
         let mut added = Vec::new();
         let mut updated = Vec::new();
@@ -278,10 +290,15 @@ impl Default for Awareness {
 
 impl std::fmt::Debug for Awareness {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Awareness")
-            .field("state", &self.state)
-            .field("doc", &self.doc)
-            .finish()
+        let mut s = f.debug_struct("Awareness");
+        s.field("doc", &self.doc);
+
+        if let Some(state) = self.state.as_ref() {
+            s.field("meta", &state.meta);
+            s.field("states", &state.states);
+        }
+
+        s.finish()
     }
 }
 
@@ -362,11 +379,11 @@ pub enum Error {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetaClientState {
     pub clock: u32,
-    pub last_updated: Instant,
+    pub last_updated: Timestamp,
 }
 
 impl MetaClientState {
-    fn new(clock: u32, last_updated: Instant) -> Self {
+    fn new(clock: u32, last_updated: Timestamp) -> Self {
         MetaClientState {
             clock,
             last_updated,
@@ -375,15 +392,17 @@ impl MetaClientState {
 }
 
 /// An [Awareness] client state representation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct AwarenessState {
+    clock: Arc<dyn Clock>,
     states: HashMap<ClientID, String>,
     meta: HashMap<ClientID, MetaClientState>,
 }
 
 impl AwarenessState {
-    fn new() -> Self {
+    fn new(clock: Arc<dyn Clock>) -> Self {
         AwarenessState {
+            clock,
             states: HashMap::new(),
             meta: HashMap::new(),
         }
@@ -461,14 +480,15 @@ impl AwarenessState {
     }
 
     fn update_meta(&mut self, client_id: ClientID) {
+        let now = self.clock.now();
         match self.meta.entry(client_id) {
             Entry::Occupied(mut e) => {
                 let clock = e.get().clock + 1;
-                let meta = MetaClientState::new(clock, Instant::now());
+                let meta = MetaClientState::new(clock, now);
                 e.insert(meta);
             }
             Entry::Vacant(e) => {
-                e.insert(MetaClientState::new(1, Instant::now()));
+                e.insert(MetaClientState::new(1, now));
             }
         }
     }
@@ -489,7 +509,7 @@ impl<'a> Iterator for AwarenessClients<'a> {
 }
 
 /// Event type emitted by an [Awareness] struct.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone)]
 pub struct Event {
     summary: AwarenessUpdateSummary,
     awareness_state: AwarenessState,
@@ -614,7 +634,7 @@ mod test {
         let e_remote = o_remote.try_recv()?;
         assert_eq!(e_remote.removed().len(), 1);
         assert_eq!(local.clients().get(&1), None);
-        assert_eq!(e_remote, e_local);
+        assert_eq!(e_remote.summary, e_local.summary);
         assert_eq!(
             e_remote.awareness_state().full_update().unwrap(),
             e_local.awareness_state().full_update().unwrap()

--- a/yrs/src/sync/mod.rs
+++ b/yrs/src/sync/mod.rs
@@ -1,5 +1,6 @@
 pub mod awareness;
 pub mod protocol;
+pub mod time;
 
 pub use crate::sync::awareness::Awareness;
 pub use crate::sync::awareness::AwarenessUpdate;
@@ -9,3 +10,5 @@ pub use crate::sync::protocol::Message;
 pub use crate::sync::protocol::MessageReader;
 pub use crate::sync::protocol::Protocol;
 pub use crate::sync::protocol::SyncMessage;
+pub use crate::sync::time::Clock;
+pub use crate::sync::time::Timestamp;

--- a/yrs/src/sync/time.rs
+++ b/yrs/src/sync/time.rs
@@ -21,6 +21,7 @@ where
 #[derive(Debug, Copy, Clone, Default)]
 pub struct SystemClock;
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Clock for SystemClock {
     fn now(&self) -> Timestamp {
         std::time::SystemTime::now()

--- a/yrs/src/sync/time.rs
+++ b/yrs/src/sync/time.rs
@@ -1,0 +1,31 @@
+/// Timestamp used by [crate::sync::Awareness] to tag most recent updates.
+pub type Timestamp = u64;
+
+/// A clock trait used to obtain the current time.
+pub trait Clock {
+    fn now(&self) -> Timestamp;
+}
+
+impl<F> Clock for F
+where
+    F: Fn() -> Timestamp,
+{
+    #[inline]
+    fn now(&self) -> Timestamp {
+        self()
+    }
+}
+
+/// A clock which uses standard (non-monotonic) OS date time.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Copy, Clone, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Timestamp {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as Timestamp
+    }
+}

--- a/ywasm/src/awareness.rs
+++ b/ywasm/src/awareness.rs
@@ -1,0 +1,154 @@
+use gloo_utils::format::JsValueSerdeExt;
+use js_sys::Uint8Array;
+use serde::Serialize;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsValue, UnwrapThrowExt};
+
+use yrs::sync::awareness::Event;
+use yrs::sync::{Awareness as AwarenessInner, AwarenessUpdate, Timestamp};
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
+
+use crate::doc::YDoc;
+use crate::Observer;
+
+#[wasm_bindgen]
+pub struct Awareness {
+    inner: AwarenessInner,
+}
+
+#[wasm_bindgen]
+impl Awareness {
+    #[wasm_bindgen(constructor)]
+    pub fn new(doc: YDoc) -> Awareness {
+        let inner = AwarenessInner::with_clock(doc.0.clone(), JsClock);
+        Awareness { inner }
+    }
+
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> YDoc {
+        YDoc(self.inner.doc().clone())
+    }
+
+    #[wasm_bindgen(js_name = destroy)]
+    pub fn destroy(&mut self) {
+        self.inner.clean_local_state();
+    }
+
+    #[wasm_bindgen(js_name = getLocalState)]
+    pub fn local_state(&self) -> crate::Result<JsValue> {
+        match self.inner.local_state() {
+            None => Ok(JsValue::NULL),
+            Some(str) => js_sys::JSON::parse(str),
+        }
+    }
+
+    #[wasm_bindgen(js_name = setLocalState)]
+    pub fn set_local_state(&mut self, state: JsValue) -> crate::Result<()> {
+        if state.is_null() {
+            self.inner.clean_local_state();
+        } else {
+            let state = js_sys::JSON::stringify(&state)?;
+            self.inner.set_local_state(state);
+        }
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = setLocalStateField)]
+    pub fn set_field(&mut self, key: &str, value: JsValue) -> crate::Result<()> {
+        let state = self.local_state()?;
+        js_sys::Reflect::set(&state, &JsValue::from_str(key), &value)?;
+        self.set_local_state(state)
+    }
+
+    #[wasm_bindgen(js_name = getStates)]
+    pub fn states(&self) -> crate::Result<js_sys::Map> {
+        let result = js_sys::Map::new();
+        for (&client_id, state) in self.inner.clients().iter() {
+            let state = js_sys::JSON::parse(&state)?;
+            result.set(&JsValue::from(client_id), &state);
+        }
+        Ok(result)
+    }
+
+    #[wasm_bindgen(js_name = onUpdate)]
+    pub fn on_update(&self, callback: js_sys::Function) -> Observer {
+        #[derive(Serialize)]
+        struct AwarenessEvent {
+            added: Vec<u64>,
+            updated: Vec<u64>,
+            removed: Vec<u64>,
+        }
+
+        impl<'a> From<&'a Event> for AwarenessEvent {
+            fn from(event: &'a Event) -> Self {
+                AwarenessEvent {
+                    added: event.added().iter().copied().collect(),
+                    updated: event.updated().iter().copied().collect(),
+                    removed: event.removed().iter().copied().collect(),
+                }
+            }
+        }
+
+        let sub = self.inner.on_update(move |e| {
+            let event = AwarenessEvent::from(e);
+            let json = JsValue::from_serde(&event).unwrap_throw();
+            callback.call1(&JsValue::NULL, &json).unwrap_throw();
+        });
+        Observer(sub)
+    }
+}
+
+#[wasm_bindgen(js_name = removeAwarenessStates)]
+pub fn remove_states(awareness: &mut Awareness, clients: Vec<u64>) -> crate::Result<()> {
+    for client_id in clients {
+        awareness.inner.remove_state(client_id);
+    }
+    Ok(())
+}
+
+#[wasm_bindgen(js_name = encodeAwarenessUpdate)]
+pub fn encode_update(
+    awareness: &Awareness,
+    clients: Option<Vec<u64>>,
+) -> crate::Result<Uint8Array> {
+    let res = match clients {
+        None => awareness.inner.update(),
+        Some(clients) => awareness.inner.update_with_clients(clients),
+    };
+
+    let update = res.map_err(|e| JsValue::from_str(&e.to_string()))?;
+    let bytes = update.encode_v1();
+    Ok(Uint8Array::from(bytes.as_slice()))
+}
+
+#[wasm_bindgen(js_name = modifyAwarenessUpdate)]
+pub fn modify_update(update: Uint8Array, modify: js_sys::Function) -> crate::Result<Uint8Array> {
+    let mut update = AwarenessUpdate::decode_v1(&update.to_vec())
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    for (client_id, state) in update.clients.iter_mut() {
+        let js = js_sys::JSON::parse(&state.json)?;
+        let new_state = modify.call2(&JsValue::NULL, &js, &JsValue::from(*client_id))?;
+        state.json = js_sys::JSON::stringify(&new_state)?.into();
+    }
+    Ok(Uint8Array::from(update.encode_v1().as_slice()))
+}
+
+#[wasm_bindgen(js_name = applyAwarenessUpdate)]
+pub fn apply_update(awareness: &mut Awareness, update: Uint8Array) -> crate::Result<()> {
+    let update = AwarenessUpdate::decode_v1(&update.to_vec())
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    awareness
+        .inner
+        .apply_update(update)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    Ok(())
+}
+
+struct JsClock;
+
+impl yrs::sync::time::Clock for JsClock {
+    fn now(&self) -> Timestamp {
+        js_sys::Date::now() as u64
+    }
+}

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -9,6 +9,7 @@ use yrs::updates::encoder::{Encode, Encoder};
 use yrs::{Assoc, ReadTxn, StickyIndex, Transact, TransactionMut, Update};
 
 mod array;
+mod awareness;
 mod collection;
 mod doc;
 mod js;


### PR DESCRIPTION
This PR does 2 things:

1. Removes dependency on `std::time` from yrs. Instead it introduces a generic notion of `Clock` and `Timestamp`. This can be used in non-wasm targets as well as for things like mocking time for tests. Related to #442
2. Introduces `Awareness` class and methods in **ywasm** crate. The API is modelled after [y-protocols](https://github.com/yjs/y-protocols/blob/master/awareness.js) Awareness class. It also tests compatibility of yrs::Awareness with wasm-32 target.

TODOs: tests for Awareness.