### PR TITLE
MapRef::get_or_init and DefaultPrelim trait

### DIFF
--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -3,8 +3,8 @@ use crate::block_iter::BlockIter;
 use crate::moving::StickyIndex;
 use crate::transaction::TransactionMut;
 use crate::types::{
-    event_change_set, AsPrelim, Branch, BranchPtr, Change, ChangeSet, In, Out, Path, RootRef,
-    SharedRef, ToJson, TypeRef,
+    event_change_set, AsPrelim, Branch, BranchPtr, Change, ChangeSet, DefaultPrelim, In, Out, Path,
+    RootRef, SharedRef, ToJson, TypeRef,
 };
 use crate::{Any, Assoc, DeepObservable, IndexedSequence, Observable, ReadTxn, ID};
 use std::borrow::Borrow;
@@ -153,6 +153,15 @@ impl AsPrelim for ArrayRef {
             prelim.push(value.as_prelim(txn));
         }
         ArrayPrelim(prelim)
+    }
+}
+
+impl DefaultPrelim for ArrayRef {
+    type Prelim = ArrayPrelim;
+
+    #[inline]
+    fn default_prelim() -> Self::Prelim {
+        ArrayPrelim::default()
     }
 }
 

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -352,6 +352,16 @@ pub trait AsPrelim {
     fn as_prelim<T: ReadTxn>(&self, txn: &T) -> Self::Prelim;
 }
 
+/// Trait which allows to generate a [Prelim]-compatible type that - when integrated - will be
+/// converted into an instance of a current type.
+pub trait DefaultPrelim {
+    type Prelim: Prelim<Return = Self>;
+
+    /// Returns an instance of [Prelim]-compatible type, which will turn into reference of a current
+    /// type after being integrated into the document store.
+    fn default_prelim() -> Self::Prelim;
+}
+
 /// Trait implemented by all Y-types, allowing for observing events which are emitted by
 /// nested types.
 #[cfg(feature = "sync")]

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1,7 +1,8 @@
 use crate::block::{EmbedPrelim, Item, ItemContent, ItemPosition, ItemPtr, Prelim, Unused};
 use crate::transaction::TransactionMut;
 use crate::types::{
-    AsPrelim, Attrs, Branch, BranchPtr, Delta, Out, Path, RootRef, SharedRef, TypePtr, TypeRef,
+    AsPrelim, Attrs, Branch, BranchPtr, DefaultPrelim, Delta, Out, Path, RootRef, SharedRef,
+    TypePtr, TypeRef,
 };
 use crate::utils::OptionExt;
 use crate::*;
@@ -468,6 +469,15 @@ impl AsPrelim for TextRef {
             .map(|diff| Delta::Inserted(diff.insert.as_prelim(txn), diff.attributes))
             .collect();
         DeltaPrelim(delta)
+    }
+}
+
+impl DefaultPrelim for TextRef {
+    type Prelim = TextPrelim;
+
+    #[inline]
+    fn default_prelim() -> Self::Prelim {
+        TextPrelim::default()
     }
 }
 

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -12,8 +12,8 @@ use crate::block_iter::BlockIter;
 use crate::transaction::TransactionMut;
 use crate::types::text::{diff_between, TextEvent, YChange};
 use crate::types::{
-    event_change_set, event_keys, AsPrelim, Branch, BranchPtr, Change, ChangeSet, Delta, Entries,
-    EntryChange, MapRef, Out, Path, RootRef, SharedRef, ToJson, TypePtr, TypeRef,
+    event_change_set, event_keys, AsPrelim, Branch, BranchPtr, Change, ChangeSet, DefaultPrelim,
+    Delta, Entries, EntryChange, MapRef, Out, Path, RootRef, SharedRef, ToJson, TypePtr, TypeRef,
 };
 use crate::{
     Any, ArrayRef, BranchID, DeepObservable, GetString, In, IndexedSequence, Map, Observable,
@@ -658,6 +658,15 @@ impl AsPrelim for XmlTextRef {
     }
 }
 
+impl DefaultPrelim for XmlTextRef {
+    type Prelim = XmlTextPrelim;
+
+    #[inline]
+    fn default_prelim() -> Self::Prelim {
+        XmlTextPrelim::default()
+    }
+}
+
 /// A preliminary type that will be materialized into an [XmlTextRef] once it will be integrated
 /// into Yrs document.
 #[repr(transparent)]
@@ -865,6 +874,15 @@ impl AsPrelim for XmlFragmentRef {
             })
             .collect();
         XmlFragmentPrelim(children)
+    }
+}
+
+impl DefaultPrelim for XmlFragmentRef {
+    type Prelim = XmlFragmentPrelim;
+
+    #[inline]
+    fn default_prelim() -> Self::Prelim {
+        XmlFragmentPrelim::default()
     }
 }
 


### PR DESCRIPTION
This PR introduces 2 new features:
1. `DefaultPrelim` trait implemented by `MapRef`/`ArrayRef`/`TextRef`/`XmlFragmentRef`/`XmlTextRef`, which allows for automatic conversion between these types and their prelim equivalents.
1. `MapRef::get_or_init` method which enables returning an element of a given type or initialize it to a given type if it didn't met the expectation. It's using `DefaultPrelim` type to perform initialization.