### PR TITLE
feature: sync

### DIFF
--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -12,6 +12,7 @@ readme = "./README.md"
 
 [features]
 weak = []
+sync = []
 
 [dependencies]
 thiserror = "1"

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -214,14 +214,14 @@ pub struct Branch {
     pub(crate) deep_observers: Observer<DeepObserveFn>,
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + Send + Sync + 'static>;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + Send + Sync + 'static>;
 
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + 'static>;
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + 'static>;
 
 impl std::fmt::Debug for Branch {
@@ -534,7 +534,7 @@ impl Branch {
         path
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe<F>(&mut self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
@@ -542,7 +542,15 @@ impl Branch {
         self.observers.subscribe(Box::new(f))
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(feature = "sync"))]
+    pub fn observe<F>(&mut self, f: F) -> Subscription
+    where
+        F: Fn(&TransactionMut, &Event) + 'static,
+    {
+        self.observers.subscribe(Box::new(f))
+    }
+
+    #[cfg(feature = "sync")]
 
     pub fn observe_with<F>(&mut self, key: Origin, f: F)
     where
@@ -551,7 +559,7 @@ impl Branch {
         self.observers.subscribe_with(key, Box::new(f))
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_with<F>(&mut self, key: Origin, f: F)
     where
         F: Fn(&TransactionMut, &Event) + 'static,
@@ -563,7 +571,7 @@ impl Branch {
         self.observers.unsubscribe(&key)
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_deep<F>(&self, f: F) -> Subscription
     where
         F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
@@ -571,7 +579,7 @@ impl Branch {
         self.deep_observers.subscribe(Box::new(f))
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_deep_with<F>(&self, key: Origin, f: F)
     where
         F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
@@ -579,7 +587,7 @@ impl Branch {
         self.deep_observers.subscribe_with(key, Box::new(f))
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_deep_with<F>(&self, key: Origin, f: F)
     where
         F: Fn(&TransactionMut, &Events) + 'static,

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -579,6 +579,14 @@ impl Branch {
         self.deep_observers.subscribe(Box::new(f))
     }
 
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_deep<F>(&self, f: F) -> Subscription
+    where
+        F: Fn(&TransactionMut, &Events) + 'static,
+    {
+        self.deep_observers.subscribe(Box::new(f))
+    }
+
     #[cfg(feature = "sync")]
     pub fn observe_deep_with<F>(&self, key: Origin, f: F)
     where

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -226,7 +226,7 @@ impl Doc {
     /// commit.
     ///
     /// Returns a subscription, which will unsubscribe function when dropped.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_update_v1<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
     where
         F: Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static,
@@ -241,8 +241,24 @@ impl Doc {
     /// necessary or passed to remote peers right away. This callback is triggered on function
     /// commit.
     ///
+    /// Returns a subscription, which will unsubscribe function when dropped.
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_update_v1<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
+    where
+        F: Fn(&TransactionMut, &UpdateEvent) + 'static,
+    {
+        let mut r = self.store.try_borrow_mut()?;
+        let events = r.events.get_or_init();
+        Ok(events.update_v1_events.subscribe(Box::new(f)))
+    }
+
+    /// Subscribe callback function for any changes performed within transaction scope. These
+    /// changes are encoded using lib0 v1 encoding and can be decoded using [Update::decode_v1] if
+    /// necessary or passed to remote peers right away. This callback is triggered on function
+    /// commit.
+    ///
     /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_update_v1_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -262,7 +278,7 @@ impl Doc {
     /// commit.
     ///
     /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_update_v1_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -291,7 +307,7 @@ impl Doc {
     /// commit.
     ///
     /// Returns a subscription, which will unsubscribe function when dropped.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_update_v2<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
     where
         F: Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static,
@@ -306,8 +322,24 @@ impl Doc {
     /// necessary or passed to remote peers right away. This callback is triggered on function
     /// commit.
     ///
+    /// Returns a subscription, which will unsubscribe function when dropped.
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_update_v2<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
+    where
+        F: Fn(&TransactionMut, &UpdateEvent) + 'static,
+    {
+        let mut r = self.store.try_borrow_mut()?;
+        let events = r.events.get_or_init();
+        Ok(events.update_v2_events.subscribe(Box::new(f)))
+    }
+
+    /// Subscribe callback function for any changes performed within transaction scope. These
+    /// changes are encoded using lib0 v2 encoding and can be decoded using [Update::decode_v2] if
+    /// necessary or passed to remote peers right away. This callback is triggered on function
+    /// commit.
+    ///
     /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_update_v2_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -327,7 +359,7 @@ impl Doc {
     /// commit.
     ///
     /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_update_v2_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -352,7 +384,7 @@ impl Doc {
 
     /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
     /// deletions when a document transaction is committed.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_transaction_cleanup<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
     where
         F: Fn(&TransactionMut, &TransactionCleanupEvent) + Send + Sync + 'static,
@@ -364,7 +396,19 @@ impl Doc {
 
     /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
     /// deletions when a document transaction is committed.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_transaction_cleanup<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
+    where
+        F: Fn(&TransactionMut, &TransactionCleanupEvent) + 'static,
+    {
+        let mut r = self.store.try_borrow_mut()?;
+        let events = r.events.get_or_init();
+        Ok(events.transaction_cleanup_events.subscribe(Box::new(f)))
+    }
+
+    /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
+    /// deletions when a document transaction is committed.
+    #[cfg(feature = "sync")]
     pub fn observe_transaction_cleanup_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -380,7 +424,7 @@ impl Doc {
 
     /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
     /// deletions when a document transaction is committed.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_transaction_cleanup_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -403,7 +447,7 @@ impl Doc {
         Ok(events.transaction_cleanup_events.unsubscribe(&key.into()))
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_after_transaction<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
     where
         F: Fn(&mut TransactionMut) + Send + Sync + 'static,
@@ -413,7 +457,7 @@ impl Doc {
         Ok(events.after_transaction_events.subscribe(Box::new(f)))
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_after_transaction_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -427,7 +471,7 @@ impl Doc {
         Ok(())
     }
 
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_after_transaction_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -452,7 +496,7 @@ impl Doc {
 
     /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
     /// [Doc] will request a load.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_subdocs<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
     where
         F: Fn(&TransactionMut, &SubdocsEvent) + Send + Sync + 'static,
@@ -464,7 +508,19 @@ impl Doc {
 
     /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
     /// [Doc] will request a load.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_subdocs<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
+    where
+        F: Fn(&TransactionMut, &SubdocsEvent) + 'static,
+    {
+        let mut r = self.store.try_borrow_mut()?;
+        let events = r.events.get_or_init();
+        Ok(events.subdocs_events.subscribe(Box::new(f)))
+    }
+
+    /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
+    /// [Doc] will request a load.
+    #[cfg(feature = "sync")]
     pub fn observe_subdocs_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -480,7 +536,7 @@ impl Doc {
 
     /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
     /// [Doc] will request a load.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_subdocs_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -504,7 +560,7 @@ impl Doc {
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_destroy<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
     where
         F: Fn(&TransactionMut, &Doc) + Send + Sync + 'static,
@@ -515,7 +571,7 @@ impl Doc {
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(feature = "sync")]
     pub fn observe_destroy_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -539,7 +595,7 @@ impl Doc {
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn observe_destroy_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where
         K: Into<Origin>,
@@ -923,22 +979,22 @@ impl Transact for Doc {
 #[derive(Error, Debug)]
 pub enum TransactionAcqError {
     #[error("Failed to acquire read-only transaction. Drop read-write transaction and retry.")]
-    SharedAcqFailed(BorrowError),
+    SharedAcqFailed,
     #[error("Failed to acquire read-write transaction. Drop other transactions and retry.")]
-    ExclusiveAcqFailed(BorrowMutError),
+    ExclusiveAcqFailed,
     #[error("All references to a parent document containing this structure has been dropped.")]
     DocumentDropped,
 }
 
 impl From<BorrowError> for TransactionAcqError {
-    fn from(e: BorrowError) -> Self {
-        TransactionAcqError::SharedAcqFailed(e)
+    fn from(_: BorrowError) -> Self {
+        TransactionAcqError::SharedAcqFailed
     }
 }
 
 impl From<BorrowMutError> for TransactionAcqError {
-    fn from(e: BorrowMutError) -> Self {
-        TransactionAcqError::ExclusiveAcqFailed(e)
+    fn from(_: BorrowMutError) -> Self {
+        TransactionAcqError::ExclusiveAcqFailed
     }
 }
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -571,6 +571,17 @@ impl Doc {
     }
 
     /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_destroy<F>(&self, f: F) -> Result<Subscription, BorrowMutError>
+    where
+        F: Fn(&TransactionMut, &Doc) + 'static,
+    {
+        let mut r = self.store.try_borrow_mut()?;
+        let events = r.events.get_or_init();
+        Ok(events.destroy_events.subscribe(Box::new(f)))
+    }
+
+    /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
     #[cfg(feature = "sync")]
     pub fn observe_destroy_with<K, F>(&self, key: K, f: F) -> Result<(), BorrowMutError>
     where

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -10,6 +10,12 @@
 //!
 //! A **Document** is the access point to create shared types, and to listen to update events.
 //!
+//! # Features
+//!
+//! - `weak` this feature enables weak references and quotations (see: [crate::WeakRef]).
+//! - `sync` this feature modifies observers callback constraints to use `Send` and `Sync` traits.
+//!   These are required when using yrs features in multithreaded environments.
+//!
 //! # Quick start
 //!
 //! Let's discuss basic features of Yrs. We'll introduce these concepts starting from

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -464,27 +464,27 @@ impl<'doc> Iterator for SubdocGuids<'doc> {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 pub type TransactionCleanupFn =
     Box<dyn Fn(&TransactionMut, &TransactionCleanupEvent) + Send + Sync + 'static>;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 pub type AfterTransactionFn = Box<dyn Fn(&mut TransactionMut) + Send + Sync + 'static>;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 pub type UpdateFn = Box<dyn Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static>;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 pub type SubdocsFn = Box<dyn Fn(&TransactionMut, &SubdocsEvent) + Send + Sync + 'static>;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 pub type DestroyFn = Box<dyn Fn(&TransactionMut, &Doc) + Send + Sync + 'static>;
 
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 pub type TransactionCleanupFn = Box<dyn Fn(&TransactionMut, &TransactionCleanupEvent) + 'static>;
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 pub type AfterTransactionFn = Box<dyn Fn(&mut TransactionMut) + 'static>;
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 pub type UpdateFn = Box<dyn Fn(&TransactionMut, &UpdateEvent) + 'static>;
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 pub type SubdocsFn = Box<dyn Fn(&TransactionMut, &SubdocsEvent) + 'static>;
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 pub type DestroyFn = Box<dyn Fn(&TransactionMut, &Doc) + 'static>;
 
 #[derive(Default)]

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -10,14 +10,14 @@ use crate::block::ClientID;
 use crate::sync::{Clock, Timestamp};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
-use crate::{Doc, Observer, Origin, Subscription};
+use crate::{Doc, Observer, Origin};
 
 const NULL_STR: &str = "null";
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(feature = "sync")]
 type AwarenessUpdateFn = Box<dyn Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static>;
 
-#[cfg(target_family = "wasm")]
+#[cfg(not(feature = "sync"))]
 type AwarenessUpdateFn = Box<dyn Fn(&Awareness, &Event, Option<&Origin>) + 'static>;
 
 /// The Awareness class implements a simple shared state protocol that can be used for non-persistent
@@ -68,8 +68,8 @@ impl Awareness {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    #[cfg(not(target_family = "wasm"))]
-    pub fn on_update<F>(&self, f: F) -> Subscription
+    #[cfg(feature = "sync")]
+    pub fn on_update<F>(&self, f: F) -> crate::Subscription
     where
         F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
@@ -77,7 +77,16 @@ impl Awareness {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(feature = "sync"))]
+    pub fn on_update<F>(&self, f: F) -> crate::Subscription
+    where
+        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+    {
+        self.on_update.subscribe(Box::new(f))
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    #[cfg(feature = "sync")]
     pub fn on_update_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
@@ -87,7 +96,7 @@ impl Awareness {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn on_update_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
@@ -105,8 +114,8 @@ impl Awareness {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    #[cfg(not(target_family = "wasm"))]
-    pub fn on_change<F>(&self, f: F) -> Subscription
+    #[cfg(feature = "sync")]
+    pub fn on_change<F>(&self, f: F) -> crate::Subscription
     where
         F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
@@ -114,7 +123,16 @@ impl Awareness {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(feature = "sync"))]
+    pub fn on_change<F>(&self, f: F) -> crate::Subscription
+    where
+        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+    {
+        self.on_change.subscribe(Box::new(f))
+    }
+
+    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    #[cfg(feature = "sync")]
     pub fn on_change_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
@@ -124,7 +142,7 @@ impl Awareness {
     }
 
     /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    #[cfg(target_family = "wasm")]
+    #[cfg(not(feature = "sync"))]
     pub fn on_change_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1,6 +1,4 @@
-use crate::block::{
-    EmbedPrelim, Item, ItemContent, ItemPosition, ItemPtr, Prelim, SplittableString, Unused,
-};
+use crate::block::{EmbedPrelim, Item, ItemContent, ItemPosition, ItemPtr, Prelim, Unused};
 use crate::transaction::TransactionMut;
 use crate::types::{
     AsPrelim, Attrs, Branch, BranchPtr, Delta, Out, Path, RootRef, SharedRef, TypePtr, TypeRef,


### PR DESCRIPTION
This PR modifies previous conditional observer API compilation to make use of dedicated feature flag `sync` instead of hardcoding it to `wasm` family target. This way users can pick if their observers are supposed to work in multithreaded environment (at least withing Rust guarantees) using feature flags.