### PR TITLE
Remove stale comment about Subscriptionid

### DIFF
--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -265,19 +265,11 @@ where
 
 /// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
 /// callback when dropped.
-///
-/// If implicit callback unsubscribe on drop is undesired, this structure can be cast [into](Subscription::into)
-/// [SubscriptionId] which is an identifier of the same subscription, which in turn must be used
-/// manually via [Observer::unsubscribe] to perform usubscribe.
 #[cfg(feature = "sync")]
 pub type Subscription = Arc<dyn Drop + Send + Sync + 'static>;
 
 /// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
 /// callback when dropped.
-///
-/// If implicit callback unsubscribe on drop is undesired, this structure can be cast [into](Subscription::into)
-/// [SubscriptionId] which is an identifier of the same subscription, which in turn must be used
-/// manually via [Observer::unsubscribe] to perform usubscribe.
 #[cfg(not(feature = "sync"))]
 pub type Subscription = Arc<dyn Drop + 'static>;
 

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -265,11 +265,17 @@ where
 
 /// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
 /// callback when dropped.
+///
+/// If you need to send the Subscription handle to another thread, you may wish to enable
+/// the `sync` feature such that Subscription implements `Send+Sync`.
 #[cfg(feature = "sync")]
 pub type Subscription = Arc<dyn Drop + Send + Sync + 'static>;
 
 /// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
 /// callback when dropped.
+///
+/// If you need to send the Subscription handle to another thread, you may wish to enable
+/// the `sync` feature such that Subscription implements `Send+Sync`.
 #[cfg(not(feature = "sync"))]
 pub type Subscription = Arc<dyn Drop + 'static>;
 


### PR DESCRIPTION
SubscriptionId was removed some time ago, and, as far as I can tell, there isn't functionality to replace it. I stumbled on this until I realized I needed to turn on the "sync" feature to pass a subscription between threads.