### PR TITLE
MapRef methods: get_as and try_update

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -245,6 +245,16 @@ typedef struct YSubscription {} YSubscription;
  */
 #define ERR_NOT_ENOUGH_MEMORY 7
 
+/**
+ * Error code: conversion attempt to specific Rust type was not possible.
+ */
+#define ERR_TYPE_MISMATCH 8
+
+/**
+ * Error code: miscallaneous error comming from serde, not covered by other error codes.
+ */
+#define ERR_CUSTOM 9
+
 #define YCHANGE_ADD 1
 
 #define YCHANGE_RETAIN 0

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1155,6 +1155,12 @@ pub const ERR_CODE_OTHER: u8 = 6;
 /// Error code: not enough memory to perform an operation.
 pub const ERR_NOT_ENOUGH_MEMORY: u8 = 7;
 
+/// Error code: conversion attempt to specific Rust type was not possible.
+pub const ERR_TYPE_MISMATCH: u8 = 8;
+
+/// Error code: miscallaneous error comming from serde, not covered by other error codes.
+pub const ERR_CUSTOM: u8 = 9;
+
 fn err_code(e: Error) -> u8 {
     match e {
         Error::InvalidVarInt => ERR_CODE_VAR_INT,
@@ -1162,6 +1168,8 @@ fn err_code(e: Error) -> u8 {
         Error::UnexpectedValue => ERR_CODE_UNEXPECTED_VALUE,
         Error::InvalidJSON(_) => ERR_CODE_INVALID_JSON,
         Error::NotEnoughMemory(_) => ERR_NOT_ENOUGH_MEMORY,
+        Error::TypeMismatch(_) => ERR_TYPE_MISMATCH,
+        Error::Custom(_) => ERR_CUSTOM,
     }
 }
 

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -674,7 +674,7 @@ impl<'a, T: ReadTxn> Iterator for Iter<'a, T> {
 /// let txt2 = root.get_or_create(&mut doc2.transact_mut());
 ///
 /// // instances of TextRef point to different heap objects
-/// assert_ne!(txt1.as_ref() as *const _, txt2.as_ref() as *const _);
+/// assert_ne!(&txt1 as *const _, &txt2 as *const _);
 ///
 /// // logical descriptors of both TextRef are the same as they refer to the
 /// // same logical entity

--- a/yrs/src/encoding/read.rs
+++ b/yrs/src/encoding/read.rs
@@ -1,4 +1,5 @@
 use crate::encoding::varint::{Signed, SignedVarInt, VarInt};
+use std::any::type_name;
 use std::collections::TryReserveError;
 use thiserror::Error;
 
@@ -18,6 +19,18 @@ pub enum Error {
 
     #[error("JSON parsing error: {0}")]
     InvalidJSON(#[from] serde_json::Error),
+
+    #[error("couldn't deserialize to target type of {0}")]
+    TypeMismatch(&'static str),
+
+    #[error("{0}")]
+    Custom(String),
+}
+
+impl Error {
+    pub fn type_mismatch<T>() -> Self {
+        Error::TypeMismatch(type_name::<T>())
+    }
 }
 
 #[derive(Default)]

--- a/yrs/src/out.rs
+++ b/yrs/src/out.rs
@@ -1,10 +1,13 @@
 use crate::block::{ItemContent, ItemPtr};
 use crate::branch::{Branch, BranchPtr};
+use crate::encoding::read::Error;
 use crate::types::{AsPrelim, ToJson};
 use crate::{
     any, Any, ArrayRef, Doc, GetString, In, MapPrelim, MapRef, ReadTxn, TextRef, XmlElementRef,
     XmlFragmentRef, XmlTextRef,
 };
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer};
 use std::convert::TryFrom;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -45,6 +48,8 @@ impl Default for Out {
 }
 
 impl Out {
+    /// Attempts to convert current [Out] value directly onto a different type, as along as it
+    /// implements [TryFrom] trait. If conversion is not possible, the original value is returned.
     #[inline]
     pub fn cast<T>(self) -> Result<T, Self>
     where

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -101,9 +101,10 @@ impl IndexedSequence for TextRef {}
 #[cfg(feature = "weak")]
 impl crate::Quotable for TextRef {}
 
-impl Into<XmlTextRef> for TextRef {
-    fn into(self) -> XmlTextRef {
-        XmlTextRef::from(self.0)
+impl AsRef<XmlTextRef> for TextRef {
+    #[inline]
+    fn as_ref(&self) -> &XmlTextRef {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -117,7 +118,7 @@ impl GetString for TextRef {
     /// render formatting attributes or embedded content. In order to retrieve it, use
     /// [TextRef::diff] method.
     fn get_string<T: ReadTxn>(&self, _txn: &T) -> String {
-        let mut start = self.as_ref().start;
+        let mut start = self.0.start;
         let mut s = String::new();
         while let Some(item) = start.as_deref() {
             if !item.is_deleted() {

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -1882,11 +1882,11 @@ mod test {
     fn basic_xml_text() {
         let d1 = Doc::with_client_id(1);
         let txt1 = d1.get_or_insert_text("text");
-        let txt1 = XmlTextRef::from(BranchPtr::from(txt1.as_ref()));
+        let txt1: &XmlTextRef = txt1.as_ref();
         let a1 = d1.get_or_insert_array("array");
         let d2 = Doc::with_client_id(2);
         let txt2 = d2.get_or_insert_text("text");
-        let txt2 = XmlTextRef::from(BranchPtr::from(txt2.as_ref()));
+        let txt2: &XmlTextRef = txt2.as_ref();
 
         txt1.insert(&mut d1.transact_mut(), 0, "abcd"); // 'abcd'
         let l1 = {
@@ -1915,9 +1915,9 @@ mod test {
     fn quote_formatted_text() {
         let doc = Doc::with_client_id(1);
         let txt1 = doc.get_or_insert_text("text1");
-        let txt1 = XmlTextRef::from(BranchPtr::from(txt1.as_ref()));
+        let txt1: &XmlTextRef = txt1.as_ref();
         let txt2 = doc.get_or_insert_text("text2");
-        let txt2 = XmlTextRef::from(BranchPtr::from(txt2.as_ref()));
+        let txt2: &XmlTextRef = txt2.as_ref();
         let array = doc.get_or_insert_array("array");
         txt1.insert(&mut doc.transact_mut(), 0, "abcde");
         let b = Attrs::from([("b".into(), true.into())]);

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -241,21 +241,17 @@ impl Xml for XmlElementRef {}
 impl XmlFragment for XmlElementRef {}
 impl IndexedSequence for XmlElementRef {}
 
-impl Into<XmlFragmentRef> for XmlElementRef {
-    fn into(self) -> XmlFragmentRef {
-        XmlFragmentRef(self.0)
+impl AsRef<XmlFragmentRef> for XmlElementRef {
+    #[inline]
+    fn as_ref(&self) -> &XmlFragmentRef {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
-impl Into<ArrayRef> for XmlElementRef {
-    fn into(self) -> ArrayRef {
-        ArrayRef::from(self.0)
-    }
-}
-
-impl Into<MapRef> for XmlElementRef {
-    fn into(self) -> MapRef {
-        MapRef::from(self.0)
+impl AsRef<ArrayRef> for XmlElementRef {
+    #[inline]
+    fn as_ref(&self) -> &ArrayRef {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -572,9 +568,10 @@ impl IndexedSequence for XmlTextRef {}
 #[cfg(feature = "weak")]
 impl crate::Quotable for XmlTextRef {}
 
-impl Into<TextRef> for XmlTextRef {
-    fn into(self) -> TextRef {
-        TextRef::from(self.0)
+impl AsRef<TextRef> for XmlTextRef {
+    #[inline]
+    fn as_ref(&self) -> &TextRef {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -791,9 +788,16 @@ impl IndexedSequence for XmlFragmentRef {}
 
 impl XmlFragmentRef {
     pub fn parent(&self) -> Option<XmlOut> {
-        let item = self.as_ref().item?;
+        let item = self.0.item?;
         let parent = item.parent.as_branch()?;
         XmlOut::try_from(*parent).ok()
+    }
+}
+
+impl AsRef<ArrayRef> for XmlFragmentRef {
+    #[inline]
+    fn as_ref(&self) -> &ArrayRef {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -938,7 +942,7 @@ impl Map for XmlHookRef {}
 
 impl ToJson for XmlHookRef {
     fn to_json<T: ReadTxn>(&self, txn: &T) -> Any {
-        let map: MapRef = self.clone().into();
+        let map: &MapRef = self.as_ref();
         map.to_json(txn)
     }
 }
@@ -962,9 +966,10 @@ impl From<BranchPtr> for XmlHookRef {
     }
 }
 
-impl Into<MapRef> for XmlHookRef {
-    fn into(self) -> MapRef {
-        MapRef::from(self.0)
+impl AsRef<MapRef> for XmlHookRef {
+    #[inline]
+    fn as_ref(&self) -> &MapRef {
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -1861,7 +1866,7 @@ mod test {
         let update = Update::decode_v1(data).unwrap();
         let doc = Doc::new();
         let txt = doc.get_or_insert_text("test");
-        let txt = XmlTextRef::from(BranchPtr::from(txt.as_ref()));
+        let txt: &XmlTextRef = txt.as_ref();
         let mut txn = doc.transact_mut();
 
         txn.apply_update(update);
@@ -1881,7 +1886,7 @@ mod test {
         let update = Update::decode_v2(data).unwrap();
         let doc = Doc::new();
         let txt = doc.get_or_insert_text("test");
-        let txt = XmlTextRef::from(BranchPtr::from(txt.as_ref()));
+        let txt: &XmlTextRef = txt.as_ref();
         let mut txn = doc.transact_mut();
 
         txn.apply_update(update);


### PR DESCRIPTION
Changes in this PR:
1. `MapRef::get_as`: a convenience method that attempts to convert MapRef entry into strongly typed Rust value.
2. `MapRef::try_update`: a convenience method that attempts to update a MapRef entry, but only if the inserted value differs from existing one. This may be useful in order to prevent overriding entry with the same value, which would cause tombstone accumulation.
3. Replaced shared type conversions from `Into` to `AsRef`.
4. Deserializing `Any` value now returns a `yrs::encoding::read::Error`.