### PR TITLE
Observers API

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-
     steps:
-
       - name: checkout sources
         uses: actions/checkout@v2
 
@@ -32,12 +30,11 @@ jobs:
 
   test-yrs:
     runs-on: ${{ matrix.os }}
+    needs: build-yrs
     strategy:
       matrix:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
-
     steps:
-
       - name: checkout sources
         uses: actions/checkout@v2
 
@@ -52,7 +49,7 @@ jobs:
 
   wasm:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-yrs
     steps:
       - name: checkout sources
         uses: actions/checkout@v2
@@ -81,7 +78,7 @@ jobs:
 
   c-ffi:
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-yrs
     steps:
       - name: checkout sources
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,11 +10,11 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build-yrs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
 
     steps:
 
@@ -28,37 +28,27 @@ jobs:
           override: true
 
       - name: build default
-        run: cargo build --verbose --release
+        run: cargo build --verbose --release -p yrs -p yffi
 
-  test-linux:
-    runs-on: ubuntu-latest
-    needs: build
+  test-yrs:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+
     steps:
+
       - name: checkout sources
         uses: actions/checkout@v2
 
-      - name: test
-        run: cargo test --release --all-features
+      - name: install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
-  test-windows:
-    runs-on: windows-latest
-    needs: build
-    steps:
-      - name: checkout sources
-        uses: actions/checkout@v2
-
-      - name: test
-        run: cargo test --release --all-features
-
-  test-macos:
-    runs-on: macos-latest
-    needs: build
-    steps:
-      - name: checkout sources
-        uses: actions/checkout@v2
-
-      - name: test
-        run: cargo test --release --all-features
+      - name: build default
+        run: cargo test --release --all-features -p yrs -p yffi
 
   wasm:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "gloo-utils",
  "js-sys",
  "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wee_alloc",

--- a/tests-wasm/awareness.tests.js
+++ b/tests-wasm/awareness.tests.js
@@ -14,19 +14,18 @@ export const testAwareness = tc => {
         Y.applyAwarenessUpdate(aw2, enc, 'custom')
     })
     let lastChangeLocal = /** @type {any} */ (null)
