### PR TITLE
make sure that empty items are never created

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -398,7 +398,7 @@ impl ItemPtr {
             TypePtr::Branch(parent_branch),
             item.parent_sub.clone(),
             item.content.clone(),
-        );
+        )?;
         item.redone = Some(*redone_item.id());
         redone_item.info.set_keep();
         let mut block_ptr = ItemPtr::from(&mut redone_item);
@@ -1216,13 +1216,16 @@ impl Item {
         parent: TypePtr,
         parent_sub: Option<Arc<str>>,
         content: ItemContent,
-    ) -> Box<Item> {
+    ) -> Option<Box<Item>> {
         let info = ItemFlags::new(if content.is_countable() {
             ITEM_FLAG_COUNTABLE
         } else {
             0
         });
         let len = content.len(OffsetKind::Utf16);
+        if len == 0 {
+            return None;
+        }
         let root_name = if let TypePtr::Named(root) = &parent {
             Some(root.clone())
         } else {
@@ -1250,7 +1253,7 @@ impl Item {
                 b.name = root_name;
             }
         }
-        item
+        Some(item)
     }
 
     /// Checks if provided `id` fits inside of updates defined within bounds of current [Item].

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -457,7 +457,11 @@ impl BlockIter {
         }
     }
 
-    pub fn insert_contents<V: Prelim>(&mut self, txn: &mut TransactionMut, value: V) -> ItemPtr {
+    pub fn insert_contents<V: Prelim>(
+        &mut self,
+        txn: &mut TransactionMut,
+        value: V,
+    ) -> Option<ItemPtr> {
         self.reduce_moves(txn);
         self.split_rel(txn);
         let id = {
@@ -484,7 +488,7 @@ impl BlockIter {
             parent,
             None,
             content,
-        );
+        )?;
         let mut block_ptr = ItemPtr::from(&mut block);
 
         block_ptr.integrate(txn, 0);
@@ -502,7 +506,7 @@ impl BlockIter {
             self.reached_end = true;
         }
 
-        block_ptr
+        Some(block_ptr)
     }
 
     pub fn insert_move(&mut self, txn: &mut TransactionMut, start: StickyIndex, end: StickyIndex) {

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -477,7 +477,7 @@ impl Branch {
         txn: &mut TransactionMut,
         index: u32,
         value: V,
-    ) -> ItemPtr {
+    ) -> Option<ItemPtr> {
         let (start, parent) = {
             if index <= self.len() {
                 (self.start, BranchPtr::from(self))

--- a/yrs/src/out.rs
+++ b/yrs/src/out.rs
@@ -1,13 +1,10 @@
 use crate::block::{ItemContent, ItemPtr};
 use crate::branch::{Branch, BranchPtr};
-use crate::encoding::read::Error;
 use crate::types::{AsPrelim, ToJson};
 use crate::{
     any, Any, ArrayRef, Doc, GetString, In, MapPrelim, MapRef, ReadTxn, TextRef, XmlElementRef,
     XmlFragmentRef, XmlTextRef,
 };
-use serde::de::Visitor;
-use serde::{Deserialize, Deserializer};
 use std::convert::TryFrom;
 use std::fmt::Formatter;
 use std::sync::Arc;

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -225,7 +225,8 @@ impl Store {
             slice.trim_start(offset);
             slice.encode(encoder);
             for i in (start + 1)..blocks.len() {
-                blocks[i].as_slice().encode(encoder);
+                let block = &blocks[i];
+                block.as_slice().encode(encoder);
             }
         }
     }

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -56,7 +56,8 @@ fn text_insert_delete() {
             TypePtr::Named("type".into()),
             None,
             ItemContent::Deleted(3),
-        ),
+        )
+        .unwrap(),
         Item::new(
             ID::new(CLIENT_ID, 3),
             None,
@@ -66,7 +67,8 @@ fn text_insert_delete() {
             TypePtr::Unknown,
             None,
             ItemContent::String("ab".into()),
-        ),
+        )
+        .unwrap(),
         Item::new(
             ID::new(CLIENT_ID, 5),
             None,
@@ -76,7 +78,8 @@ fn text_insert_delete() {
             TypePtr::Unknown,
             None,
             ItemContent::Deleted(1),
-        ),
+        )
+        .unwrap(),
         Item::new(
             ID::new(CLIENT_ID, 6),
             None,
@@ -86,7 +89,8 @@ fn text_insert_delete() {
             TypePtr::Unknown,
             None,
             ItemContent::Deleted(1),
-        ),
+        )
+        .unwrap(),
         Item::new(
             ID::new(CLIENT_ID, 7),
             None,
@@ -96,7 +100,8 @@ fn text_insert_delete() {
             TypePtr::Unknown,
             None,
             ItemContent::String("hi".into()),
-        ),
+        )
+        .unwrap(),
     ];
     let expected_ds = {
         let mut ds = IdSet::new();
@@ -154,6 +159,7 @@ fn map_set() {
             Some("k1".into()),
             ItemContent::Any(vec![Any::from("v1")]),
         )
+        .unwrap()
         .into(),
         Item::new(
             ID::new(CLIENT_ID, 1),
@@ -165,6 +171,7 @@ fn map_set() {
             Some("k2".into()),
             ItemContent::Any(vec![Any::from("v2")]),
         )
+        .unwrap()
         .into(),
     ];
 
@@ -207,6 +214,7 @@ fn array_insert() {
         None,
         ItemContent::Any(vec![Any::String("a".into()), Any::String("b".into())]),
     )
+    .unwrap()
     .into()];
 
     let payload = &[
@@ -250,6 +258,7 @@ fn xml_fragment_insert() {
             None,
             ItemContent::Type(Branch::new(TypeRef::XmlText)),
         )
+        .unwrap()
         .into(),
         Item::new(
             ID::new(CLIENT_ID, 1),
@@ -261,6 +270,7 @@ fn xml_fragment_insert() {
             None,
             ItemContent::Type(Branch::new(TypeRef::XmlElement("node-name".into()))),
         )
+        .unwrap()
         .into(),
     ];
 

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -731,7 +731,7 @@ impl<'doc> TransactionMut<'doc> {
         pos: &block::ItemPosition,
         value: T,
         parent_sub: Option<Arc<str>>,
-    ) -> ItemPtr {
+    ) -> Option<ItemPtr> {
         let (left, right, origin, id) = {
             let store = self.store_mut();
             let left = pos.left;
@@ -761,7 +761,7 @@ impl<'doc> TransactionMut<'doc> {
             pos.parent.clone(),
             parent_sub,
             content,
-        );
+        )?;
         let mut block_ptr = ItemPtr::from(&mut block);
 
         block_ptr.integrate(self, 0);
@@ -772,7 +772,7 @@ impl<'doc> TransactionMut<'doc> {
             remainder.integrate(self, inner_ref.unwrap().into())
         }
 
-        block_ptr
+        Some(block_ptr)
     }
 
     fn call_type_observers(

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -214,7 +214,10 @@ pub trait Array: AsRef<Branch> + Sized {
         T: IntoIterator<Item = V>,
         V: Into<Any>,
     {
-        self.insert(txn, index, RangePrelim(values));
+        let prelim = RangePrelim::new(values);
+        if !prelim.is_empty() {
+            self.insert(txn, index, prelim);
+        }
     }
 
     /// Inserts given `value` at the end of the current array.
@@ -554,21 +557,29 @@ impl Into<EmbedPrelim<ArrayPrelim>> for ArrayPrelim {
 
 /// Prelim range defines a way to insert multiple elements effectively at once one after another
 /// in an efficient way, provided that these elements correspond to a primitive JSON-like types.
-struct RangePrelim<T, V>(T)
-where
-    T: IntoIterator<Item = V>,
-    V: Into<Any>;
+#[repr(transparent)]
+struct RangePrelim(Vec<Any>);
 
-impl<T, V> Prelim for RangePrelim<T, V>
-where
-    T: IntoIterator<Item = V>,
-    V: Into<Any>,
-{
+impl RangePrelim {
+    fn new<I, T>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<Any>,
+    {
+        RangePrelim(iter.into_iter().map(|v| v.into()).collect())
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl Prelim for RangePrelim {
     type Return = Unused;
 
     fn into_content(self, _txn: &mut TransactionMut) -> (ItemContent, Option<Self>) {
-        let vec: Vec<Any> = self.0.into_iter().map(|v| v.into()).collect();
-        (ItemContent::Any(vec), None)
+        (ItemContent::Any(self.0), None)
     }
 
     fn integrate(self, _txn: &mut TransactionMut, _inner_ref: BranchPtr) {}
@@ -632,7 +643,7 @@ mod test {
     use crate::types::{Change, DeepObservable, Event, Out, Path, PathSegment, ToJson};
     use crate::{
         any, Any, Array, ArrayPrelim, Assoc, Doc, Map, MapRef, Observable, SharedRef, StateVector,
-        Transact, Update, ID,
+        Transact, Update, WriteTxn, ID,
     };
     use std::collections::{HashMap, HashSet};
     use std::iter::FromIterator;
@@ -1752,5 +1763,33 @@ mod test {
         assert_eq!(v, Some(2.into()));
         let v = iter.next();
         assert_eq!(v, None);
+    }
+
+    #[test]
+    fn insert_empty_range() {
+        let doc = Doc::with_client_id(1);
+        let mut txn = doc.transact_mut();
+        let array = txn.get_or_insert_array("array");
+
+        array.insert(&mut txn, 0, 1);
+        array.insert_range::<_, Any>(&mut txn, 1, []);
+        array.push_back(&mut txn, 2);
+
+        assert_eq!(
+            array.iter(&txn).collect::<Vec<_>>(),
+            vec![1.into(), 2.into()]
+        );
+
+        let data = txn.encode_state_as_update_v1(&StateVector::default());
+
+        let doc2 = Doc::with_client_id(2);
+        let mut txn = doc2.transact_mut();
+        let array = txn.get_or_insert_array("array");
+        txn.apply_update(Update::decode_v1(&data).unwrap());
+
+        assert_eq!(
+            array.iter(&txn).collect::<Vec<_>>(),
+            vec![1.into(), 2.into()]
+        );
     }
 }

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -189,7 +189,9 @@ pub trait Array: AsRef<Branch> + Sized {
     {
         let mut walker = BlockIter::new(BranchPtr::from(self.as_ref()));
         if walker.try_forward(txn, index) {
-            let ptr = walker.insert_contents(txn, value);
+            let ptr = walker
+                .insert_contents(txn, value)
+                .expect("cannot insert empty value");
             if let Ok(integrated) = ptr.try_into() {
                 integrated
             } else {

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -199,7 +199,9 @@ pub trait Map: AsRef<Branch> + Sized {
             }
         };
 
-        let ptr = txn.create_item(&pos, value, Some(key));
+        let ptr = txn
+            .create_item(&pos, value, Some(key))
+            .expect("Cannot insert empty value");
         if let Ok(integrated) = ptr.try_into() {
             integrated
         } else {

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -1,6 +1,5 @@
 use std::borrow::Borrow;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::{TryFrom, TryInto};
 use std::fmt::Formatter;
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -1065,7 +1065,7 @@ pub trait XmlFragment: AsRef<Branch> {
     where
         V: XmlPrelim,
     {
-        let ptr = self.as_ref().insert_at(txn, index, xml_node);
+        let ptr = self.as_ref().insert_at(txn, index, xml_node).unwrap(); // XML node is never empty
         if let Ok(integrated) = V::Return::try_from(ptr) {
             integrated
         } else {
@@ -1508,7 +1508,6 @@ mod test {
 
     use arc_swap::ArcSwapOption;
 
-    use crate::branch::BranchPtr;
     use crate::test_utils::exchange_updates;
     use crate::transaction::ReadTxn;
     use crate::types::xml::{Xml, XmlFragment, XmlOut};


### PR DESCRIPTION
Original issue was that while we make checks if user is not trying to insert empty text into `TextRef` this didn't work for `Text::apply_delta`. 

It was a symptom of more general issue - we shouldn't be able to create Item blocks with empty contents in the first place. This PR solves while gracefully ignoring user attempts to do an invalid operation.