### PR TITLE
make yrs::Any conversion to serde_json::Value more seamless

### DIFF
--- a/yrs/src/encoding/serde/mod.rs
+++ b/yrs/src/encoding/serde/mod.rs
@@ -7,8 +7,10 @@ pub use ser::to_any;
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::any;
     use crate::any::Any;
     use serde::{Deserialize, Serialize};
+    use serde_json::json;
     use std::collections::HashMap;
 
     fn roundtrip(any: &Any) -> Any {
@@ -214,5 +216,57 @@ mod test {
             any,
             serde_json::from_str::<Any>(serde_json::to_string(&any).unwrap().as_str()).unwrap()
         );
+    }
+
+    #[test]
+    fn any_is_serde_json_convertible() {
+        let any = any!({
+            "bool": true,
+            "int": 1,
+            "negativeInt": -1,
+            "realNumber": -123.2387f64,
+            "null": Any::Null,
+            "map": {
+                "bool": true,
+                "int": 1,
+                "negativeInt": -1,
+                "realNumber": -123.2387f64,
+                "null": Any::Null
+            },
+            "key6":[
+                true,
+                1,
+                -1,
+                -123.2387f64,
+                Any::Null
+            ]
+        });
+
+        let expected = json!({
+            "bool": true,
+            "int": 1,
+            "negativeInt": -1,
+            "realNumber": -123.2387f64,
+            "null": Any::Null,
+            "map": {
+                "bool": true,
+                "int": 1,
+                "negativeInt": -1,
+                "realNumber": -123.2387f64,
+                "null": Any::Null
+            },
+            "key6":[
+                true,
+                1,
+                -1,
+                -123.2387f64,
+                Any::Null
+            ]
+        });
+
+        let json = serde_json::to_value(&any).unwrap();
+        assert_eq!(json, expected);
+        let any2: Any = serde_json::from_value(json).unwrap();
+        assert_eq!(any, any2);
     }
 }

--- a/yrs/src/encoding/serde/ser.rs
+++ b/yrs/src/encoding/serde/ser.rs
@@ -22,7 +22,13 @@ impl Serialize for Any {
             Any::Null => serializer.serialize_none(),
             Any::Undefined => serializer.serialize_none(),
             Any::Bool(value) => serializer.serialize_bool(*value),
-            Any::Number(value) => serializer.serialize_f64(*value),
+            Any::Number(value) => {
+                if value.fract() == 0.0 {
+                    serializer.serialize_i64(*value as i64)
+                } else {
+                    serializer.serialize_f64(*value)
+                }
+            }
             Any::BigInt(value) => serializer.serialize_i64(*value),
             Any::String(value) => serializer.serialize_str(value.as_ref()),
             Any::Array(values) => {

--- a/yrs/src/encoding/serde/ser.rs
+++ b/yrs/src/encoding/serde/ser.rs
@@ -23,10 +23,13 @@ impl Serialize for Any {
             Any::Undefined => serializer.serialize_none(),
             Any::Bool(value) => serializer.serialize_bool(*value),
             Any::Number(value) => {
-                if value.fract() == 0.0 {
-                    serializer.serialize_i64(*value as i64)
+                let value = *value;
+                // since JS doesn't clearly recognise difference between integers and floats,
+                // we check if it's possible to perform lossless conversion to i64
+                if value as i64 as f64 == value {
+                    serializer.serialize_i64(value as i64)
                 } else {
-                    serializer.serialize_f64(*value)
+                    serializer.serialize_f64(value)
                 }
             }
             Any::BigInt(value) => serializer.serialize_i64(*value),
@@ -515,7 +518,7 @@ mod test {
     fn test_serialize_any_to_array() {
         assert_eq!(
             serde_json::to_string(&Any::from(vec![Any::from(true), Any::from(1)])).unwrap(),
-            "[true,1.0]"
+            "[true,1]"
         );
     }
 
@@ -527,7 +530,7 @@ mod test {
                 ("key2".into(), Any::from(1))
             ])))
             .unwrap(),
-            json!({"key1":true, "key2":1.0})
+            json!({"key1":true, "key2":1})
         );
     }
 
@@ -550,7 +553,7 @@ mod test {
                 )
             ])))
             .unwrap(),
-            json!({"key1": true, "key2":1.0, "key3":{"key4":true, "key5":1.0}, "key6": [true,1.0]})
+            json!({"key1": true, "key2":1, "key3":{"key4":true, "key5":1}, "key6": [true,1]})
         );
     }
 


### PR DESCRIPTION
This PR introduces tests for conversion between common `Any` and `serde_json::Value`s. The crux here is that `Any` by default supports only floating point numbers (because of Yjs compatibility), so that even integers are converted to them. However for many cases, we actually want to use integers. For that in serde serialiser we first check if number can be converted to integer (it has no fractional part).