### PR TITLE
release-v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,14 +1079,14 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "yffi"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "yrs",
 ]
 
 [[package]]
 name = "yrs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "arc-swap",
  "assert_matches2",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -1123,13 +1123,13 @@ uint8_t ydoc_should_load(YDoc *doc);
  */
 uint8_t ydoc_auto_load(YDoc *doc);
 
-YSubscription *ydoc_observe_updates_v1(YDoc *doc,
-                                       void *state,
-                                       void (*cb)(void*, uint32_t, const char*));
+YSubscription *ydoc_observe_updates_v1(YDoc *doc, void *state, void (*cb)(void*,
+                                                                          uint32_t,
+                                                                          const char*));
 
-YSubscription *ydoc_observe_updates_v2(YDoc *doc,
-                                       void *state,
-                                       void (*cb)(void*, uint32_t, const char*));
+YSubscription *ydoc_observe_updates_v2(YDoc *doc, void *state, void (*cb)(void*,
+                                                                          uint32_t,
+                                                                          const char*));
 
 YSubscription *ydoc_observe_after_transaction(YDoc *doc,
                                               void *state,
@@ -2154,9 +2154,8 @@ void yunobserve(YSubscription *subscription);
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yunobserve` function.
  */
-YSubscription *ytext_observe(const Branch *txt,
-                             void *state,
-                             void (*cb)(void*, const struct YTextEvent*));
+YSubscription *ytext_observe(const Branch *txt, void *state, void (*cb)(void*,
+                                                                        const struct YTextEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YMap` instance. Callbacks
@@ -2164,9 +2163,8 @@ YSubscription *ytext_observe(const Branch *txt,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yunobserve` function.
  */
-YSubscription *ymap_observe(const Branch *map,
-                            void *state,
-                            void (*cb)(void*, const struct YMapEvent*));
+YSubscription *ymap_observe(const Branch *map, void *state, void (*cb)(void*,
+                                                                       const struct YMapEvent*));
 
 /**
  * Subscribes a given callback function `cb` to changes made by this `YArray` instance. Callbacks
@@ -2206,9 +2204,9 @@ YSubscription *yxmltext_observe(const Branch *xml,
  * Returns a subscription ID which can be then used to unsubscribe this callback by using
  * `yunobserve` function.
  */
-YSubscription *yobserve_deep(Branch *ytype,
-                             void *state,
-                             void (*cb)(void*, uint32_t, const struct YEvent*));
+YSubscription *yobserve_deep(Branch *ytype, void *state, void (*cb)(void*,
+                                                                    uint32_t,
+                                                                    const struct YEvent*));
 
 /**
  * Returns a pointer to a shared collection, which triggered passed event `e`.

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.19.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.19.1", features = ["weak"] }
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.19.0"
+version = "0.19.1"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.19.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.19.1", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
- New methods: 
  - `Array::get_as` for casting `Out` value getter to strong Rust types.
  - `Map::get_as` for casting `Out` value getter to strong Rust types.
  - `Map::try_update` for conditional insertion of values (to prevent unnecessary tombstone generation).
  - `UndoManager::undo_stack` and `UndoManager::redo_stack` accessor methods to inspect corresponding undo manager data.
- Removed `Clone` trait from `UndoManager` as it's unsafe for practical use.