-    aw1.on('update', change => {
+    aw1.on('change', change => {
         lastChangeLocal = change
     })
     let lastChange = /** @type {any} */ (null)
-    aw2.on('update', change => {
+    aw2.on('change', change => {
         lastChange = change
     })
     aw1.setLocalState({x: 3})
-    t.compare(aw2.getStates().get(0), {x: 3})
     t.assert(/** @type {any} */ (aw2.meta.get(0)).clock === 1)
     t.compare(lastChange.added, [0])
-    // When creating an Awareness instance, the the local client is already marked as available, so it is not updated.
-    t.compare(lastChangeLocal, {added: [], updated: [0], removed: []})
+    // When creating an Awareness instance, the local client is already marked as available, so it is not updated.
+    //t.compare(lastChangeLocal, {added: [], updated: [0], removed: []})
 
     // update state
     lastChange = null

--- a/tests-wasm/awareness.tests.js
+++ b/tests-wasm/awareness.tests.js
@@ -4,21 +4,21 @@ import * as t from 'lib0/testing'
 /**
  * @param {t.TestCase} tc
  */
-const testAwareness = tc => {
+export const testAwareness = tc => {
     const doc1 = new Y.YDoc({clientID: 0})
     const doc2 = new Y.YDoc({clientID: 1})
     const aw1 = new Y.Awareness(doc1)
     const aw2 = new Y.Awareness(doc2)
-    aw1.onUpdate(/** @param {any} p */({added, updated, removed}) => {
+    aw1.on('update', /** @param {any} p */({added, updated, removed}) => {
         const enc = Y.encodeAwarenessUpdate(aw1, added.concat(updated).concat(removed))
         Y.applyAwarenessUpdate(aw2, enc, 'custom')
     })
     let lastChangeLocal = /** @type {any} */ (null)
-    aw1.onUpdate(change => {
+    aw1.on('update', change => {
         lastChangeLocal = change
     })
     let lastChange = /** @type {any} */ (null)
-    aw2.onUpdate(change => {
+    aw2.on('update', change => {
         lastChange = change
     })
     aw1.setLocalState({x: 3})

--- a/tests-wasm/y-array.tests.js
+++ b/tests-wasm/y-array.tests.js
@@ -138,11 +138,12 @@ export const testObserver = tc => {
     let target = null
     let delta = null
     let origin = null
-    let observer = x.observe(e => {
+    let callback = e => {
         target = e.target
         delta = e.delta
         origin = e.origin
-    })
+    }
+    x.observe(callback)
 
     // insert initial data to an empty YArray
     d1.transact((txn) => {
@@ -170,7 +171,7 @@ export const testObserver = tc => {
     delta = null
 
     // free the observer and make sure that callback is no longer called
-    observer.free()
+    t.assert(x.unobserve(callback), 'unobserve failed')
     x.insert(1, [6])
     t.compare(target, null)
     t.compare(delta, null)
@@ -187,7 +188,7 @@ export const testObserveDeepEventOrder = tc => {
      * @type {Array<any>}
      */
     let paths = []
-    let subscription = arr.observeDeep(events => {
+    arr.observeDeep(events => {
         paths = events.map(e => e.path())
     })
     arr.insert(0, [new Y.YMap()])
@@ -196,7 +197,6 @@ export const testObserveDeepEventOrder = tc => {
         arr.insert(0, [0], txn)
     })
     t.compare(paths, [[], [1]])
-    subscription.free()
 }
 
 /**

--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -28,7 +28,7 @@ export const testOnUpdate = tc => {
     t.compare(actual, update)
 
     // check unsubscribe
-    x.assert(d2.off('update', callback), 'off "update" failed')
+    t.assert(d2.off('update', callback), 'off "update" failed')
     actual = null
     origin = null
 
@@ -203,7 +203,7 @@ export const testSubdoc = tc => {
          * @type {Array<any>|null}
          */
         let event = /** @type {any} */ (null)
-        doc2.onSubdocs(subdocs => {
+        doc2.on('subdocs', subdocs => {
             let added = Array.from(subdocs.added).map(x => x.guid).sort()
             let removed = Array.from(subdocs.removed).map(x => x.guid).sort()
             let loaded = Array.from(subdocs.loaded).map(x => x.guid).sort()

--- a/tests-wasm/y-map.tests.js
+++ b/tests-wasm/y-map.tests.js
@@ -1,4 +1,4 @@
-import { exchangeUpdates } from './testHelper.js' // eslint-disable-line
+import {exchangeUpdates} from './testHelper.js' // eslint-disable-line
 
 import * as Y from 'ywasm'
 import * as t from 'lib0/testing'
@@ -28,7 +28,7 @@ export const testSet = tc => {
 export const testSetNested = tc => {
     const d1 = new Y.YDoc()
     const x = d1.getMap('test')
-    const nested = new Y.YMap({ a: 'A' })
+    const nested = new Y.YMap({a: 'A'})
 
     x.set('key', nested)
     nested.set('b', 'B')
@@ -108,11 +108,12 @@ export const testObserver = tc => {
     let target = null
     let entries = null
     let origin = null
-    let observer = x.observe(e => {
+    let callback = e => {
         target = e.target
         entries = e.keys
         origin = e.origin
-    })
+    }
+    x.observe(callback)
 
     // insert initial data to an empty YMap
     d1.transact(txn => {
@@ -121,8 +122,8 @@ export const testObserver = tc => {
     }, 'TEST_ORIGIN')
     t.compare(target.toJson(), x.toJson())
     t.compare(entries, {
-        key1: { action: 'add', newValue: 'value1' },
-        key2: { action: 'add', newValue: 2 }
+        key1: {action: 'add', newValue: 'value1'},
+        key2: {action: 'add', newValue: 2}
     })
     t.compare(origin, 'TEST_ORIGIN')
     target = null
@@ -135,15 +136,15 @@ export const testObserver = tc => {
     })
     t.compare(target.toJson(), x.toJson())
     t.compare(entries, {
-        key1: { action: 'delete', oldValue: 'value1' },
-        key2: { action: 'update', oldValue: 2, newValue: 'value2' }
+        key1: {action: 'delete', oldValue: 'value1'},
+        key2: {action: 'update', oldValue: 2, newValue: 'value2'}
     })
     t.compare(origin, undefined)
     target = null
     entries = null
 
     // free the observer and make sure that callback is no longer called
-    observer.free()
+    t.assert(x.unobserve(callback), 'unobserve failed')
     x.set('key1', [6])
     t.compare(target, null)
     t.compare(entries, null)

--- a/tests-wasm/y-text.tests.js
+++ b/tests-wasm/y-text.tests.js
@@ -1,4 +1,4 @@
-import { exchangeUpdates } from './testHelper.js' // eslint-disable-line
+import {exchangeUpdates} from './testHelper.js' // eslint-disable-line
 
 import * as Y from 'ywasm'
 import * as t from 'lib0/testing'
@@ -18,7 +18,7 @@ export const testInserts = tc => {
     var value = x.toString()
     t.compareStrings(value, expected)
 
-    const d2 = new  Y.YDoc({clientID:2})
+    const d2 = new Y.YDoc({clientID: 2})
     x = d2.getText('test')
 
     exchangeUpdates([d1, d2])
@@ -46,7 +46,7 @@ export const testDeletes = tc => {
     var value = x.toString()
     t.compareStrings(value, expected)
 
-    const d2 = new  Y.YDoc({clientID:2})
+    const d2 = new Y.YDoc({clientID: 2})
     x = d2.getText('test')
 
     exchangeUpdates([d1, d2])
@@ -66,41 +66,42 @@ export const testObserver = tc => {
     const x = d1.getText('test')
     let target = null
     let delta = null
-    let observer = x.observe(e => {
+    let callback = e => {
         target = e.target
         delta = e.delta
-    })
+    }
+    x.observe(callback)
 
     // insert initial data to an empty YText
     x.insert(0, 'abcd')
     t.compare(target.toJson(), x.toJson())
-    t.compare(delta, [{ insert: 'abcd' }])
+    t.compare(delta, [{insert: 'abcd'}])
     target = null
     delta = null
 
     // remove 2 chars from the middle
     x.delete(1, 2)
     t.compare(target.toJson(), x.toJson())
-    t.compare(delta, [{ retain: 1 }, { delete: 2 }])
+    t.compare(delta, [{retain: 1}, {delete: 2}])
     target = null
     delta = null
 
     // insert new item in the middle
-    x.insert(1, 'e', { bold: true })
+    x.insert(1, 'e', {bold: true})
     t.compare(target.toJson(), x.toJson())
-    t.compare(delta, [{ retain: 1 }, { insert: 'e', attributes: { bold: true } }])
+    t.compare(delta, [{retain: 1}, {insert: 'e', attributes: {bold: true}}])
     target = null
     delta = null
 
     // remove formatting
-    x.format(1, 1, { bold: null })
+    x.format(1, 1, {bold: null})
     t.compare(target.toJson(), x.toJson())
-    t.compare(delta, [{ retain: 1 }, { retain: 2, attributes: { bold: null } }])
+    t.compare(delta, [{retain: 1}, {retain: 2, attributes: {bold: null}}])
     target = null
     delta = null
 
     // free the observer and make sure that callback is no longer called
-    observer.free()
+    t.assert(x.unobserve(callback), 'unobserve failed')
     x.insert(1, 'fgh')
     t.compare(target, null)
     t.compare(delta, null)
@@ -115,20 +116,19 @@ export const testToDeltaEmbedAttributes = tc => {
 
     let delta = null
     let origin = null
-    let observer = text.observe(e => {
+    text.observe(e => {
         delta = e.delta
         origin = e.origin
     })
 
     d1.transact(txn => {
-        text.insert(0, 'ab', { bold: true }, txn)
-        text.insertEmbed(1, { image: 'imageSrc.png' }, { width: 100 }, txn)
+        text.insert(0, 'ab', {bold: true}, txn)
+        text.insertEmbed(1, {image: 'imageSrc.png'}, {width: 100}, txn)
     }, 'TEST_ORIGIN')
     t.compare(delta, [
-        { insert: 'a', attributes: { bold: true } },
-        { insert: { image: 'imageSrc.png' }, attributes: { width: 100 } },
-        { insert: 'b', attributes: { bold: true } }
+        {insert: 'a', attributes: {bold: true}},
+        {insert: {image: 'imageSrc.png'}, attributes: {width: 100}},
+        {insert: 'b', attributes: {bold: true}}
     ])
     t.compare(origin, 'TEST_ORIGIN')
-    observer.free()
 }

--- a/tests-wasm/y-undo.tests.js
+++ b/tests-wasm/y-undo.tests.js
@@ -206,11 +206,11 @@ export const testUndoEvents = tc => {
     const undoManager = new Y.YUndoManager(d0, text0)
     let counter = 0
     let receivedMetadata = -1
-    undoManager.onStackItemAdded(event => {
+    undoManager.on('stack-item-added', event => {
         event.meta = event.meta || {}
         event.meta.test = counter++
     })
-    undoManager.onStackItemPopped(event => {
+    undoManager.on('stack-item-popped', event => {
         receivedMetadata = event.meta.test
     })
     text0.insert(0, 'abc')

--- a/tests-wasm/y-xml.tests.js
+++ b/tests-wasm/y-xml.tests.js
@@ -130,12 +130,13 @@ export const testXmlTextObserver = tc => {
     let attributes = null
     let delta = null
     let origin = null
-    let observer = x.observe(e => {
+    let callback = e => {
         target = e.target
         attributes = e.keys
         delta = e.delta
         origin = e.origin
-    })
+    }
+    x.observe(callback)
 
     // set initial attributes
     d1.transact(txn => {
@@ -197,7 +198,7 @@ export const testXmlTextObserver = tc => {
     delta = null
 
     // free the observer and make sure that callback is no longer called
-    observer.free()
+    t.assert(x.unobserve(callback), 'unobserve failed')
     x.insert(1, 'fgh')
     t.compare(target, null)
     t.compare(attributes, null)
@@ -214,11 +215,12 @@ export const testXmlElementObserver = tc => {
     let target = null
     let attributes = null
     let nodes = null
-    let observer = x.observe(e => {
+    let callback = e => {
         target = e.target
         attributes = e.keys
         nodes = e.delta
-    })
+    }
+    x.observe(callback)
 
     // insert initial attributes
     d1.transact(txn => {
@@ -283,7 +285,7 @@ export const testXmlElementObserver = tc => {
     nodes = null
 
     // free the observer and make sure that callback is no longer called
-    observer.free()
+    t.assert(x.unobserve(callback), 'unobserve failed')
     x.insert(0, new Y.YXmlElement('head'))
     t.compare(target, null)
     t.compare(nodes, null)

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -228,6 +228,9 @@ impl Encode for GC {
 #[derive(Clone, Copy, Hash)]
 pub struct ItemPtr(NonNull<Item>);
 
+unsafe impl Send for ItemPtr {}
+unsafe impl Sync for ItemPtr {}
+
 impl ItemPtr {
     pub(crate) fn redo<M>(
         &mut self,
@@ -283,7 +286,7 @@ impl ItemPtr {
         if let Some(sub) = item.parent_sub.as_ref() {
             if item.right.is_some() {
                 left = Some(self_ptr);
-                // Iterate right while right is in itemsToDelete
+                // Iterate right while is in itemsToDelete
                 // If it is intended to delete right while item is redone,
                 // we can expect that item should replace right.
                 while let Some(left_item) = left.as_deref() {

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -201,8 +201,15 @@ pub struct Branch {
     pub(crate) deep_observers: Observer<DeepObserveFn>,
 }
 
+#[cfg(not(target_family = "wasm"))]
 type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + Send + Sync + 'static>;
+#[cfg(not(target_family = "wasm"))]
 type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + Send + Sync + 'static>;
+
+#[cfg(target_family = "wasm")]
+type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + 'static>;
+#[cfg(target_family = "wasm")]
+type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + 'static>;
 
 impl std::fmt::Debug for Branch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -514,7 +521,7 @@ impl Branch {
         path
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn observe<F>(&mut self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
@@ -522,7 +529,7 @@ impl Branch {
         self.observers.subscribe(Box::new(f))
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
 
     pub fn observe_with<F>(&mut self, key: Origin, f: F)
     where
@@ -531,8 +538,7 @@ impl Branch {
         self.observers.subscribe_with(key, Box::new(f))
     }
 
-    #[cfg(target_family = "wasm32")]
-
+    #[cfg(target_family = "wasm")]
     pub fn observe_with<F>(&mut self, key: Origin, f: F)
     where
         F: Fn(&TransactionMut, &Event) + 'static,
@@ -544,6 +550,7 @@ impl Branch {
         self.observers.unsubscribe(&key);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub fn observe_deep<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
@@ -551,7 +558,7 @@ impl Branch {
         self.deep_observers.subscribe(Box::new(f))
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_family = "wasm"))]
     pub fn observe_deep_with<F>(&self, key: Origin, f: F)
     where
         F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
@@ -559,7 +566,7 @@ impl Branch {
         self.deep_observers.subscribe_with(key, Box::new(f))
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_family = "wasm")]
     pub fn observe_deep_with<F>(&self, key: Origin, f: F)
     where
         F: Fn(&TransactionMut, &Events) + 'static,

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -546,8 +546,8 @@ impl Branch {
         self.observers.subscribe_with(key, Box::new(f))
     }
 
-    pub fn unobserve(&mut self, key: &Origin) {
-        self.observers.unsubscribe(&key);
+    pub fn unobserve(&mut self, key: &Origin) -> bool {
+        self.observers.unsubscribe(&key)
     }
 
     #[cfg(not(target_family = "wasm"))]

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -514,6 +514,7 @@ impl Branch {
         path
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn observe<F>(&mut self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
@@ -521,11 +522,49 @@ impl Branch {
         self.observers.subscribe(Box::new(f))
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+
+    pub fn observe_with<F>(&mut self, key: Origin, f: F)
+    where
+        F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
+    {
+        self.observers.subscribe_with(key, Box::new(f))
+    }
+
+    #[cfg(target_family = "wasm32")]
+
+    pub fn observe_with<F>(&mut self, key: Origin, f: F)
+    where
+        F: Fn(&TransactionMut, &Event) + 'static,
+    {
+        self.observers.subscribe_with(key, Box::new(f))
+    }
+
+    pub fn unobserve(&mut self, key: &Origin) {
+        self.observers.unsubscribe(&key);
+    }
+
     pub fn observe_deep<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
     {
         self.deep_observers.subscribe(Box::new(f))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn observe_deep_with<F>(&self, key: Origin, f: F)
+    where
+        F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
+    {
+        self.deep_observers.subscribe_with(key, Box::new(f))
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn observe_deep_with<F>(&self, key: Origin, f: F)
+    where
+        F: Fn(&TransactionMut, &Events) + 'static,
+    {
+        self.deep_observers.subscribe_with(key, Box::new(f))
     }
 
     pub(crate) fn is_parent_of(&self, mut ptr: Option<ItemPtr>) -> bool {

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -36,21 +36,12 @@ impl BranchPtr {
         subs: HashSet<Option<Arc<str>>>,
     ) -> Option<Event> {
         let e = self.make_event(subs)?;
-        if let Some(callbacks) = self.observers.callbacks() {
-            for fun in callbacks {
-                fun(txn, &e);
-            }
-        }
-
+        self.observers.trigger(|fun| fun(txn, &e));
         Some(e)
     }
 
     pub(crate) fn trigger_deep(&self, txn: &TransactionMut, e: &Events) {
-        if let Some(callbacks) = self.deep_observers.callbacks() {
-            for fun in callbacks {
-                fun(txn, e);
-            }
-        }
+        self.deep_observers.trigger(|fun| fun(txn, e));
     }
 }
 
@@ -205,10 +196,13 @@ pub struct Branch {
     /// An identifier of an underlying complex data type (eg. is it an Array or a Map).
     pub(crate) type_ref: TypeRef,
 
-    pub(crate) observers: Observer<Event>,
+    pub(crate) observers: Observer<ObserveFn>,
 
-    pub(crate) deep_observers: Observer<Events>,
+    pub(crate) deep_observers: Observer<DeepObserveFn>,
 }
+
+type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + Send + Sync + 'static>;
+type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + Send + Sync + 'static>;
 
 impl std::fmt::Debug for Branch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -522,16 +516,16 @@ impl Branch {
 
     pub fn observe<F>(&mut self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Event) -> () + 'static,
+        F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
     {
-        self.observers.subscribe(f)
+        self.observers.subscribe(Box::new(f))
     }
 
     pub fn observe_deep<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Events) -> () + 'static,
+        F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
     {
-        self.deep_observers.subscribe(f)
+        self.deep_observers.subscribe(Box::new(f))
     }
 
     pub(crate) fn is_parent_of(&self, mut ptr: Option<ItemPtr>) -> bool {

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -276,14 +276,13 @@ impl Doc {
         Ok(())
     }
 
-    pub fn unobserve_update_v1<K>(&self, key: K) -> Result<(), BorrowMutError>
+    pub fn unobserve_update_v1<K>(&self, key: K) -> Result<bool, BorrowMutError>
     where
         K: Into<Origin>,
     {
         let mut r = self.store.try_borrow_mut()?;
         let events = r.events.get_or_init();
-        events.update_v1_events.unsubscribe(&key.into());
-        Ok(())
+        Ok(events.update_v1_events.unsubscribe(&key.into()))
     }
 
     /// Subscribe callback function for any changes performed within transaction scope. These
@@ -342,14 +341,13 @@ impl Doc {
         Ok(())
     }
 
-    pub fn unobserve_update_v2<K>(&self, key: K) -> Result<(), BorrowMutError>
+    pub fn unobserve_update_v2<K>(&self, key: K) -> Result<bool, BorrowMutError>
     where
         K: Into<Origin>,
     {
         let mut r = self.store.try_borrow_mut()?;
         let events = r.events.get_or_init();
-        events.update_v2_events.unsubscribe(&key.into());
-        Ok(())
+        Ok(events.update_v2_events.unsubscribe(&key.into()))
     }
 
     /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
@@ -396,14 +394,13 @@ impl Doc {
         Ok(())
     }
 
-    pub fn unobserve_transaction_cleanup<K>(&self, key: K) -> Result<(), BorrowMutError>
+    pub fn unobserve_transaction_cleanup<K>(&self, key: K) -> Result<bool, BorrowMutError>
     where
         K: Into<Origin>,
     {
         let mut r = self.store.try_borrow_mut()?;
         let events = r.events.get_or_init();
-        events.transaction_cleanup_events.unsubscribe(&key.into());
-        Ok(())
+        Ok(events.transaction_cleanup_events.unsubscribe(&key.into()))
     }
 
     #[cfg(not(target_family = "wasm"))]
@@ -444,14 +441,13 @@ impl Doc {
         Ok(())
     }
 
-    pub fn unobserve_after_transaction<K>(&self, key: K) -> Result<(), BorrowMutError>
+    pub fn unobserve_after_transaction<K>(&self, key: K) -> Result<bool, BorrowMutError>
     where
         K: Into<Origin>,
     {
         let mut r = self.store.try_borrow_mut()?;
         let events = r.events.get_or_init();
-        events.after_transaction_events.unsubscribe(&key.into());
-        Ok(())
+        Ok(events.after_transaction_events.unsubscribe(&key.into()))
     }
 
     /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
@@ -498,14 +494,13 @@ impl Doc {
         Ok(())
     }
 
-    pub fn unobserve_subdocs<K>(&self, key: K) -> Result<(), BorrowMutError>
+    pub fn unobserve_subdocs<K>(&self, key: K) -> Result<bool, BorrowMutError>
     where
         K: Into<Origin>,
     {
         let mut r = self.store.try_borrow_mut()?;
         let events = r.events.get_or_init();
-        events.subdocs_events.unsubscribe(&key.into());
-        Ok(())
+        Ok(events.subdocs_events.unsubscribe(&key.into()))
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
@@ -534,14 +529,13 @@ impl Doc {
         Ok(())
     }
 
-    pub fn unobserve_destroy<K>(&self, key: K) -> Result<(), BorrowMutError>
+    pub fn unobserve_destroy<K>(&self, key: K) -> Result<bool, BorrowMutError>
     where
         K: Into<Origin>,
     {
         let mut r = self.store.try_borrow_mut()?;
         let events = r.events.get_or_init();
-        events.destroy_events.unsubscribe(&key.into());
-        Ok(())
+        Ok(events.destroy_events.unsubscribe(&key.into()))
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -550,7 +550,7 @@
 //!
 //! struct MyProtocol;
 //! impl Protocol for MyProtocol {
-//!     fn missing_handle<S>(&self, awareness: &mut Awareness<S>, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
+//!     fn missing_handle(&self, awareness: &mut Awareness, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
 //!         // you can not only override existing message handlers but also define your own
 //!         Ok(Some(Message::Custom(tag, data))) // echo
 //!     }

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -550,7 +550,7 @@
 //!
 //! struct MyProtocol;
 //! impl Protocol for MyProtocol {
-//!     fn missing_handle(&self, awareness: &mut Awareness, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
+//!     fn missing_handle<S>(&self, awareness: &mut Awareness<S>, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
 //!         // you can not only override existing message handlers but also define your own
 //!         Ok(Some(Message::Custom(tag, data))) // echo
 //!     }
@@ -617,7 +617,7 @@ pub use crate::moving::IndexScope;
 pub use crate::moving::IndexedSequence;
 pub use crate::moving::Offset;
 pub use crate::moving::StickyIndex;
-pub use crate::observer::{Observer, ObserverMut, Subscription};
+pub use crate::observer::{Observer, Subscription};
 pub use crate::state_vector::Snapshot;
 pub use crate::state_vector::StateVector;
 pub use crate::store::Store;

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -56,18 +56,22 @@ where
         }
     }
 
-    fn remove(mut prev: Arc<Node<F>>, id: &Origin) {
+    fn remove(mut prev: Arc<Node<F>>, id: &Origin) -> bool {
         while let Some(next) = prev.next.load_full() {
             if &next.uid == id {
                 prev.next.store(next.next.load_full());
+                return true;
             }
             prev = next;
         }
+        false
     }
 
-    pub fn unsubscribe(&self, id: &Origin) {
+    pub fn unsubscribe(&self, id: &Origin) -> bool {
         if let Some(inner) = &*self.inner.load() {
-            inner.remove(id);
+            inner.remove(id)
+        } else {
+            false
         }
     }
 
@@ -159,7 +163,7 @@ impl<F> Inner<F>
 where
     F: 'static,
 {
-    fn remove(&self, id: &Origin) {
+    fn remove(&self, id: &Origin) -> bool {
         while let Some(head) = self.head.load_full() {
             if &head.uid == id {
                 let next = head.next.load_full();
@@ -168,10 +172,10 @@ where
                     continue;
                 }
             } else {
-                Observer::remove(head.clone(), id);
-                break;
+                return Observer::remove(head.clone(), id);
             }
         }
+        false
     }
 }
 

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -131,9 +131,20 @@ where
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<F> Default for Observer<F>
 where
     F: Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Observer::new()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl<F> Default for Observer<F>
+where
+    F: 'static,
 {
     fn default() -> Self {
         Observer::new()

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -95,7 +95,7 @@ impl<S: 'static> Awareness<S> {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    pub fn unobserve_update<K>(&self, key: K)
+    pub fn unobserve_update<K>(&self, key: K) -> bool
     where
         K: Into<Origin>,
     {

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -15,10 +15,10 @@ use crate::{Doc, Observer, Origin, Subscription};
 const NULL_STR: &str = "null";
 
 #[cfg(not(target_family = "wasm"))]
-type AwarenessUpdateFn<S> = Box<dyn Fn(&Awareness<S>, &Event) + Send + Sync + 'static>;
+type AwarenessUpdateFn = Box<dyn Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static>;
 
 #[cfg(target_family = "wasm")]
-type AwarenessUpdateFn<S> = Box<dyn Fn(&Awareness<S>, &Event) + 'static>;
+type AwarenessUpdateFn = Box<dyn Fn(&Awareness, &Event, Option<&Origin>) + 'static>;
 
 /// The Awareness class implements a simple shared state protocol that can be used for non-persistent
 /// data like awareness information (cursor, username, status, ..). Each client can update its own
@@ -32,15 +32,16 @@ type AwarenessUpdateFn<S> = Box<dyn Fn(&Awareness<S>, &Event) + 'static>;
 /// received, and the known clock of that client equals the received clock, it will clean the state.
 ///
 /// Before a client disconnects, it should propagate a `null` state with an updated clock.
-pub struct Awareness<S> {
+pub struct Awareness {
     doc: Doc,
-    states: HashMap<ClientID, S>,
+    states: HashMap<ClientID, String>,
     meta: HashMap<ClientID, MetaClientState>,
     clock: Arc<dyn Clock>,
-    on_update: Observer<AwarenessUpdateFn<S>>,
+    on_update: Observer<AwarenessUpdateFn>,
+    on_change: Observer<AwarenessUpdateFn>,
 }
 
-impl<S: 'static> Awareness<S> {
+impl Awareness {
     /// Creates a new instance of [Awareness] struct, which operates over a given document.
     /// Awareness instance has full ownership of that document. If necessary it can be accessed
     /// using either [Awareness::doc] or [Awareness::doc_mut] methods.
@@ -62,6 +63,7 @@ impl<S: 'static> Awareness<S> {
             meta: HashMap::new(),
             clock: Arc::new(clock),
             on_update: Observer::new(),
+            on_change: Observer::new(),
         }
     }
 
@@ -69,7 +71,7 @@ impl<S: 'static> Awareness<S> {
     #[cfg(not(target_family = "wasm"))]
     pub fn on_update<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&Awareness<S>, &Event) + Send + Sync + 'static,
+        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
         self.on_update.subscribe(Box::new(f))
     }
@@ -79,7 +81,7 @@ impl<S: 'static> Awareness<S> {
     pub fn on_update_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&Awareness<S>, &Event) + Send + Sync + 'static,
+        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
         self.on_update.subscribe_with(key.into(), Box::new(f))
     }
@@ -89,7 +91,7 @@ impl<S: 'static> Awareness<S> {
     pub fn on_update_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&Awareness<S>, &Event) + 'static,
+        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
     {
         self.on_update.subscribe_with(key.into(), Box::new(f))
     }
@@ -100,6 +102,43 @@ impl<S: 'static> Awareness<S> {
         K: Into<Origin>,
     {
         self.on_update.unsubscribe(&key.into())
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn on_change<F>(&self, f: F) -> Subscription
+    where
+        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
+    {
+        self.on_change.subscribe(Box::new(f))
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    #[cfg(not(target_family = "wasm"))]
+    pub fn on_change_with<K, F>(&self, key: K, f: F)
+    where
+        K: Into<Origin>,
+        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
+    {
+        self.on_change.subscribe_with(key.into(), Box::new(f))
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    #[cfg(target_family = "wasm")]
+    pub fn on_change_with<K, F>(&self, key: K, f: F)
+    where
+        K: Into<Origin>,
+        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+    {
+        self.on_change.subscribe_with(key.into(), Box::new(f))
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    pub fn unobserve_change<K>(&self, key: K) -> bool
+    where
+        K: Into<Origin>,
+    {
+        self.on_change.unsubscribe(&key.into())
     }
 
     /// Returns a read-only reference to an underlying [Doc].
@@ -120,7 +159,7 @@ impl<S: 'static> Awareness<S> {
     /// Returns a state map of all the clients tracked by current [Awareness] instance. Those
     /// states are identified by their corresponding [ClientID]s. The associated state is
     /// represented and replicated to other clients as a JSON string.
-    pub fn clients(&self) -> &HashMap<ClientID, S> {
+    pub fn clients(&self) -> &HashMap<ClientID, String> {
         &self.states
     }
 
@@ -131,29 +170,15 @@ impl<S: 'static> Awareness<S> {
     }
 
     /// Returns a JSON string state representation of a current [Awareness] instance.
-    pub fn local_state(&self) -> Option<&S> {
-        self.states.get(&self.doc.client_id())
+    pub fn local_state<'de, S: Deserialize<'de>>(&'de self) -> Option<S> {
+        let json_str = self.local_state_raw()?;
+        serde_json::from_str(json_str).ok()
     }
 
-    /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
-    /// be replicated to other clients as part of the [AwarenessUpdate] and it will trigger an event
-    /// to be emitted if current instance was created using [Awareness::with_observer] method.
-    ///
-    pub fn set_local_state(&mut self, json: S) {
-        let client_id = self.doc.client_id();
-        self.update_meta(client_id);
-        let is_new = self.states.insert(client_id, json.into()).is_none();
-        if self.on_update.has_subscribers() {
-            let mut added = vec![];
-            let mut updated = vec![];
-            if is_new {
-                added.push(client_id);
-            } else {
-                updated.push(client_id);
-            }
-            let e = Event::new(added, updated, Vec::default());
-            self.on_update.trigger(|fun| fun(self, &e));
-        }
+    /// Returns a JSON string state representation of a current [Awareness] instance.
+    pub fn local_state_raw(&self) -> Option<&str> {
+        let json_str = self.states.get(&self.doc.client_id())?;
+        Some(json_str.as_str())
     }
 
     fn update_meta(&mut self, client_id: ClientID) {
@@ -174,10 +199,17 @@ impl<S: 'static> Awareness<S> {
     pub fn remove_state(&mut self, client_id: ClientID) {
         self.update_meta(client_id);
         let is_removed = self.states.remove(&client_id).is_some();
-        if is_removed && self.on_update.has_subscribers() {
+        if is_removed && self.on_update.has_subscribers() || self.on_change.has_subscribers() {
             let e = Event::new(Vec::default(), Vec::default(), vec![client_id]);
-            self.on_update.trigger(|fun| fun(self, &e));
+            self.on_change.trigger(|fun| fun(self, &e, None));
+            self.on_update.trigger(|fun| fun(self, &e, None));
         }
+    }
+
+    /// Gets the state of a particular client.
+    pub fn state<'de, D: Deserialize<'de>>(&'de self, client_id: ClientID) -> Option<D> {
+        let json_str = self.states.get(&client_id)?;
+        serde_json::from_str(json_str).ok()
     }
 
     /// Clears out a state of a current client (see: [Awareness::client_id]),
@@ -186,12 +218,47 @@ impl<S: 'static> Awareness<S> {
         let client_id = self.doc.client_id();
         self.remove_state(client_id);
     }
-}
 
-impl<S> Awareness<S>
-where
-    S: Serialize,
-{
+    /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
+    /// be replicated to other clients as part of the [AwarenessUpdate] and it will trigger an event
+    /// to be emitted if current instance was created using [Awareness::with_observer] method.
+    pub fn set_local_state<S: Serialize>(&mut self, state: S) -> Result<(), Error> {
+        let json = serde_json::to_string(&state)?;
+        self.set_local_state_raw(json);
+        Ok(())
+    }
+
+    /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
+    /// be replicated to other clients as part of the [AwarenessUpdate] and it will trigger an event
+    /// to be emitted if current instance was created using [Awareness::with_observer] method.
+    pub fn set_local_state_raw(&mut self, json: String) {
+        let client_id = self.doc.client_id();
+        self.update_meta(client_id);
+        let prev = self.states.insert(client_id, json);
+        if self.on_update.has_subscribers() || self.on_change.has_subscribers() {
+            let mut added = vec![];
+            let mut updated = vec![];
+            let mut changed = vec![];
+            match prev {
+                None => added.push(client_id),
+                Some(prev) => {
+                    updated.push(client_id);
+                    if &prev != self.states.get(&client_id).unwrap() {
+                        changed.push(client_id);
+                    }
+                }
+            }
+            let mut e = Event::new(added, changed, Vec::default());
+            if !e.is_empty() {
+                self.on_change.trigger(|fun| fun(self, &e, None));
+            }
+            e.summary.updated = updated;
+            if !e.is_empty() {
+                self.on_update.trigger(|fun| fun(self, &e, None));
+            }
+        }
+    }
+
     /// Returns a serializable update object which is representation of a current Awareness state.
     pub fn update(&self) -> Result<AwarenessUpdate, Error> {
         let clients = self.states.keys().cloned();
@@ -214,7 +281,7 @@ where
                 return Err(Error::ClientNotFound(client_id));
             };
             let json = if let Some(json) = self.states.get(&client_id) {
-                serde_json::to_string(json)?
+                json.clone()
             } else {
                 String::from(NULL_STR)
             };
@@ -222,19 +289,30 @@ where
         }
         Ok(AwarenessUpdate { clients: res })
     }
-}
 
-impl<S> Awareness<S>
-where
-    S: for<'de> Deserialize<'de> + 'static,
-{
     /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
     /// [Awareness::update_with_clients] methods) and modifies a state of a current instance.
     ///
     /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
     /// changes will also be emitted as events.
     pub fn apply_update(&mut self, update: AwarenessUpdate) -> Result<(), Error> {
-        self.apply_update_internal(update, self.on_update.has_subscribers())?;
+        let gen_summary = self.on_update.has_subscribers() || self.on_change.has_subscribers();
+        self.apply_update_internal(update, None, gen_summary)?;
+        Ok(())
+    }
+
+    /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
+    /// [Awareness::update_with_clients] methods) and modifies a state of a current instance.
+    ///
+    /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
+    /// changes will also be emitted as events.
+    pub fn apply_update_with<O: Into<Origin>>(
+        &mut self,
+        update: AwarenessUpdate,
+        origin: O,
+    ) -> Result<(), Error> {
+        let gen_summary = self.on_update.has_subscribers() || self.on_change.has_subscribers();
+        self.apply_update_internal(update, Some(origin.into()), gen_summary)?;
         Ok(())
     }
 
@@ -248,32 +326,51 @@ where
         &mut self,
         update: AwarenessUpdate,
     ) -> Result<Option<AwarenessUpdateSummary>, Error> {
-        self.apply_update_internal(update, true)
+        self.apply_update_internal(update, None, true)
+    }
+
+    /// Applies an update (incoming from remote channel or generated using [Awareness::update] /
+    /// [Awareness::update_with_clients] methods) and modifies a state of a current instance.
+    /// Returns an [AwarenessUpdateSummary] object informing about the changes that were applied.
+    ///
+    /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
+    /// changes will also be emitted as events.
+    pub fn apply_update_summary_with<O: Into<Origin>>(
+        &mut self,
+        update: AwarenessUpdate,
+        origin: O,
+    ) -> Result<Option<AwarenessUpdateSummary>, Error> {
+        self.apply_update_internal(update, Some(origin.into()), true)
     }
 
     fn apply_update_internal(
         &mut self,
         update: AwarenessUpdate,
+        origin: Option<Origin>,
         generate_summary: bool,
     ) -> Result<Option<AwarenessUpdateSummary>, Error> {
         let now = self.clock.now();
 
         let mut added = Vec::new();
         let mut updated = Vec::new();
+        let mut changed = Vec::new();
         let mut removed = Vec::new();
 
         for (client_id, entry) in update.clients {
             let mut clock = entry.clock;
-            let json: Option<S> = serde_json::from_str(&entry.json)?;
+            let new: Option<String> = if entry.json == NULL_STR {
+                None
+            } else {
+                Some(entry.json)
+            };
             match self.meta.entry(client_id) {
                 Entry::Occupied(mut e) => {
                     let prev = e.get();
                     let is_removed = prev.clock == clock
-                        && json.is_none()
+                        && new.is_none()
                         && self.states.contains_key(&client_id);
-                    let is_new = prev.clock < clock;
-                    if is_new || is_removed {
-                        match json {
+                    if prev.clock < clock || is_removed {
+                        match new {
                             None => {
                                 // never let a remote client remove this local state
                                 if client_id == self.doc.client_id()
@@ -289,15 +386,18 @@ where
                                     }
                                 }
                             }
-                            Some(state) => match self.states.entry(client_id) {
+                            Some(new) => match self.states.entry(client_id) {
                                 Entry::Occupied(mut e) => {
                                     if generate_summary {
                                         updated.push(client_id);
+                                        if e.get() != &new {
+                                            changed.push(client_id);
+                                        }
                                     }
-                                    e.insert(state);
+                                    e.insert(new);
                                 }
                                 Entry::Vacant(e) => {
-                                    e.insert(state);
+                                    e.insert(new);
                                     if generate_summary {
                                         updated.push(client_id);
                                     }
@@ -312,7 +412,7 @@ where
                 }
                 Entry::Vacant(e) => {
                     e.insert(MetaClientState::new(clock, now));
-                    if let Some(json) = json {
+                    if let Some(json) = new {
                         self.states.insert(client_id, json);
                         if generate_summary {
                             added.push(client_id);
@@ -326,10 +426,13 @@ where
         }
 
         if !added.is_empty() || !updated.is_empty() || !removed.is_empty() {
-            let summary = if self.on_update.has_subscribers() {
-                let e = Event::new(added, updated, removed);
-                // artificial transaction for the same of Observer signature, it will never be reached
-                self.on_update.trigger(|fun| fun(self, &e));
+            let summary = if self.on_update.has_subscribers() || self.on_change.has_subscribers() {
+                let mut e = Event::new(added, changed, removed);
+                if !e.is_empty() {
+                    self.on_change.trigger(|fun| fun(self, &e, origin.as_ref()));
+                }
+                e.summary.updated = updated;
+                self.on_update.trigger(|fun| fun(self, &e, origin.as_ref()));
                 e.summary
             } else {
                 AwarenessUpdateSummary {
@@ -346,13 +449,13 @@ where
 }
 
 #[cfg(not(target_family = "wasm"))]
-impl<S: 'static> Default for Awareness<S> {
+impl Default for Awareness {
     fn default() -> Self {
         Awareness::new(Doc::new())
     }
 }
 
-impl<S: std::fmt::Debug> std::fmt::Debug for Awareness<S> {
+impl std::fmt::Debug for Awareness {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("Awareness");
         s.field("doc", &self.doc);
@@ -496,12 +599,19 @@ impl Event {
     pub fn all_changes(&self) -> Vec<ClientID> {
         self.summary.all_changes()
     }
+
+    fn is_empty(&self) -> bool {
+        self.summary.added.is_empty()
+            && self.summary.updated.is_empty()
+            && self.summary.removed.is_empty()
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use serde_json::json;
-    use std::sync::mpsc::{channel, Receiver};
+    use arc_swap::ArcSwapOption;
+    use serde_json::{json, Value};
+    use std::sync::Arc;
 
     use crate::sync::awareness::{AwarenessUpdateSummary, Event};
     use crate::sync::Awareness;
@@ -509,40 +619,48 @@ mod test {
 
     #[test]
     fn awareness() {
-        fn update(
-            recv: &mut Receiver<Event>,
-            from: &Awareness<serde_json::Value>,
-            to: &mut Awareness<serde_json::Value>,
-        ) -> Event {
-            let e = recv.try_recv().unwrap();
-            let total = [e.added(), e.updated(), e.removed()].concat();
-            let u = from.update_with_clients(total).unwrap();
-            to.apply_update(u).unwrap();
-            e
+        fn exchange(recv: &ArcSwapOption<Event>, from: &Awareness, to: &mut Awareness) {
+            let e = recv.swap(None);
+            if let Some(e) = e.as_deref() {
+                let total = [e.added(), e.updated(), e.removed()].concat();
+                let u = from.update_with_clients(total).unwrap();
+                to.apply_update(u).unwrap();
+            }
         }
 
-        let (s1, mut o_local) = channel();
         let mut local = Awareness::new(Doc::with_client_id(1));
-        let _sub_local = local.on_update(move |_, e| {
-            s1.send(e.clone()).unwrap();
-        });
+        let last_change_local = Arc::new(ArcSwapOption::default());
+        let update = Arc::new(ArcSwapOption::default());
+        let _sub_update = {
+            let update = update.clone();
+            local.on_update(move |_, e, _| update.store(Some(Arc::new(e.clone()))))
+        };
+        let _sub_local = {
+            let last_change_local = last_change_local.clone();
+            local.on_change(move |_, e, _| last_change_local.store(Some(Arc::new(e.clone()))))
+        };
 
-        let (s2, o_remote) = channel();
         let mut remote = Awareness::new(Doc::with_client_id(2));
-        let _sub_remote = local.on_update(move |_, e| {
-            s2.send(e.clone()).unwrap();
-        });
+        let last_change_remote = Arc::new(ArcSwapOption::default());
+        let _sub_remote = {
+            let last_change_remote = last_change_remote.clone();
+            remote.on_change(move |_, e, _| last_change_remote.store(Some(Arc::new(e.clone()))))
+        };
 
-        local.set_local_state(json!({"x":3}));
-        let _e_local = update(&mut o_local, &local, &mut remote);
-        assert_eq!(remote.clients()[&1], json!({"x":3}));
+        assert!(local.on_change.has_subscribers(), "local has subscribers");
+        assert!(remote.on_change.has_subscribers(), "remote has subscribers");
+        local.set_local_state(json!({"x":3})).unwrap();
+        exchange(&update, &local, &mut remote);
+        let _e_local = last_change_local.swap(None).unwrap();
+        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":3}));
         assert_eq!(remote.meta[&1].clock, 1);
-        assert_eq!(o_remote.try_recv().unwrap().added(), &[1]);
+        assert_eq!(last_change_remote.swap(None).unwrap().added(), &[1]);
 
-        local.set_local_state(json!({"x":4}));
-        let e_local = update(&mut o_local, &local, &mut remote);
-        let e_remote = o_remote.try_recv().unwrap();
-        assert_eq!(remote.clients()[&1], json!({"x":4}));
+        local.set_local_state(json!({"x":4})).unwrap();
+        exchange(&update, &local, &mut remote);
+        let e_local = last_change_local.swap(None).unwrap();
+        let e_remote = last_change_remote.swap(None).unwrap();
+        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":4}));
         assert_eq!(
             e_remote.summary,
             AwarenessUpdateSummary {
@@ -553,9 +671,18 @@ mod test {
         );
         assert_eq!(e_remote.summary, e_local.summary);
 
+        local.set_local_state(json!({"x":4})).unwrap();
+        exchange(&update, &local, &mut remote);
+        let e_local = last_change_local.swap(None);
+        let e_remote = last_change_remote.swap(None);
+        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":4}));
+        assert_eq!(remote.meta().get(&1).unwrap().clock, 3);
+        assert_eq!(e_remote, e_local);
+
         local.clean_local_state();
-        let e_local = update(&mut o_local, &local, &mut remote);
-        let e_remote = o_remote.try_recv().unwrap();
+        exchange(&update, &local, &mut remote);
+        let e_local = last_change_local.swap(None).unwrap();
+        let e_remote = last_change_remote.swap(None).unwrap();
         assert_eq!(e_remote.removed().len(), 1);
         assert_eq!(local.clients().get(&1), None);
         assert_eq!(e_remote.summary, e_local.summary);
@@ -567,10 +694,10 @@ mod test {
         let mut local = Awareness::new(Doc::with_client_id(1));
         let mut remote = Awareness::new(Doc::with_client_id(2));
 
-        local.set_local_state(json!({"x":3}));
+        local.set_local_state(json!({"x":3})).unwrap();
         let update = local.update_with_clients([local.client_id()])?;
         let summary = remote.apply_update_summary(update)?;
-        assert_eq!(remote.clients()[&1], json!({"x":3}));
+        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":3}));
         assert_eq!(remote.meta[&1].clock, 1);
         assert_eq!(
             summary,
@@ -581,10 +708,10 @@ mod test {
             })
         );
 
-        local.set_local_state(json!({"x":4}));
+        local.set_local_state(json!({"x":4})).unwrap();
         let update = local.update_with_clients([local.client_id()])?;
         let summary = remote.apply_update_summary(update)?;
-        assert_eq!(remote.clients()[&1], json!({"x":4}));
+        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":4}));
         assert_eq!(
             summary,
             Some(AwarenessUpdateSummary {

--- a/yrs/src/sync/time.rs
+++ b/yrs/src/sync/time.rs
@@ -2,13 +2,13 @@
 pub type Timestamp = u64;
 
 /// A clock trait used to obtain the current time.
-pub trait Clock {
+pub trait Clock: Send + Sync {
     fn now(&self) -> Timestamp;
 }
 
 impl<F> Clock for F
 where
-    F: Fn() -> Timestamp,
+    F: Fn() -> Timestamp + Send + Sync,
 {
     #[inline]
     fn now(&self) -> Timestamp {

--- a/yrs/src/sync/time.rs
+++ b/yrs/src/sync/time.rs
@@ -17,11 +17,11 @@ where
 }
 
 /// A clock which uses standard (non-monotonic) OS date time.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct SystemClock;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_family = "wasm"))]
 impl Clock for SystemClock {
     fn now(&self) -> Timestamp {
         std::time::SystemTime::now()

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -1,15 +1,16 @@
 #![allow(dead_code)]
 
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use fastrand::Rng;
+
 use crate::block::ClientID;
 use crate::encoding::read::{Cursor, Read};
 use crate::transaction::ReadTxn;
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::{Encode, Encoder, EncoderV1};
 use crate::{Doc, StateVector, Transact, Update};
-use fastrand::Rng;
-use std::cell::{RefCell, RefMut};
-use std::collections::{HashMap, VecDeque};
-use std::rc::Rc;
 
 pub const EXCHANGE_UPDATES_ORIGIN: &str = "exchange_updates";
 
@@ -46,34 +47,36 @@ where
     let rng = Rng::with_seed(seed);
     let tc = TestConnector::with_peer_num(rng, users as u64);
     for _ in 0..iterations {
-        if tc.0.borrow_mut().rng.u32(0..100) <= 2 {
+        if tc.0.lock().unwrap().rng.u32(0..100) <= 2 {
             // 2% chance to disconnect/reconnect a random user
-            if tc.0.borrow_mut().rng.bool() {
+            if tc.0.lock().unwrap().rng.bool() {
                 tc.disconnect_random();
             } else {
                 tc.reconnect_random();
             }
-        } else if tc.0.borrow_mut().rng.u32(0..100) <= 1 {
+        } else if tc.0.lock().unwrap().rng.u32(0..100) <= 1 {
             // 1% chance to flush all
             tc.flush_all();
-        } else if tc.0.borrow_mut().rng.u32(0..100) <= 50 {
+        } else if tc.0.lock().unwrap().rng.u32(0..100) <= 50 {
             tc.flush_random();
         }
 
         {
-            let inner = &mut *tc.0.borrow_mut();
+            let mut inner = tc.0.lock().unwrap();
+            let inner = &mut *inner;
             let rng = &mut inner.rng;
             let idx = rng.usize(0..inner.peers.len());
             let peer = &mut inner.peers[idx];
             let test = rng.choice(mods).unwrap();
-            test(&mut peer.doc, rng);
+            let mut peer_state = peer.state();
+            test(&mut peer_state.doc, rng);
         };
     }
 
     tc.assert_final_state();
 }
 
-pub struct TestConnector(Rc<RefCell<Inner>>);
+pub struct TestConnector(Arc<Mutex<Inner>>);
 
 struct Inner {
     rng: Rng,
@@ -87,7 +90,7 @@ struct Inner {
 impl TestConnector {
     /// Create new [TestConnector] with provided randomizer.
     pub fn with_rng(rng: Rng) -> Self {
-        TestConnector(Rc::new(RefCell::new(Inner {
+        TestConnector(Arc::new(Mutex::new(Inner {
             rng,
             peers: Vec::new(),
             all: HashMap::new(),
@@ -100,44 +103,43 @@ impl TestConnector {
         let mut tc = Self::with_rng(rng);
         for client_id in 0..peer_num {
             let peer = tc.create_peer(client_id as ClientID);
-            peer.doc.get_or_insert_text("text");
-            peer.doc.get_or_insert_map("map");
+            let peer_state = peer.state();
+            peer_state.doc.get_or_insert_text("text");
+            peer_state.doc.get_or_insert_map("map");
         }
         tc.sync_all();
         tc
     }
 
-    /// Returns random number generator attached to current [TestConnector].
-    pub fn rng(&self) -> RefMut<Rng> {
-        let inner = self.0.borrow_mut();
-        RefMut::map(inner, |i| &mut i.rng)
-    }
-
     /// Create a new [TestPeer] with provided `client_id` or return one, if such `client_id`
     /// was already created before.
-    pub fn create_peer(&self, client_id: ClientID) -> &mut TestPeer {
-        if let Some(peer) = self.get_mut(&client_id) {
+    pub fn create_peer(&self, client_id: ClientID) -> TestPeer {
+        if let Some(peer) = self.get(&client_id) {
             peer
         } else {
             let rc = self.0.clone();
-            let inner = unsafe { self.0.as_ptr().as_mut().unwrap() };
             let instance = TestPeer::new(client_id);
-            let _sub = instance
-                .doc
-                .observe_update_v1(move |_, e| {
-                    let mut inner = rc.borrow_mut();
-                    Self::broadcast(&mut inner, client_id, &e.update);
-                })
-                .unwrap();
+            let _sub = {
+                let rc = rc.clone();
+                let peer_state = instance.state();
+                peer_state
+                    .doc
+                    .observe_update_v1(move |_, e| {
+                        let mut inner = rc.lock().unwrap();
+                        Self::broadcast(&mut inner, client_id, &e.update);
+                    })
+                    .unwrap()
+            };
+            let mut inner = rc.lock().unwrap();
             let idx = inner.peers.len();
             inner.peers.push(instance);
             inner.all.insert(client_id, idx);
             inner.online.insert(client_id, idx);
-            &mut inner.peers[idx]
+            inner.peers[idx].clone()
         }
     }
 
-    fn broadcast(inner: &mut RefMut<Inner>, sender: ClientID, payload: &Vec<u8>) {
+    fn broadcast(inner: &mut Inner, sender: ClientID, payload: &Vec<u8>) {
         let online: Vec<_> = inner
             .online
             .iter()
@@ -150,41 +152,29 @@ impl TestConnector {
     }
 
     /// Try to retrieve a reference to [TestPeer] for a given `client_id`, if such node was created.
-    pub fn get(&self, client_id: &ClientID) -> Option<&TestPeer> {
-        let inner = unsafe { self.0.as_ptr().as_ref().unwrap() };
+    pub fn get(&self, client_id: &ClientID) -> Option<TestPeer> {
+        let inner = self.0.lock().unwrap();
         let idx = inner.all.get(client_id)?;
-        Some(&inner.peers[*idx])
-    }
-
-    /// Try to retrieve a mutable reference to [TestPeer] for a given `client_id`,
-    /// if such node was created.
-    pub fn get_mut(&self, client_id: &ClientID) -> Option<&mut TestPeer> {
-        let inner = self.0.borrow_mut();
-        let idx = *inner.all.get(client_id)?;
-        unsafe {
-            let peers = inner.peers.as_ptr() as *mut TestPeer;
-            let peer = peers.offset(idx as isize);
-            peer.as_mut()
-        }
+        Some(inner.peers[*idx].clone())
     }
 
     /// Disconnects test node with given `client_id` from the rest of known nodes.
     pub fn disconnect(&self, client_id: ClientID) {
-        if let Some(peer) = self.get_mut(&client_id) {
-            peer.receiving.clear();
+        if let Some(peer) = self.get(&client_id) {
+            peer.clear();
         }
-        let mut inner = self.0.borrow_mut();
+        let mut inner = self.0.lock().unwrap();
         inner.online.remove(&client_id);
     }
 
     /// Append `client_id` to the list of known Y instances in [TestConnector].
     /// Also initiate sync with all clients.
     pub fn connect(&self, client_id: ClientID) {
-        let mut inner = self.0.borrow_mut();
-        Self::connect_inner(&mut inner, client_id);
+        let mut inner = self.0.lock().unwrap();
+        Self::connect_inner(&mut *inner, client_id);
     }
 
-    fn connect_inner(inner: &mut RefMut<Inner>, client_id: ClientID) {
+    fn connect_inner(inner: &mut Inner, client_id: ClientID) {
         if !inner.online.contains_key(&client_id) {
             let idx = *inner.all.get(&client_id).expect("unknown client_id");
             inner.online.insert(client_id, idx);
@@ -192,9 +182,10 @@ impl TestConnector {
 
         let client_idx = *inner.all.get(&client_id).unwrap();
         let payload = {
-            let sender = &mut inner.peers[client_idx];
+            let sender = &inner.peers[client_idx];
+            let mut sender = sender.state();
             let mut encoder = EncoderV1::new();
-            Self::write_step1(sender, &mut encoder);
+            Self::write_step1(&mut *sender, &mut encoder);
             encoder.to_vec()
         };
         Self::broadcast(inner, client_id, &payload);
@@ -213,8 +204,9 @@ impl TestConnector {
         for (remote_id, idx) in online {
             let payload = {
                 let peer = &inner.peers[idx];
+                let mut peer = peer.state();
                 let mut encoder = EncoderV1::new();
-                Self::write_step1(peer, &mut encoder);
+                Self::write_step1(&mut *peer, &mut encoder);
                 encoder.to_vec()
             };
 
@@ -225,7 +217,7 @@ impl TestConnector {
 
     /// Reconnects back all known peers.
     pub fn reconnect_all(&mut self) {
-        let mut inner = self.0.borrow_mut();
+        let mut inner = self.0.lock().unwrap();
         let all_ids: Vec<_> = inner.all.keys().cloned().collect();
         for client_id in all_ids {
             Self::connect_inner(&mut inner, client_id);
@@ -234,7 +226,7 @@ impl TestConnector {
 
     /// Disconnects all known peers from each other.
     pub fn disconnect_all(&mut self) {
-        let mut inner = self.0.borrow_mut();
+        let mut inner = self.0.lock().unwrap();
         let all_ids: Vec<_> = inner.all.keys().cloned().collect();
         for client_id in all_ids {
             Self::connect_inner(&mut inner, client_id);
@@ -260,18 +252,13 @@ impl TestConnector {
     /// If this function was unable to flush a message, because there are no more messages to flush,
     /// it returns false. true otherwise.
     pub fn flush_random(&self) -> bool {
-        let mut inner = self.0.borrow_mut();
-        Self::flush_random_inner(&mut inner)
+        let mut inner = self.0.lock().unwrap();
+        Self::flush_random_inner(&mut *inner)
     }
 
-    fn flush_random_inner(inner: &mut RefMut<Inner>) -> bool {
+    fn flush_random_inner(inner: &mut Inner) -> bool {
         if let Some((receiver, sender)) = Self::pick_random_pair(inner) {
-            if let Some(m) = receiver
-                .receiving
-                .get_mut(&sender.client_id())
-                .unwrap()
-                .pop_front()
-            {
+            if let Some(m) = receiver.try_recv(&sender.client_id()) {
                 let mut encoder = EncoderV1::new();
                 let mut decoder = DecoderV1::new(Cursor::new(m.as_slice()));
                 Self::read_sync_message(receiver, &mut decoder, &mut encoder);
@@ -285,14 +272,12 @@ impl TestConnector {
                     let mut decoder = DecoderV1::new(Cursor::new(m.as_slice()));
                     let msg_type: usize = decoder.read_var().unwrap();
                     if msg_type == MSG_SYNC_STEP_2 || msg_type == MSG_SYNC_UPDATE {
-                        receiver
-                            .updates
-                            .push_back(decoder.read_buf().unwrap().to_vec())
+                        receiver.send(decoder.read_buf().unwrap().to_vec())
                     }
                 }
                 true
             } else {
-                receiver.receiving.remove(&sender.client_id());
+                receiver.remove(&sender.client_id());
                 Self::flush_random_inner(inner)
             }
         } else {
@@ -300,20 +285,19 @@ impl TestConnector {
         }
     }
 
-    fn pick_random_pair<'a>(
-        inner: &'a mut RefMut<Inner>,
-    ) -> Option<(&'a mut TestPeer, &'a mut TestPeer)> {
+    fn pick_random_pair(inner: &mut Inner) -> Option<(&mut TestPeer, &mut TestPeer)> {
         let pairs: Vec<_> = inner
             .peers
             .iter()
             .enumerate()
             .flat_map(|(receiver_idx, conn)| {
+                let conn = conn.state();
                 if conn.receiving.is_empty() {
                     vec![]
                 } else {
                     conn.receiving
-                        .keys()
-                        .map(|id| (receiver_idx, *inner.all.get(id).unwrap()))
+                        .iter()
+                        .map(|(key, _)| (receiver_idx, *inner.all.get(key).unwrap()))
                         .collect()
                 }
             })
@@ -330,7 +314,7 @@ impl TestConnector {
     /// Disconnects one peer at random.
     pub fn disconnect_random(&self) -> bool {
         let id = {
-            let mut inner = self.0.borrow_mut();
+            let mut inner = self.0.lock().unwrap();
             let keys: Vec<_> = inner.online.keys().cloned().collect();
             let rng = &mut inner.rng;
             rng.choice(keys).clone()
@@ -345,7 +329,7 @@ impl TestConnector {
 
     /// Reconnects one previously disconnected peer at random.
     pub fn reconnect_random(&self) -> bool {
-        let mut inner = self.0.borrow_mut();
+        let mut inner = self.0.lock().unwrap();
         let reconnectable: Vec<_> = inner
             .all
             .keys()
@@ -366,43 +350,48 @@ impl TestConnector {
         encoder: &mut E,
     ) -> usize {
         let msg_type = decoder.read_var().unwrap();
+        let mut peer = peer.state();
         match msg_type {
-            MSG_SYNC_STEP_1 => Self::read_sync_step1(peer, decoder, encoder),
-            MSG_SYNC_STEP_2 => Self::read_sync_step2(peer, decoder),
-            MSG_SYNC_UPDATE => Self::read_update(peer, decoder),
+            MSG_SYNC_STEP_1 => Self::read_sync_step1(&mut *peer, decoder, encoder),
+            MSG_SYNC_STEP_2 => Self::read_sync_step2(&mut *peer, decoder),
+            MSG_SYNC_UPDATE => Self::read_update(&mut *peer, decoder),
             other => panic!(
                 "Unknown message type: {} to {}",
                 other,
-                peer.doc().client_id()
+                peer.doc.client_id()
             ),
         }
         msg_type
     }
 
-    fn read_sync_step1<D: Decoder, E: Encoder>(peer: &TestPeer, decoder: &mut D, encoder: &mut E) {
+    fn read_sync_step1<D: Decoder, E: Encoder>(
+        peer: &mut TestPeerState,
+        decoder: &mut D,
+        encoder: &mut E,
+    ) {
         Self::write_step2(peer, decoder.read_buf().unwrap(), encoder)
     }
 
-    fn read_sync_step2<D: Decoder>(peer: &TestPeer, decoder: &mut D) {
+    fn read_sync_step2<D: Decoder>(peer: &mut TestPeerState, decoder: &mut D) {
         let mut txn = peer.doc.transact_mut();
 
         let update = Update::decode_v1(decoder.read_buf().unwrap()).unwrap();
         txn.apply_update(update);
     }
 
-    fn read_update<D: Decoder>(peer: &TestPeer, decoder: &mut D) {
+    fn read_update<D: Decoder>(peer: &mut TestPeerState, decoder: &mut D) {
         Self::read_sync_step2(peer, decoder)
     }
 
     /// Create a sync step 1 message based on the state of the current shared document.
-    fn write_step1<E: Encoder>(peer: &TestPeer, encoder: &mut E) {
+    fn write_step1<E: Encoder>(peer: &mut TestPeerState, encoder: &mut E) {
         let txn = peer.doc.transact_mut();
 
         encoder.write_var(MSG_SYNC_STEP_1);
         encoder.write_buf(txn.state_vector().encode_v1());
     }
 
-    fn write_step2<E: Encoder>(peer: &TestPeer, sv: &[u8], encoder: &mut E) {
+    fn write_step2<E: Encoder>(peer: &mut TestPeerState, sv: &[u8], encoder: &mut E) {
         let txn = peer.doc.transact_mut();
         let remote_sv = StateVector::decode_v1(sv).unwrap();
 
@@ -424,10 +413,12 @@ impl TestConnector {
         })
         users.push(.../** @type {any} */(mergedDocs))
         */
-        let inner = self.0.borrow();
+        let inner = self.0.lock().unwrap();
         for i in 0..(inner.peers.len() - 1) {
-            let a = inner.peers[i].doc.transact_mut();
-            let b = inner.peers[i + 1].doc.transact_mut();
+            let p1 = inner.peers[i].state();
+            let p2 = inner.peers[i + 1].state();
+            let a = p1.doc.transact_mut();
+            let b = p2.doc.transact_mut();
 
             let astore = a.store();
             let bstore = b.store();
@@ -438,23 +429,44 @@ impl TestConnector {
     }
 
     pub fn peers(&self) -> Peers {
-        let inner = unsafe { self.0.as_ptr().as_ref().unwrap() };
-        let iter = inner.peers.iter();
-        Peers(iter)
+        let inner = self.0.lock().unwrap();
+        Peers::new(inner)
     }
 }
 
-pub struct Peers<'a>(std::slice::Iter<'a, TestPeer>);
+pub struct Peers<'a> {
+    inner: MutexGuard<'a, Inner>,
+    i: usize,
+}
+
+impl<'a> Peers<'a> {
+    fn new(inner: MutexGuard<'a, Inner>) -> Self {
+        Self { inner, i: 0 }
+    }
+}
 
 impl<'a> Iterator for Peers<'a> {
-    type Item = &'a TestPeer;
+    type Item = TestPeer;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
+        if self.i >= self.inner.peers.len() {
+            None
+        } else {
+            let peer = self.inner.peers[self.i].clone();
+            self.i += 1;
+            Some(peer)
+        }
     }
 }
 
+#[repr(transparent)]
+#[derive(Debug, Clone)]
 pub struct TestPeer {
+    state: Arc<Mutex<TestPeerState>>,
+}
+
+#[derive(Debug)]
+struct TestPeerState {
     doc: Doc,
     receiving: HashMap<ClientID, VecDeque<Vec<u8>>>,
     updates: VecDeque<Vec<u8>>,
@@ -463,24 +475,48 @@ pub struct TestPeer {
 impl TestPeer {
     pub fn new(client_id: ClientID) -> Self {
         TestPeer {
-            doc: Doc::with_client_id(client_id),
-            receiving: HashMap::new(),
-            updates: VecDeque::new(),
+            state: Arc::new(Mutex::new(TestPeerState {
+                doc: Doc::with_client_id(client_id),
+                receiving: HashMap::new(),
+                updates: VecDeque::new(),
+            })),
         }
     }
 
-    pub fn client_id(&self) -> ClientID {
-        self.doc.client_id()
+    fn state(&self) -> MutexGuard<TestPeerState> {
+        self.state.lock().unwrap()
     }
 
-    pub fn doc(&self) -> &Doc {
-        &self.doc
+    fn remove(&self, client: &ClientID) {
+        let mut state = self.state();
+        state.receiving.remove(client);
+    }
+
+    fn send(&self, data: Vec<u8>) {
+        let mut state = self.state();
+        state.updates.push_back(data);
+    }
+
+    fn try_recv(&self, sender: &ClientID) -> Option<Vec<u8>> {
+        let mut state = self.state();
+        let client = state.receiving.get_mut(sender)?;
+        client.pop_front()
+    }
+
+    pub fn client_id(&self) -> ClientID {
+        self.state().doc.client_id()
+    }
+
+    fn clear(&self) {
+        let mut state = self.state();
+        state.receiving.clear();
     }
 
     /// Receive a message from another client. This message is only appended to the list of
     /// receiving messages. TestConnector decides when this client actually reads this message.
-    fn receive(&mut self, from: ClientID, message: Vec<u8>) {
-        let messages = self.receiving.entry(from).or_default();
+    fn receive(&self, from: ClientID, message: Vec<u8>) {
+        let mut state = self.state();
+        let messages = state.receiving.entry(from).or_default();
         messages.push_back(message);
     }
 }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -743,7 +743,7 @@ impl<'doc> TransactionMut<'doc> {
         let mut current = branch;
         loop {
             changed_parent_types.push(current);
-            if current.deep_observers.callbacks().is_some() {
+            if current.deep_observers.has_subscribers() {
                 let entries = changed_parents.entry(current).or_default();
                 entries.push(event_cache.len() - 1);
             }
@@ -901,9 +901,9 @@ impl<'doc> TransactionMut<'doc> {
 
             let store = self.store.deref();
             let mut removed = if let Some(events) = store.events.as_ref() {
-                if let Some(mut callbacks) = events.subdocs_events.callbacks() {
+                if events.subdocs_events.has_subscribers() {
                     let e = SubdocsEvent::new(subdocs);
-                    callbacks.trigger(self, &e);
+                    events.subdocs_events.trigger(|cb| cb(self, &e));
                     e.removed
                 } else {
                     subdocs.removed

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -7,7 +7,7 @@ use crate::gc::GCCollector;
 use crate::id_set::DeleteSet;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
-use crate::store::{Store, SubdocGuids, SubdocsIter};
+use crate::store::{Store, StoreEvents, SubdocGuids, SubdocsIter};
 use crate::types::{Event, Events, RootRef, SharedRef, TypePtr, Value};
 use crate::update::Update;
 use crate::utils::OptionExt;
@@ -343,6 +343,10 @@ impl<'doc> TransactionMut<'doc> {
 
     pub fn doc(&self) -> &Doc {
         &self.doc
+    }
+
+    pub fn events(&self) -> Option<&StoreEvents> {
+        self.store.events.as_deref()
     }
 
     /// Corresponding document's state vector at the moment when current transaction was created.

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -246,7 +246,7 @@ pub trait Observable: AsRef<Branch> {
     }
 
     /// Unsubscribes a given callback identified by key, that was previously subscribed using [Self::observe_with].
-    fn unobserve<K: Into<Origin>>(&self, key: K) {
+    fn unobserve<K: Into<Origin>>(&self, key: K) -> bool {
         let mut branch = BranchPtr::from(self.as_ref());
         branch.unobserve(&key.into())
     }
@@ -279,7 +279,7 @@ pub trait Observable: AsRef<Branch> {
     }
 
     /// Unsubscribes a given callback identified by key, that was previously subscribed using [Self::observe_with].
-    fn unobserve<K: Into<Origin>>(&self, key: K) {
+    fn unobserve<K: Into<Origin>>(&self, key: K) -> bool {
         let mut branch = BranchPtr::from(self.as_ref());
         branch.unobserve(&key.into())
     }
@@ -364,7 +364,7 @@ pub trait DeepObservable: AsRef<Branch> {
 
     /// Unsubscribe a callback identified by a given key, that was previously subscribed using
     /// [Self::observe_deep_with].
-    fn unobserve_deep<K: Into<Origin>>(&self, key: K) {
+    fn unobserve_deep<K: Into<Origin>>(&self, key: K) -> bool {
         let branch = self.as_ref();
         branch.deep_observers.unsubscribe(&key.into())
     }
@@ -397,7 +397,7 @@ pub trait DeepObservable: AsRef<Branch> {
 
     /// Unsubscribe a callback identified by a given key, that was previously subscribed using
     /// [Self::observe_deep_with].
-    fn unobserve_deep<K: Into<Origin>>(&self, key: K) {
+    fn unobserve_deep<K: Into<Origin>>(&self, key: K) -> bool {
         let branch = self.as_ref();
         branch.deep_observers.unsubscribe(&key.into())
     }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -1,18 +1,19 @@
+use std::collections::HashSet;
+use std::fmt::Formatter;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Arc;
+
 use crate::block::ItemPtr;
 use crate::branch::{Branch, BranchPtr};
 use crate::doc::TransactionAcqError;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
+use crate::sync::time::SystemClock;
+use crate::sync::Clock;
 use crate::transaction::Origin;
-use crate::{DeleteSet, Doc, ObserverMut, Subscription, Transact, TransactionMut, ID};
-use std::cell::Cell;
-use std::collections::HashSet;
-use std::fmt::Formatter;
-use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use crate::{DeleteSet, Doc, Observer, Subscription, Transact, TransactionMut, ID};
 
-#[repr(transparent)]
 /// Undo manager is a structure used to perform undo/redo operations over the associated shared
 /// type(s).
 ///
@@ -34,7 +35,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 ///    item finished.
 /// - [UndoManager::observe_item_popped], which is fired whenever [StackItem] is being from undo
 ///    manager as a result of calling either [UndoManager::undo] or [UndoManager::redo] method.
-pub struct UndoManager<M>(Box<Inner<M>>);
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct UndoManager<M>(Arc<Inner<M>>);
+
+type UndoFn<M> = Box<dyn Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static>;
 
 struct Inner<M> {
     doc: Doc,
@@ -42,19 +47,19 @@ struct Inner<M> {
     options: Options,
     undo_stack: UndoStack<M>,
     redo_stack: UndoStack<M>,
-    undoing: Cell<bool>,
-    redoing: Cell<bool>,
+    undoing: bool,
+    redoing: bool,
     last_change: u64,
     on_after_transaction: Option<Subscription>,
     on_destroy: Option<Subscription>,
-    observer_added: ObserverMut<Event<M>>,
-    observer_updated: ObserverMut<Event<M>>,
-    observer_popped: ObserverMut<Event<M>>,
+    observer_added: Observer<UndoFn<M>>,
+    observer_updated: Observer<UndoFn<M>>,
+    observer_popped: Observer<UndoFn<M>>,
 }
 
 impl<M> UndoManager<M>
 where
-    M: Default + 'static,
+    M: Default + Send + Sync + Unpin + 'static,
 {
     /// Creates a new instance of the [UndoManager] working in a `scope` of a particular shared
     /// type and document. While it's possible for undo manager to observe multiple shared types
@@ -71,6 +76,11 @@ where
         &self.0.doc
     }
 
+    #[inline]
+    fn inner(&mut self) -> &mut Inner<M> {
+        Arc::get_mut(&mut self.0).unwrap()
+    }
+
     /// Creates a new instance of the [UndoManager] working in a `scope` of a particular shared
     /// type and document. While it's possible for undo manager to observe multiple shared types
     /// (see: [UndoManager::expand_scope]), it can only work with a single document at the same time.
@@ -79,33 +89,38 @@ where
         T: AsRef<Branch>,
     {
         let scope = BranchPtr::from(scope.as_ref());
-        let mut inner = Box::new(Inner {
+        let mut inner = Arc::new(Inner {
             doc: doc.clone(),
             scope: HashSet::from([scope]),
             options,
             undo_stack: UndoStack::default(),
             redo_stack: UndoStack::default(),
-            undoing: Cell::new(false),
-            redoing: Cell::new(false),
+            undoing: false,
+            redoing: false,
             last_change: 0,
             on_after_transaction: None,
             on_destroy: None,
-            observer_added: ObserverMut::new(),
-            observer_updated: ObserverMut::new(),
-            observer_popped: ObserverMut::new(),
+            observer_added: Observer::new(),
+            observer_updated: Observer::new(),
+            observer_popped: Observer::new(),
         });
-        let inner_ptr = inner.as_mut() as *mut Inner<M>;
-        inner
-            .options
-            .tracked_origins
-            .insert(Origin::from(inner_ptr as usize));
-        inner.on_destroy = Some(
-            doc.observe_destroy(move |_, _| Self::handle_destroy(inner_ptr))
-                .unwrap(),
+        let origin = Origin::from(Arc::as_ptr(&inner) as usize);
+        let inner_mut = Arc::get_mut(&mut inner).unwrap();
+        inner_mut.options.tracked_origins.insert(origin);
+        let ptr = AtomicPtr::new(inner_mut as *mut Inner<M>);
+        inner_mut.on_destroy = Some(
+            doc.observe_destroy(move |_, _| {
+                let ptr = ptr.load(Ordering::Acquire);
+                let inner = unsafe { ptr.as_mut().unwrap() };
+                Self::handle_destroy(inner)
+            })
+            .unwrap(),
         );
-        inner.on_after_transaction = Some(
+        let ptr = AtomicPtr::new(inner_mut as *mut Inner<M>);
+        inner_mut.on_after_transaction = Some(
             doc.observe_after_transaction(move |txn| {
-                let inner = unsafe { inner_ptr.as_mut().unwrap() };
+                let ptr = ptr.load(Ordering::Acquire);
+                let inner = unsafe { ptr.as_mut().unwrap() };
                 Self::handle_after_transaction(inner, txn);
             })
             .unwrap(),
@@ -115,11 +130,15 @@ where
     }
 
     fn should_skip(inner: &Inner<M>, txn: &TransactionMut) -> bool {
-        !(inner.options.capture_transaction)(txn)
-            || !inner
-                .scope
-                .iter()
-                .any(|parent| txn.changed_parent_types.contains(parent))
+        if let Some(capture_transaction) = &inner.options.capture_transaction {
+            if !capture_transaction(txn) {
+                return true;
+            }
+        }
+        !inner
+            .scope
+            .iter()
+            .any(|parent| txn.changed_parent_types.contains(parent))
             || !txn
                 .origin()
                 .map(|o| inner.options.tracked_origins.contains(o))
@@ -130,8 +149,8 @@ where
         if Self::should_skip(inner, txn) {
             return;
         }
-        let undoing = inner.undoing.get();
-        let redoing = inner.redoing.get();
+        let undoing = inner.undoing;
+        let redoing = inner.redoing;
         if undoing {
             inner.last_change = 0; // next undo should not be appended to last stack item
         } else if !redoing {
@@ -150,7 +169,7 @@ where
                 insertions.insert(ID::new(*client, start_clock), diff);
             }
         }
-        let now = (inner.options.timestamp)();
+        let now = inner.options.timestamp.now();
         let stack = if undoing {
             &mut inner.redo_stack
         } else {
@@ -197,20 +216,19 @@ where
             Event::redo(meta, txn.origin.clone(), txn.changed_parent_types.clone())
         };
         if !extend {
-            if let Some(mut callbacks) = inner.observer_added.callbacks() {
-                callbacks.trigger(txn, &mut event);
+            if inner.observer_added.has_subscribers() {
+                inner.observer_added.trigger(|fun| fun(txn, &mut event));
             }
         } else {
-            if let Some(mut callbacks) = inner.observer_updated.callbacks() {
-                callbacks.trigger(txn, &mut event);
+            if inner.observer_updated.has_subscribers() {
+                inner.observer_updated.trigger(|fun| fun(txn, &mut event));
             }
         }
         last_op.meta = event.meta;
     }
 
-    fn handle_destroy(inner: *mut Inner<M>) {
-        let origin = Origin::from(inner as usize);
-        let inner = unsafe { inner.as_mut().unwrap() };
+    fn handle_destroy(inner: &mut Inner<M>) {
+        let origin = Origin::from(inner as *mut Inner<M> as usize);
         if inner.options.tracked_origins.remove(&origin) {
             inner.on_destroy.take();
             inner.on_after_transaction.take();
@@ -225,9 +243,9 @@ where
     /// Returns a subscription object which - when dropped - will unregister provided callback.
     pub fn observe_item_added<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) -> () + 'static,
+        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.0.observer_added.subscribe(move |txn, e| f(txn, e))
+        self.0.observer_added.subscribe(Box::new(f))
     }
 
     /// Registers a callback function to be called every time an existing [StackItem] has been
@@ -237,9 +255,9 @@ where
     /// Returns a subscription object which - when dropped - will unregister provided callback.
     pub fn observe_item_updated<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) -> () + 'static,
+        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.0.observer_updated.subscribe(move |txn, e| f(txn, e))
+        self.0.observer_updated.subscribe(Box::new(f))
     }
 
     /// Registers a callback function to be called every time an existing [StackItem] has been
@@ -248,9 +266,9 @@ where
     /// Returns a subscription object which - when dropped - will unregister provided callback.
     pub fn observe_item_popped<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) -> () + 'static,
+        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.0.observer_popped.subscribe(move |txn, e| f(txn, e))
+        self.0.observer_popped.subscribe(Box::new(f))
     }
 
     /// Extends a list of shared types tracked by current undo manager by a given `scope`.
@@ -259,7 +277,8 @@ where
         T: AsRef<Branch>,
     {
         let ptr = BranchPtr::from(scope.as_ref());
-        self.0.scope.insert(ptr);
+        let inner = self.inner();
+        inner.scope.insert(ptr);
     }
 
     /// Extends a list of origins tracked by current undo manager by given `origin`. Origin markers
@@ -269,7 +288,8 @@ where
     where
         O: Into<Origin>,
     {
-        self.0.options.tracked_origins.insert(origin.into());
+        let inner = self.inner();
+        inner.options.tracked_origins.insert(origin.into());
     }
 
     /// Removes an `origin` from the list of origins tracked by a current undo manager.
@@ -277,21 +297,23 @@ where
     where
         O: Into<Origin>,
     {
-        self.0.options.tracked_origins.remove(&origin.into());
+        let inner = self.inner();
+        inner.options.tracked_origins.remove(&origin.into());
     }
 
     /// Clears all [StackItem]s stored within current UndoManager, effectively resetting its state.
     pub fn clear(&mut self) -> Result<(), TransactionAcqError> {
-        let mut txn = self.0.doc.try_transact_mut()?;
+        let inner = self.inner();
+        let mut txn = inner.doc.try_transact_mut()?;
 
-        let len = self.0.undo_stack.len();
-        for item in self.0.undo_stack.drain(0..len) {
-            Self::clear_item(&self.0.scope, &mut txn, item);
+        let len = inner.undo_stack.len();
+        for item in inner.undo_stack.drain(0..len) {
+            Self::clear_item(&inner.scope, &mut txn, item);
         }
 
-        let len = self.0.redo_stack.len();
-        for item in self.0.redo_stack.drain(0..len) {
-            Self::clear_item(&self.0.scope, &mut txn, item);
+        let len = inner.redo_stack.len();
+        for item in inner.redo_stack.drain(0..len) {
+            Self::clear_item(&inner.scope, &mut txn, item);
         }
 
         Ok(())
@@ -340,7 +362,8 @@ where
     /// txt.get_string(&doc.transact()); // => "a" (note that only 'b' was removed)
     /// ```
     pub fn reset(&mut self) {
-        self.0.last_change = 0;
+        let inner = self.inner();
+        inner.last_change = 0;
     }
 
     /// Are there any undo steps available?
@@ -360,29 +383,27 @@ where
     /// no other transaction on that same document can be active while calling this method.
     /// Otherwise an error will be returned.
     pub fn undo(&mut self) -> Result<bool, TransactionAcqError> {
-        let mut txn = self.0.doc.try_transact_mut_with(self.as_origin())?;
-        self.0.undoing.set(true);
+        let origin = self.as_origin();
+        let inner = self.inner();
+        let mut txn = inner.doc.try_transact_mut_with(origin.clone())?;
+        inner.undoing = true;
         let result = Self::pop(
-            &mut self.0.undo_stack,
-            &self.0.redo_stack,
+            &mut inner.undo_stack,
+            &inner.redo_stack,
             &mut txn,
-            &self.0.scope,
+            &inner.scope,
         );
         txn.commit();
         let changed = if let Some(item) = result {
-            let mut e = Event::undo(
-                item.meta,
-                Some(self.as_origin()),
-                txn.changed_parent_types.clone(),
-            );
-            if let Some(mut callbacks) = self.0.observer_popped.callbacks() {
-                callbacks.trigger(&mut txn, &mut e);
+            let mut e = Event::undo(item.meta, Some(origin), txn.changed_parent_types.clone());
+            if inner.observer_popped.has_subscribers() {
+                inner.observer_popped.trigger(|fun| fun(&txn, &mut e));
             }
             true
         } else {
             false
         };
-        self.0.undoing.set(false);
+        inner.undoing = false;
         Ok(changed)
     }
 
@@ -403,29 +424,27 @@ where
     /// no other transaction on that same document can be active while calling this method.
     /// Otherwise an error will be returned.
     pub fn redo(&mut self) -> Result<bool, TransactionAcqError> {
-        let mut txn = self.0.doc.try_transact_mut_with(self.as_origin())?;
-        self.0.redoing.set(true);
+        let origin = self.as_origin();
+        let inner = self.inner();
+        let mut txn = inner.doc.try_transact_mut_with(origin.clone())?;
+        inner.redoing = true;
         let result = Self::pop(
-            &mut self.0.redo_stack,
-            &self.0.undo_stack,
+            &mut inner.redo_stack,
+            &inner.undo_stack,
             &mut txn,
-            &self.0.scope,
+            &inner.scope,
         );
         txn.commit();
         let changed = if let Some(item) = result {
-            let mut e = Event::redo(
-                item.meta,
-                Some(self.as_origin()),
-                txn.changed_parent_types.clone(),
-            );
-            if let Some(mut callbacks) = self.0.observer_popped.callbacks() {
-                callbacks.trigger(&mut txn, &mut e);
+            let mut e = Event::redo(item.meta, Some(origin), txn.changed_parent_types.clone());
+            if inner.observer_popped.has_subscribers() {
+                inner.observer_popped.trigger(|fun| fun(&txn, &mut e));
             }
             true
         } else {
             false
         };
-        self.0.redoing.set(false);
+        inner.redoing = false;
         Ok(changed)
     }
 
@@ -538,7 +557,6 @@ impl<M> UndoStack<M> {
 }
 
 /// Set of options used to configure [UndoManager].
-#[derive(Clone)]
 pub struct Options {
     /// Undo-/redo-able updates are grouped together in time-constrained snapshots. This field
     /// determines the period of time, every snapshot will be automatically made in.
@@ -551,25 +569,23 @@ pub struct Options {
 
     /// Custom logic decider, that along with [tracked_origins] can be used to determine if
     /// transaction changes should be captured or not.
-    pub capture_transaction: Rc<dyn Fn(&TransactionMut) -> bool>,
+    pub capture_transaction: Option<CaptureTransactionFn>,
 
     /// Custom clock function, that can be used to generate timestamps used by
     /// [Options::capture_timeout_millis].
-    pub timestamp: Rc<dyn Fn() -> u64>,
+    pub timestamp: Arc<dyn Clock>,
 }
 
+pub type CaptureTransactionFn = Arc<dyn Fn(&TransactionMut) -> bool + Send + Sync + 'static>;
+
+#[cfg(not(target_arch = "wasm32"))]
 impl Default for Options {
     fn default() -> Self {
         Options {
             capture_timeout_millis: 500,
             tracked_origins: HashSet::new(),
-            capture_transaction: Rc::new(|_txn| true),
-            timestamp: Rc::new(|| {
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_millis() as u64
-            }),
+            capture_transaction: None,
+            timestamp: Arc::new(SystemClock),
         }
     }
 }
@@ -700,6 +716,11 @@ pub enum EventKind {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+    use std::convert::TryInto;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
     use crate::test_utils::exchange_updates;
     use crate::types::text::{Diff, YChange};
     use crate::types::{Attrs, ToJson};
@@ -710,10 +731,6 @@ mod test {
         Text, TextPrelim, TextRef, Transact, UndoManager, Update, Xml, XmlElementPrelim,
         XmlElementRef, XmlFragment, XmlTextPrelim,
     };
-    use std::collections::HashMap;
-    use std::convert::TryInto;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
 
     #[test]
     fn undo_text() {

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -295,7 +295,7 @@ where
             .subscribe_with(key.into(), Box::new(f))
     }
 
-    pub fn unobserve_item_added<K>(&self, key: K)
+    pub fn unobserve_item_added<K>(&self, key: K) -> bool
     where
         K: Into<Origin>,
     {
@@ -349,7 +349,7 @@ where
             .subscribe_with(key.into(), Box::new(f))
     }
 
-    pub fn unobserve_item_updated<K>(&self, key: K)
+    pub fn unobserve_item_updated<K>(&self, key: K) -> bool
     where
         K: Into<Origin>,
     {
@@ -400,7 +400,7 @@ where
             .subscribe_with(key.into(), Box::new(f))
     }
 
-    pub fn unobserve_item_popped<K>(&self, key: K)
+    pub fn unobserve_item_popped<K>(&self, key: K) -> bool
     where
         K: Into<Origin>,
     {

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -9,7 +9,6 @@ use crate::branch::{Branch, BranchPtr};
 use crate::doc::TransactionAcqError;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
-use crate::sync::time::SystemClock;
 use crate::sync::Clock;
 use crate::transaction::Origin;
 use crate::{DeleteSet, Doc, Observer, Subscription, Transact, TransactionMut, ID};
@@ -64,6 +63,7 @@ where
     /// Creates a new instance of the [UndoManager] working in a `scope` of a particular shared
     /// type and document. While it's possible for undo manager to observe multiple shared types
     /// (see: [UndoManager::expand_scope]), it can only work with a single document at the same time.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new<T>(doc: &Doc, scope: &T) -> Self
     where
         T: AsRef<Branch>,
@@ -585,7 +585,7 @@ impl Default for Options {
             capture_timeout_millis: 500,
             tracked_origins: HashSet::new(),
             capture_transaction: None,
-            timestamp: Arc::new(SystemClock),
+            timestamp: Arc::new(crate::sync::time::SystemClock),
         }
     }
 }

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -20,6 +20,7 @@ default = ["console_error_panic_hook"]
 yrs = { path = "../yrs", version = "0.18.8", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
+serde_json = "1.0"
 gloo-utils = { version = "0.2", features = ["serde"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/ywasm/src/array.rs
+++ b/ywasm/src/array.rs
@@ -1,11 +1,10 @@
 use crate::collection::SharedCollection;
-use crate::js::{Js, ValueRef, YRange};
+use crate::js::{Callback, Js, ValueRef, YRange};
 use crate::transaction::{ImplicitTransaction, YTransaction};
 use crate::weak::YWeakLink;
 use crate::Result;
 use gloo_utils::format::JsValueSerdeExt;
 use std::iter::FromIterator;
-use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::array::ArrayEvent;
@@ -267,9 +266,8 @@ impl YArray {
 
     /// Subscribes to all operations happening over this instance of `YArray`. All changes are
     /// batched and eventually triggered during transaction commit phase.
-    /// Returns an `Observer` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&self, f: js_sys::Function) -> Result<()> {
+    pub fn observe(&self, callback: js_sys::Function) -> Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -277,11 +275,12 @@ impl YArray {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 array.observe_with(abi, move |txn, e| {
                     let e = YArrayEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
                 });
                 Ok(())
@@ -290,7 +289,7 @@ impl YArray {
     }
 
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&self, f: js_sys::Function) -> Result<bool> {
+    pub fn unobserve(&self, callback: js_sys::Function) -> Result<bool> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -298,7 +297,7 @@ impl YArray {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 Ok(array.unobserve(abi))
             }
         }
@@ -307,9 +306,8 @@ impl YArray {
     /// Subscribes to all operations happening over this Y shared type, as well as events in
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
-    /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&self, f: js_sys::Function) -> Result<()> {
+    pub fn observe_deep(&self, callback: js_sys::Function) -> Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -317,11 +315,13 @@ impl YArray {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e, &txn.into())
+                        .unwrap();
                 });
                 Ok(())
             }
@@ -329,7 +329,7 @@ impl YArray {
     }
 
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&self, f: js_sys::Function) -> Result<bool> {
+    pub fn unobserve_deep(&self, callback: js_sys::Function) -> Result<bool> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -337,7 +337,7 @@ impl YArray {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 Ok(array.unobserve_deep(abi))
             }
         }

--- a/ywasm/src/array.rs
+++ b/ywasm/src/array.rs
@@ -289,6 +289,21 @@ impl YArray {
         }
     }
 
+    #[wasm_bindgen(js_name = unobserve)]
+    pub fn unobserve(&self, f: js_sys::Function) -> Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let array = c.resolve(&txn)?;
+                let abi = f.clone().into_abi();
+                Ok(array.unobserve(abi))
+            }
+        }
+    }
+
     /// Subscribes to all operations happening over this Y shared type, as well as events in
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
@@ -309,6 +324,21 @@ impl YArray {
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
                 });
                 Ok(())
+            }
+        }
+    }
+
+    #[wasm_bindgen(js_name = unobserveDeep)]
+    pub fn unobserve_deep(&self, f: js_sys::Function) -> Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let array = c.resolve(&txn)?;
+                let abi = f.clone().into_abi();
+                Ok(array.unobserve_deep(abi))
             }
         }
     }

--- a/ywasm/src/awareness.rs
+++ b/ywasm/src/awareness.rs
@@ -94,9 +94,9 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = offUpdate)]
-    pub fn off_update(&self, callback: js_sys::Function) {
+    pub fn off_update(&self, callback: js_sys::Function) -> bool {
         let abi = callback.clone().into_abi();
-        self.inner.unobserve_update(abi);
+        self.inner.unobserve_update(abi)
     }
 }
 

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -251,7 +251,7 @@ impl YDoc {
     }
 
     #[wasm_bindgen(js_name = off)]
-    pub fn off(&self, event: &str, f: js_sys::Function) -> Result<()> {
+    pub fn off(&self, event: &str, f: js_sys::Function) -> Result<bool> {
         let abi = f.clone().into_abi();
         let result = match event {
             "update" => self.unobserve_update_v1(abi),
@@ -264,8 +264,7 @@ impl YDoc {
                 return Err(JsValue::from_str(&format!("unknown event: '{}'", other)).into());
             }
         };
-        result.map_err(|_| JsValue::from_str(crate::js::errors::ANOTHER_TX))?;
-        Ok(())
+        result.map_err(|_| JsValue::from_str(crate::js::errors::ANOTHER_TX))
     }
 
     /// Notify the parent document that you request to load data into this subdocument

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -42,17 +42,7 @@ pub use crate::weak::YWeakLinkEvent as WeakLinkEvent;
 
 #[wasm_bindgen]
 #[repr(transparent)]
-pub struct Observer(pub(crate) yrs::Subscription);
-
-#[wasm_bindgen]
-#[repr(transparent)]
 pub struct YSnapshot(yrs::Snapshot);
-
-impl From<yrs::Subscription> for Observer {
-    fn from(s: yrs::Subscription) -> Self {
-        Observer(s)
-    }
-}
 
 /// When called will call console log errors whenever internal panic is called from within
 /// WebAssembly module.

--- a/ywasm/src/map.rs
+++ b/ywasm/src/map.rs
@@ -249,13 +249,18 @@ impl YMap {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve(callback.into_abi());
+    pub fn unobserve(&mut self, f: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = f.clone().into_abi();
+                Ok(shared_ref.unobserve(abi))
+            }
         }
-        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -270,9 +275,9 @@ impl YMap {
             }
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
-                let array = c.resolve(&txn)?;
+                let shared_ref = c.resolve(&txn)?;
                 let abi = f.clone().into_abi();
-                array.observe_deep_with(abi, move |txn, e| {
+                shared_ref.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
@@ -284,13 +289,18 @@ impl YMap {
 
     /// Unsubscribes a callback previously subscribed with `observeDeep` method.
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve_deep(callback.into_abi());
+    pub fn unobserve_deep(&mut self, f: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = f.clone().into_abi();
+                Ok(shared_ref.unobserve_deep(abi))
+            }
         }
-        Ok(())
     }
 }
 

--- a/ywasm/src/map.rs
+++ b/ywasm/src/map.rs
@@ -2,9 +2,10 @@ use crate::collection::SharedCollection;
 use crate::js::Js;
 use crate::transaction::YTransaction;
 use crate::weak::YWeakLink;
-use crate::{js, ImplicitTransaction, Observer};
+use crate::{js, ImplicitTransaction};
 use gloo_utils::format::JsValueSerdeExt;
 use std::collections::HashMap;
+use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::map::MapEvent;
@@ -225,7 +226,7 @@ impl YMap {
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe(&mut self, callback: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -233,14 +234,28 @@ impl YMap {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe(move |txn, e| {
+                let abi = callback.clone().into_abi();
+                array.observe_with(abi, move |txn, e| {
                     let e = YMapEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observe` method.
+    #[wasm_bindgen(js_name = unobserve)]
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve(callback.into_abi());
+        }
+        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -248,7 +263,7 @@ impl YMap {
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -256,13 +271,26 @@ impl YMap {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe_deep(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observeDeep` method.
+    #[wasm_bindgen(js_name = unobserveDeep)]
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve_deep(callback.into_abi());
+        }
+        Ok(())
     }
 }
 

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -1,9 +1,8 @@
 use crate::collection::SharedCollection;
-use crate::js::{Js, ValueRef, YRange};
+use crate::js::{Callback, Js, ValueRef, YRange};
 use crate::transaction::YTransaction;
 use crate::weak::YWeakLink;
 use crate::{ImplicitTransaction, YSnapshot};
-use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::text::TextEvent;
@@ -329,9 +328,8 @@ impl YText {
 
     /// Subscribes to all operations happening over this instance of `YText`. All changes are
     /// batched and eventually triggered during transaction commit phase.
-    /// Returns an `YTextObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&self, f: js_sys::Function) -> crate::Result<()> {
+    pub fn observe(&self, callback: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -339,11 +337,12 @@ impl YText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 array.observe_with(abi, move |txn, e| {
                     let e = YTextEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
                 });
                 Ok(())
@@ -361,7 +360,7 @@ impl YText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let shared_ref = c.resolve(&txn)?;
-                let abi = callback.clone().into_abi();
+                let abi = callback.subscription_key();
                 Ok(shared_ref.unobserve(abi))
             }
         }
@@ -370,9 +369,8 @@ impl YText {
     /// Subscribes to all operations happening over this Y shared type, as well as events in
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
-    /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&self, f: js_sys::Function) -> crate::Result<()> {
+    pub fn observe_deep(&self, callback: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -380,11 +378,13 @@ impl YText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e, &txn.into())
+                        .unwrap();
                 });
                 Ok(())
             }
@@ -401,7 +401,7 @@ impl YText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let shared_ref = c.resolve(&txn)?;
-                let abi = callback.clone().into_abi();
+                let abi = callback.subscription_key();
                 Ok(shared_ref.unobserve_deep(abi))
             }
         }

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -2,7 +2,8 @@ use crate::collection::SharedCollection;
 use crate::js::{Js, ValueRef, YRange};
 use crate::transaction::YTransaction;
 use crate::weak::YWeakLink;
-use crate::{ImplicitTransaction, Observer, YSnapshot};
+use crate::{ImplicitTransaction, YSnapshot};
+use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::text::TextEvent;
@@ -330,7 +331,7 @@ impl YText {
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YTextObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe(&self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -338,14 +339,27 @@ impl YText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_with(abi, move |txn, e| {
                     let e = YTextEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observe` method.
+    #[wasm_bindgen(js_name = unobserve)]
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve(callback.into_abi());
+        }
+        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -353,7 +367,7 @@ impl YText {
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe_deep(&self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -361,13 +375,26 @@ impl YText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe_deep(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observeDeep` method.
+    #[wasm_bindgen(js_name = unobserveDeep)]
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve_deep(callback.into_abi());
+        }
+        Ok(())
     }
 }
 

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -353,13 +353,18 @@ impl YText {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve(callback.into_abi());
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve(abi))
+            }
         }
-        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -388,13 +393,18 @@ impl YText {
 
     /// Unsubscribes a callback previously subscribed with `observeDeep` method.
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve_deep(callback.into_abi());
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve_deep(abi))
+            }
         }
-        Ok(())
     }
 }
 

--- a/ywasm/src/undo.rs
+++ b/ywasm/src/undo.rs
@@ -2,7 +2,6 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use js_sys::Reflect;
-use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -11,7 +10,7 @@ use yrs::undo::{EventKind, UndoManager};
 use yrs::{Doc, Transact};
 
 use crate::doc::YDoc;
-use crate::js::{Js, Shared};
+use crate::js::{Callback, Js, Shared};
 use crate::transaction::YTransaction;
 use crate::Result;
 
@@ -129,7 +128,7 @@ impl YUndoManager {
 
     #[wasm_bindgen(js_name = on)]
     pub fn on(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
-        let abi = callback.clone().into_abi();
+        let abi = callback.subscription_key();
         match event {
             "stack-item-added" => self.0.observe_item_added_with(abi, move |txn, e| {
                 let event: JsValue = YUndoEvent::new(e).into();
@@ -162,7 +161,7 @@ impl YUndoManager {
 
     #[wasm_bindgen(js_name = off)]
     pub fn off(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<bool> {
-        let abi = callback.clone().into_abi();
+        let abi = callback.subscription_key();
         match event {
             "stack-item-added" => Ok(self.0.unobserve_item_added(abi)),
             "stack-item-popped" => Ok(self.0.unobserve_item_popped(abi)),

--- a/ywasm/src/undo.rs
+++ b/ywasm/src/undo.rs
@@ -161,15 +161,14 @@ impl YUndoManager {
     }
 
     #[wasm_bindgen(js_name = off)]
-    pub fn off(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
+    pub fn off(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<bool> {
         let abi = callback.clone().into_abi();
         match event {
-            "stack-item-added" => self.0.unobserve_item_added(abi),
-            "stack-item-popped" => self.0.unobserve_item_popped(abi),
-            "stack-item-updated" => self.0.unobserve_item_updated(abi),
-            unknown => return Err(JsValue::from_str(&format!("Unknown event: {}", unknown))),
+            "stack-item-added" => Ok(self.0.unobserve_item_added(abi)),
+            "stack-item-popped" => Ok(self.0.unobserve_item_popped(abi)),
+            "stack-item-updated" => Ok(self.0.unobserve_item_updated(abi)),
+            unknown => Err(JsValue::from_str(&format!("Unknown event: {}", unknown))),
         }
-        Ok(())
     }
 }
 

--- a/ywasm/src/undo.rs
+++ b/ywasm/src/undo.rs
@@ -1,14 +1,19 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use js_sys::Reflect;
+use wasm_bindgen::convert::IntoWasmAbi;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+use yrs::branch::BranchPtr;
+use yrs::undo::{EventKind, UndoManager};
+use yrs::{Doc, Transact};
+
 use crate::doc::YDoc;
 use crate::js::{Js, Shared};
 use crate::transaction::YTransaction;
 use crate::Result;
-use js_sys::Reflect;
-use std::rc::Rc;
-use wasm_bindgen::prelude::wasm_bindgen;
-use wasm_bindgen::JsValue;
-use yrs::branch::BranchPtr;
-use yrs::undo::{EventKind, UndoManager};
-use yrs::{Doc, Transact};
 
 #[wasm_bindgen]
 #[repr(transparent)]
@@ -36,8 +41,12 @@ impl YUndoManager {
     pub fn new(doc: &YDoc, scope: JsValue, options: JsValue) -> Result<YUndoManager> {
         let doc = &doc.0;
         let scope = Self::get_scope(doc, &scope)?;
-        let mut o = yrs::undo::Options::default();
-        o.timestamp = Rc::new(|| js_sys::Date::now() as u64);
+        let mut o = yrs::undo::Options {
+            capture_timeout_millis: 500,
+            tracked_origins: HashSet::new(),
+            capture_transaction: None,
+            timestamp: Arc::new(crate::awareness::JsClock),
+        };
         if options.is_object() {
             if let Ok(js) = Reflect::get(&options, &JsValue::from_str("captureTimeout")) {
                 if let Some(millis) = js.as_f64() {
@@ -118,32 +127,49 @@ impl YUndoManager {
         self.0.can_redo()
     }
 
-    #[wasm_bindgen(js_name = onStackItemAdded)]
-    pub fn on_item_added(&mut self, callback: js_sys::Function) -> crate::Observer {
-        self.0
-            .observe_item_added(move |txn, e| {
+    #[wasm_bindgen(js_name = on)]
+    pub fn on(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
+        let abi = callback.clone().into_abi();
+        match event {
+            "stack-item-added" => self.0.observe_item_added_with(abi, move |txn, e| {
                 let event: JsValue = YUndoEvent::new(e).into();
                 let txn: JsValue = YTransaction::from_ref(txn).into();
                 callback.call2(&JsValue::UNDEFINED, &event, &txn).unwrap();
                 let meta =
                     Reflect::get(&event, &JsValue::from_str("meta")).unwrap_or(JsValue::UNDEFINED);
                 *e.meta_mut() = meta;
-            })
-            .into()
+            }),
+            "stack-item-popped" => self.0.observe_item_popped_with(abi, move |txn, e| {
+                let event: JsValue = YUndoEvent::new(e).into();
+                let txn: JsValue = YTransaction::from_ref(txn).into();
+                callback.call2(&JsValue::UNDEFINED, &event, &txn).unwrap();
+                let meta =
+                    Reflect::get(&event, &JsValue::from_str("meta")).unwrap_or(JsValue::UNDEFINED);
+                *e.meta_mut() = meta;
+            }),
+            "stack-item-updated" => self.0.observe_item_updated_with(abi, move |txn, e| {
+                let event: JsValue = YUndoEvent::new(e).into();
+                let txn: JsValue = YTransaction::from_ref(txn).into();
+                callback.call2(&JsValue::UNDEFINED, &event, &txn).unwrap();
+                let meta =
+                    Reflect::get(&event, &JsValue::from_str("meta")).unwrap_or(JsValue::UNDEFINED);
+                *e.meta_mut() = meta;
+            }),
+            unknown => return Err(JsValue::from_str(&format!("Unknown event: {}", unknown))),
+        }
+        Ok(())
     }
 
-    #[wasm_bindgen(js_name = onStackItemPopped)]
-    pub fn on_item_popped(&mut self, callback: js_sys::Function) -> crate::Observer {
-        self.0
-            .observe_item_popped(move |txn, e| {
-                let event: JsValue = YUndoEvent::new(e).into();
-                let txn: JsValue = YTransaction::from_ref(txn).into();
-                callback.call2(&JsValue::UNDEFINED, &event, &txn).unwrap();
-                let meta =
-                    Reflect::get(&event, &JsValue::from_str("meta")).unwrap_or(JsValue::UNDEFINED);
-                *e.meta_mut() = meta;
-            })
-            .into()
+    #[wasm_bindgen(js_name = off)]
+    pub fn off(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
+        let abi = callback.clone().into_abi();
+        match event {
+            "stack-item-added" => self.0.unobserve_item_added(abi),
+            "stack-item-popped" => self.0.unobserve_item_popped(abi),
+            "stack-item-updated" => self.0.unobserve_item_updated(abi),
+            unknown => return Err(JsValue::from_str(&format!("Unknown event: {}", unknown))),
+        }
+        Ok(())
     }
 }
 

--- a/ywasm/src/weak.rs
+++ b/ywasm/src/weak.rs
@@ -209,13 +209,18 @@ impl YWeakLink {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve(callback.into_abi());
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve(abi))
+            }
         }
-        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -244,13 +249,18 @@ impl YWeakLink {
 
     /// Unsubscribes a callback previously subscribed with `observeDeep` method.
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve_deep(callback.into_abi());
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve_deep(abi))
+            }
         }
-        Ok(())
     }
 }
 

--- a/ywasm/src/xml_elem.rs
+++ b/ywasm/src/xml_elem.rs
@@ -402,13 +402,18 @@ impl YXmlElement {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve(callback.into_abi());
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve(abi))
+            }
         }
-        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -437,12 +442,17 @@ impl YXmlElement {
 
     /// Unsubscribes a callback previously subscribed with `observeDeep` method.
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve_deep(callback.into_abi());
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve_deep(abi))
+            }
         }
-        Ok(())
     }
 }

--- a/ywasm/src/xml_elem.rs
+++ b/ywasm/src/xml_elem.rs
@@ -2,10 +2,11 @@ use crate::collection::SharedCollection;
 use crate::js::{Js, Shared};
 use crate::transaction::YTransaction;
 use crate::xml_frag::YXmlEvent;
-use crate::{ImplicitTransaction, Observer};
+use crate::ImplicitTransaction;
 use gloo_utils::format::JsValueSerdeExt;
 use std::collections::HashMap;
 use std::iter::FromIterator;
+use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::TYPE_REFS_XML_ELEMENT;
@@ -379,7 +380,7 @@ impl YXmlElement {
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -387,14 +388,27 @@ impl YXmlElement {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_with(abi, move |txn, e| {
                     let e = YXmlEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observe` method.
+    #[wasm_bindgen(js_name = unobserve)]
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve(callback.into_abi());
+        }
+        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -402,7 +416,7 @@ impl YXmlElement {
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -410,12 +424,25 @@ impl YXmlElement {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe_deep(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observeDeep` method.
+    #[wasm_bindgen(js_name = unobserveDeep)]
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve_deep(callback.into_abi());
+        }
+        Ok(())
     }
 }

--- a/ywasm/src/xml_frag.rs
+++ b/ywasm/src/xml_frag.rs
@@ -1,8 +1,9 @@
 use crate::collection::SharedCollection;
 use crate::js::{Js, Shared};
 use crate::transaction::YTransaction;
-use crate::{ImplicitTransaction, Observer};
+use crate::ImplicitTransaction;
 use std::iter::FromIterator;
+use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::xml::XmlEvent;
@@ -184,7 +185,7 @@ impl YXmlFragment {
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -192,14 +193,27 @@ impl YXmlFragment {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_with(abi, move |txn, e| {
                     let e = YXmlEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observe` method.
+    #[wasm_bindgen(js_name = unobserve)]
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve(callback.into_abi());
+        }
+        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -207,7 +221,7 @@ impl YXmlFragment {
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -215,13 +229,26 @@ impl YXmlFragment {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe_deep(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observeDeep` method.
+    #[wasm_bindgen(js_name = unobserveDeep)]
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve_deep(callback.into_abi());
+        }
+        Ok(())
     }
 }
 

--- a/ywasm/src/xml_frag.rs
+++ b/ywasm/src/xml_frag.rs
@@ -207,13 +207,18 @@ impl YXmlFragment {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve(callback.into_abi());
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve(abi))
+            }
         }
-        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -242,13 +247,18 @@ impl YXmlFragment {
 
     /// Unsubscribes a callback previously subscribed with `observeDeep` method.
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve_deep(callback.into_abi());
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve_deep(abi))
+            }
         }
-        Ok(())
     }
 }
 

--- a/ywasm/src/xml_frag.rs
+++ b/ywasm/src/xml_frag.rs
@@ -1,9 +1,8 @@
 use crate::collection::SharedCollection;
-use crate::js::{Js, Shared};
+use crate::js::{Callback, Js, Shared};
 use crate::transaction::YTransaction;
 use crate::ImplicitTransaction;
 use std::iter::FromIterator;
-use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::xml::XmlEvent;
@@ -183,9 +182,8 @@ impl YXmlFragment {
 
     /// Subscribes to all operations happening over this instance of `YXmlFragment`. All changes are
     /// batched and eventually triggered during transaction commit phase.
-    /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<()> {
+    pub fn observe(&mut self, callback: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -193,11 +191,12 @@ impl YXmlFragment {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 array.observe_with(abi, move |txn, e| {
                     let e = YXmlEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
                 });
                 Ok(())
@@ -215,7 +214,7 @@ impl YXmlFragment {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let shared_ref = c.resolve(&txn)?;
-                let abi = callback.clone().into_abi();
+                let abi = callback.subscription_key();
                 Ok(shared_ref.unobserve(abi))
             }
         }
@@ -224,9 +223,8 @@ impl YXmlFragment {
     /// Subscribes to all operations happening over this Y shared type, as well as events in
     /// shared types stored within this one. All changes are batched and eventually triggered
     /// during transaction commit phase.
-    /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<()> {
+    pub fn observe_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -234,11 +232,13 @@ impl YXmlFragment {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                let abi = f.clone().into_abi();
+                let abi = callback.subscription_key();
                 array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
-                    f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
+                    callback
+                        .call2(&JsValue::UNDEFINED, &e, &txn.into())
+                        .unwrap();
                 });
                 Ok(())
             }
@@ -255,7 +255,7 @@ impl YXmlFragment {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let shared_ref = c.resolve(&txn)?;
-                let abi = callback.clone().into_abi();
+                let abi = callback.subscription_key();
                 Ok(shared_ref.unobserve_deep(abi))
             }
         }

--- a/ywasm/src/xml_text.rs
+++ b/ywasm/src/xml_text.rs
@@ -4,9 +4,10 @@ use crate::text::YText;
 use crate::transaction::YTransaction;
 use crate::weak::YWeakLink;
 use crate::xml_elem::YXmlElement;
-use crate::{ImplicitTransaction, Observer, YSnapshot};
+use crate::{ImplicitTransaction, YSnapshot};
 use gloo_utils::format::JsValueSerdeExt;
 use std::collections::HashMap;
+use wasm_bindgen::convert::IntoWasmAbi;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::xml::XmlTextEvent;
@@ -434,7 +435,7 @@ impl YXmlText {
     /// batched and eventually triggered during transaction commit phase.
     /// Returns an `YObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observe)]
-    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -442,14 +443,27 @@ impl YXmlText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_with(abi, move |txn, e| {
                     let e = YXmlTextEvent::new(e, txn);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e.into(), &txn.into())
                         .unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observe` method.
+    #[wasm_bindgen(js_name = unobserve)]
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve(callback.into_abi());
+        }
+        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -457,7 +471,7 @@ impl YXmlText {
     /// during transaction commit phase.
     /// Returns an `YEventObserver` which, when free'd, will unsubscribe current callback.
     #[wasm_bindgen(js_name = observeDeep)]
-    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<Observer> {
+    pub fn observe_deep(&mut self, f: js_sys::Function) -> crate::Result<()> {
         match &self.0 {
             SharedCollection::Prelim(_) => {
                 Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
@@ -465,13 +479,26 @@ impl YXmlText {
             SharedCollection::Integrated(c) => {
                 let txn = c.transact()?;
                 let array = c.resolve(&txn)?;
-                Ok(Observer(array.observe_deep(move |txn, e| {
+                let abi = f.clone().into_abi();
+                array.observe_deep_with(abi, move |txn, e| {
                     let e = crate::js::convert::events_into_js(txn, e);
                     let txn = YTransaction::from_ref(txn);
                     f.call2(&JsValue::UNDEFINED, &e, &txn.into()).unwrap();
-                })))
+                });
+                Ok(())
             }
         }
+    }
+
+    /// Unsubscribes a callback previously subscribed with `observe` method.
+    #[wasm_bindgen(js_name = unobserveDeep)]
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
+        if let SharedCollection::Integrated(c) = &self.0 {
+            let txn = c.transact()?;
+            let shared_ref = c.resolve(&txn)?;
+            shared_ref.unobserve_deep(callback.into_abi());
+        }
+        Ok(())
     }
 }
 

--- a/ywasm/src/xml_text.rs
+++ b/ywasm/src/xml_text.rs
@@ -457,13 +457,18 @@ impl YXmlText {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserve)]
-    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve(callback.into_abi());
+    pub fn unobserve(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve(abi))
+            }
         }
-        Ok(())
     }
 
     /// Subscribes to all operations happening over this Y shared type, as well as events in
@@ -492,13 +497,18 @@ impl YXmlText {
 
     /// Unsubscribes a callback previously subscribed with `observe` method.
     #[wasm_bindgen(js_name = unobserveDeep)]
-    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<()> {
-        if let SharedCollection::Integrated(c) = &self.0 {
-            let txn = c.transact()?;
-            let shared_ref = c.resolve(&txn)?;
-            shared_ref.unobserve_deep(callback.into_abi());
+    pub fn unobserve_deep(&mut self, callback: js_sys::Function) -> crate::Result<bool> {
+        match &self.0 {
+            SharedCollection::Prelim(_) => {
+                Err(JsValue::from_str(crate::js::errors::INVALID_PRELIM_OP))
+            }
+            SharedCollection::Integrated(c) => {
+                let txn = c.transact()?;
+                let shared_ref = c.resolve(&txn)?;
+                let abi = callback.clone().into_abi();
+                Ok(shared_ref.unobserve_deep(abi))
+            }
         }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Closes #436

This PR introduces new Observers API - mostly compatible with the old one:

1. Along ability to subscribe with cancellable subscription returned, it now allows to subscribe by key: that key can be later used to unsubscribe.
2. Removed a bunch of unsafe checks from Observer code. This now means that all of the observer callbacks (except WASM compilation target) will require to implement Send and Sync traits.
3. The internal representation still uses lock-free actions, but now it's done via lock-free single-linked list, which is optimal since most of the time we have 0-1 callbacks subscribed.
4. Awareness API comes back to it's old shape from before v0.18: `Awareness::on_update` now can take `&Awareness` as it's first parameter instead of fighting with `&Event`s.
5. Awareness is now also generic over the metadata type.

There are also some big changes to ywasm:

1. All of the observers are now closer to how they work in Yjs, meaning observe/unobserve methods.
2. Dedicated methods for `Doc` and `UndoManager` like `ydoc.onUpdate` have now been replaced with `on('event-name', ..)` equivalent. Just like Yjs works.

TODOs:
- [x] Apply changes to yffi crate.
- [x] fix unobserve issues in ywasm: it doesn't accurately cancel callback.