### PR TITLE
alow direct construction of XmlDeltaPrelim

### DIFF
--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -727,8 +727,8 @@ impl From<XmlTextPrelim> for In {
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct XmlDeltaPrelim {
-    attributes: HashMap<Arc<str>, String>,
-    delta: Vec<Delta<In>>,
+    pub attributes: HashMap<Arc<str>, String>,
+    pub delta: Vec<Delta<In>>,
 }
 
 impl Deref for XmlDeltaPrelim {


### PR DESCRIPTION
Currently, there is no way to build XmlIn other than `as_prelim`.

As background, I am currently implementing elixir binding and am having trouble[ encode/decode prelim to elixir types.](https://github.com/satoren/y_ex/pull/40/files#diff-0543d4713142d5424d993a2a571f2a0b0e01f1751bf81feb7fa321538e617526R89)