### PR TITLE
Async transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,10 +42,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15832d94c458da98cac0ffa6eca52cc19c2a3c6c951058500a5ae8f01f0fdf56"
 
 [[package]]
-name = "atomic_refcell"
-version = "0.1.13"
+name = "async-lock"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "autocfg"
@@ -172,6 +177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +285,27 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -461,6 +496,18 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pkg-config"
@@ -1090,7 +1137,7 @@ version = "0.19.2"
 dependencies = [
  "arc-swap",
  "assert_matches2",
- "atomic_refcell",
+ "async-lock",
  "criterion",
  "fastrand",
  "flate2",

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -19,7 +19,7 @@ thiserror = "1"
 fastrand = { version = "2", features = ["js"] }
 smallstr = { version = "0.3", features = ["union"] }
 smallvec = { version = "1.13", features = ["union", "const_generics", "const_new"] }
-atomic_refcell = "0.1"
+async-lock = "3.4"
 arc-swap = "1.7"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -12,7 +12,7 @@ use crate::undo::UndoStack;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::OptionExt;
-use crate::*;
+use crate::{Any, DeleteSet, Doc, Options, Out, Transact};
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;
 use std::collections::HashSet;
@@ -917,7 +917,7 @@ impl Item {
 /// relation to its neighbors and parent.
 #[derive(Debug)]
 pub(crate) struct ItemPosition {
-    pub parent: types::TypePtr,
+    pub parent: TypePtr,
     pub left: Option<ItemPtr>,
     pub right: Option<ItemPtr>,
     pub index: u32,

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -118,7 +118,7 @@ impl BlockIter {
             self.rel = 0;
         }
 
-        let encoding = txn.store().options.offset_kind;
+        let encoding = txn.store().offset_kind;
         while self.can_forward(item, len) {
             if item == self.curr_move_end
                 || (self.reached_end && self.curr_move_end.is_none() && self.curr_move.is_some())
@@ -188,7 +188,7 @@ impl BlockIter {
             panic!("Length exceeded");
         }
         self.index -= len;
-        let encoding = txn.store().options.offset_kind;
+        let encoding = txn.store().offset_kind;
         if self.reached_end {
             if let Some(next_item) = self.next_item.as_deref() {
                 self.rel = if next_item.is_countable() && !next_item.is_deleted() {
@@ -303,7 +303,7 @@ impl BlockIter {
             panic!("Length exceeded");
         }
 
-        let encoding = txn.store().options.offset_kind;
+        let encoding = txn.store().offset_kind;
         let mut i: &Item;
         while len > 0 {
             while let Some(block) = item.as_deref() {
@@ -365,7 +365,7 @@ impl BlockIter {
         }
         self.index += len;
         let mut next_item = self.next_item;
-        let encoding = txn.store().options.offset_kind;
+        let encoding = txn.store().offset_kind;
         let mut read = 0u32;
         while len > 0 {
             if !self.reached_end {
@@ -466,7 +466,7 @@ impl BlockIter {
         self.split_rel(txn);
         let id = {
             let store = txn.store();
-            let client_id = store.options.client_id;
+            let client_id = store.client_id;
             let clock = store.blocks.get_clock(&client_id);
             ID::new(client_id, clock)
         };

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -392,7 +392,7 @@ impl Branch {
         mut ptr: Option<ItemPtr>,
         mut index: u32,
     ) -> (Option<ItemPtr>, Option<ItemPtr>) {
-        let encoding = txn.store.options.offset_kind;
+        let encoding = txn.store.offset_kind;
         while let Some(item) = ptr {
             let content_len = item.content_len(encoding);
             if !item.is_deleted() && item.is_countable() {
@@ -434,7 +434,7 @@ impl Branch {
         };
         while remaining > 0 {
             if let Some(item) = ptr {
-                let encoding = txn.store().options.offset_kind;
+                let encoding = txn.store().offset_kind;
                 if !item.is_deleted() {
                     let content_len = item.content_len(encoding);
                     let (l, r) = if remaining < content_len {

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -385,7 +385,7 @@ impl Branch {
     /// If `index` point to the end of a block and no splitting is necessary, tuple will return only
     /// left side (beginning of a block), while right side will be `None`.
     ///
-    /// If `index` is outside of the range of an array component of current branch node, both tuple
+    /// If `index` is outside the range of an array component of current branch node, both tuple
     /// values will be `None`.
     fn index_to_ptr(
         txn: &mut TransactionMut,

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -602,6 +602,7 @@ pub mod sync;
 mod test_utils;
 #[cfg(test)]
 mod tests;
+mod transact;
 pub mod undo;
 
 pub use crate::alt::{
@@ -617,7 +618,6 @@ pub use crate::branch::Root;
 pub use crate::doc::Doc;
 pub use crate::doc::OffsetKind;
 pub use crate::doc::Options;
-pub use crate::doc::Transact;
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
 pub use crate::input::In;
@@ -631,6 +631,7 @@ pub use crate::out::Out;
 pub use crate::state_vector::Snapshot;
 pub use crate::state_vector::StateVector;
 pub use crate::store::Store;
+pub use crate::transact::{AsyncTransact, Transact, TransactionAcqError};
 pub use crate::transaction::Origin;
 pub use crate::transaction::ReadTxn;
 pub use crate::transaction::RootRefs;

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -506,7 +506,7 @@ impl StickyIndex {
                                 } else {
                                     right.start + 1
                                 };
-                                let encoding = store.options.offset_kind;
+                                let encoding = store.offset_kind;
                                 let mut n = right.ptr.left;
                                 while let Some(item) = n.as_deref() {
                                     if !item.is_deleted() && item.is_countable() {

--- a/yrs/src/out.rs
+++ b/yrs/src/out.rs
@@ -229,7 +229,7 @@ impl std::fmt::Display for Out {
             Out::YXmlText(_) => write!(f, "XmlTextRef"),
             #[cfg(feature = "weak")]
             Out::YWeakLink(_) => write!(f, "WeakRef"),
-            Out::YDoc(v) => write!(f, "Doc(guid:{})", v.options().guid),
+            Out::YDoc(v) => write!(f, "Doc(guid:{})", v.guid()),
             Out::UndefinedRef(_) => write!(f, "UndefinedRef"),
         }
     }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -15,6 +15,7 @@ use crate::{
     Uuid, ID,
 };
 use arc_swap::{ArcSwap, DefaultStrategy, Guard};
+use async_lock::futures::{Read, Write};
 use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::borrow::Borrow;
 use std::collections::hash_map::Entry;
@@ -437,12 +438,28 @@ impl DocStore {
         }))
     }
 
-    pub fn try_read(&self) -> Option<RwLockReadGuard<Store>> {
+    pub(crate) fn try_read(&self) -> Option<RwLockReadGuard<Store>> {
         self.0.store.try_read()
     }
 
-    pub fn try_write(&self) -> Option<RwLockWriteGuard<Store>> {
+    pub(crate) fn read_blocking(&self) -> RwLockReadGuard<Store> {
+        self.0.store.read_blocking()
+    }
+
+    pub(crate) fn read_async(&self) -> Read<Store> {
+        self.0.store.read()
+    }
+
+    pub(crate) fn try_write(&self) -> Option<RwLockWriteGuard<Store>> {
         self.0.store.try_write()
+    }
+
+    pub(crate) fn write_blocking(&self) -> RwLockWriteGuard<Store> {
+        self.0.store.write_blocking()
+    }
+
+    pub(crate) fn write_async(&self) -> Write<Store> {
+        self.0.store.write()
     }
 
     pub(crate) fn options(&self) -> Guard<Arc<Options>, DefaultStrategy> {

--- a/yrs/src/sync/protocol.rs
+++ b/yrs/src/sync/protocol.rs
@@ -299,13 +299,6 @@ pub enum Error {
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
-#[cfg(feature = "net")]
-impl From<tokio::task::JoinError> for Error {
-    fn from(value: tokio::task::JoinError) -> Self {
-        Error::Other(value.into())
-    }
-}
-
 /// Since y-sync protocol enables for a multiple messages to be packed into a singe byte payload,
 /// [MessageReader] can be used over the decoder to read these messages one by one in iterable
 /// fashion.
@@ -370,7 +363,7 @@ mod test {
             crate::sync::Message::Auth(Some(
                 "reason
             }"
-                .to_string(),
+                    .to_string(),
             )),
             crate::sync::Message::AwarenessQuery,
         ];

--- a/yrs/src/transact.rs
+++ b/yrs/src/transact.rs
@@ -1,0 +1,235 @@
+use crate::{Doc, Origin, Store, Transaction, TransactionMut};
+use async_lock::futures::{Read, Write};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use thiserror::Error;
+
+/// Trait implemented by [Doc] and shared types, used for carrying over the responsibilities of
+/// creating new transactions, used as a unit of work in Yrs.
+pub trait Transact {
+    /// Creates and returns a lightweight read-only transaction.
+    ///
+    /// # Errors
+    ///
+    /// While it's possible to have multiple read-only transactions active at the same time,
+    /// this method will return a [TransactionAcqError::SharedAcqFailed] error whenever called
+    /// while a read-write transaction (see: [Self::try_transact_mut]) is active at the same time.
+    fn try_transact(&self) -> Result<Transaction, TransactionAcqError>;
+
+    /// Creates and returns a read-write capable transaction. This transaction can be used to
+    /// mutate the contents of underlying document store and upon dropping or committing it may
+    /// subscription callbacks.
+    ///
+    /// # Errors
+    ///
+    /// Only one read-write transaction can be active at the same time. If any other transaction -
+    /// be it a read-write or read-only one - is active at the same time, this method will return
+    /// a [TransactionAcqError::ExclusiveAcqFailed] error.
+    fn try_transact_mut(&self) -> Result<TransactionMut, TransactionAcqError>;
+
+    /// Creates and returns a read-write capable transaction with an `origin` classifier attached.
+    /// This transaction can be used to mutate the contents of underlying document store and upon
+    /// dropping or committing it may subscription callbacks.
+    ///
+    /// An `origin` may be used to identify context of operations made (example updates performed
+    /// locally vs. incoming from remote replicas) and it's used i.e. by [`UndoManager`][crate::undo::UndoManager].
+    ///
+    /// # Errors
+    ///
+    /// Only one read-write transaction can be active at the same time. If any other transaction -
+    /// be it a read-write or read-only one - is active at the same time, this method will return
+    /// a [TransactionAcqError::ExclusiveAcqFailed] error.
+    fn try_transact_mut_with<T>(&self, origin: T) -> Result<TransactionMut, TransactionAcqError>
+    where
+        T: Into<Origin>;
+
+    /// Creates and returns a read-write capable transaction with an `origin` classifier attached.
+    /// This transaction can be used to mutate the contents of underlying document store and upon
+    /// dropping or committing it may subscription callbacks.
+    ///
+    /// An `origin` may be used to identify context of operations made (example updates performed
+    /// locally vs. incoming from remote replicas) and it's used i.e. by [`UndoManager`][crate::undo::UndoManager].
+    ///
+    /// # Errors
+    ///
+    /// Only one read-write transaction can be active at the same time. If any other transaction -
+    /// be it a read-write or read-only one - is active at the same time, this method will panic.
+    fn transact_mut_with<T>(&self, origin: T) -> TransactionMut
+    where
+        T: Into<Origin>,
+    {
+        self.try_transact_mut_with(origin).unwrap()
+    }
+
+    /// Creates and returns a lightweight read-only transaction.
+    ///
+    /// # Panics
+    ///
+    /// While it's possible to have multiple read-only transactions active at the same time,
+    /// this method will panic whenever called while a read-write transaction
+    /// (see: [Self::transact_mut]) is active at the same time.
+    fn transact(&self) -> Transaction {
+        self.try_transact().unwrap()
+    }
+
+    /// Creates and returns a read-write capable transaction. This transaction can be used to
+    /// mutate the contents of underlying document store and upon dropping or committing it may
+    /// subscription callbacks.
+    ///
+    /// # Panics
+    ///
+    /// Only one read-write transaction can be active at the same time. If any other transaction -
+    /// be it a read-write or read-only one - is active at the same time, this method will panic.
+    fn transact_mut(&self) -> TransactionMut {
+        self.try_transact_mut().unwrap()
+    }
+}
+
+impl Transact for Doc {
+    fn try_transact(&self) -> Result<Transaction, TransactionAcqError> {
+        match self.store.try_read() {
+            Some(store) => Ok(Transaction::new(store)),
+            None => Err(TransactionAcqError::SharedAcqFailed),
+        }
+    }
+
+    fn try_transact_mut(&self) -> Result<TransactionMut, TransactionAcqError> {
+        match self.store.try_write() {
+            Some(store) => Ok(TransactionMut::new(self.clone(), store, None)),
+            None => Err(TransactionAcqError::ExclusiveAcqFailed),
+        }
+    }
+
+    fn try_transact_mut_with<T>(&self, origin: T) -> Result<TransactionMut, TransactionAcqError>
+    where
+        T: Into<Origin>,
+    {
+        match self.store.try_write() {
+            Some(store) => Ok(TransactionMut::new(
+                self.clone(),
+                store,
+                Some(origin.into()),
+            )),
+            None => Err(TransactionAcqError::ExclusiveAcqFailed),
+        }
+    }
+
+    fn transact_mut_with<T>(&self, origin: T) -> TransactionMut
+    where
+        T: Into<Origin>,
+    {
+        let lock = self.store.write_blocking();
+        TransactionMut::new(self.clone(), lock, Some(origin.into()))
+    }
+
+    fn transact(&self) -> Transaction {
+        let lock = self.store.read_blocking();
+        Transaction::new(lock)
+    }
+
+    fn transact_mut(&self) -> TransactionMut {
+        let lock = self.store.write_blocking();
+        TransactionMut::new(self.clone(), lock, None)
+    }
+}
+
+/// Trait implemented by [Doc] and shared types, used for carrying over the responsibilities of
+/// creating new transactions, used as a unit of work in Yrs.
+pub trait AsyncTransact<'doc> {
+    type Read: Future<Output = Transaction<'doc>>;
+    type Write: Future<Output = TransactionMut<'doc>>;
+
+    fn transact(&'doc self) -> Self::Read;
+    fn transact_mut(&'doc self) -> Self::Write;
+
+    /// Creates and returns a read-write capable transaction with an `origin` classifier attached.
+    /// This transaction can be used to mutate the contents of underlying document store and upon
+    /// dropping or committing it may subscription callbacks.
+    ///
+    /// An `origin` may be used to identify context of operations made (example updates performed
+    /// locally vs. incoming from remote replicas) and it's used i.e. by [`UndoManager`][crate::undo::UndoManager].
+    fn transact_mut_with<T>(&'doc self, origin: T) -> Self::Write
+    where
+        T: Into<Origin>;
+}
+
+impl<'doc> AsyncTransact<'doc> for Doc {
+    type Read = AcquireTransaction<'doc>;
+    type Write = AcquireTransactionMut<'doc>;
+
+    fn transact(&'doc self) -> Self::Read {
+        let fut = self.store.read_async();
+        AcquireTransaction { fut }
+    }
+
+    fn transact_mut(&'doc self) -> Self::Write {
+        let fut = self.store.write_async();
+        AcquireTransactionMut {
+            doc: self.clone(),
+            origin: None,
+            fut,
+        }
+    }
+
+    fn transact_mut_with<T>(&'doc self, origin: T) -> Self::Write
+    where
+        T: Into<Origin>,
+    {
+        let fut = self.store.write_async();
+        AcquireTransactionMut {
+            doc: self.clone(),
+            origin: Some(origin.into()),
+            fut,
+        }
+    }
+}
+
+pub struct AcquireTransaction<'doc> {
+    fut: Read<'doc, Store>,
+}
+
+impl<'doc> Unpin for AcquireTransaction<'doc> {}
+
+impl<'doc> Future for AcquireTransaction<'doc> {
+    type Output = Transaction<'doc>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let pinned = unsafe { Pin::new_unchecked(&mut self.fut) };
+        pinned.poll(cx).map(Transaction::new)
+    }
+}
+
+pub struct AcquireTransactionMut<'doc> {
+    doc: Doc,
+    origin: Option<Origin>,
+    fut: Write<'doc, Store>,
+}
+
+impl<'doc> Unpin for AcquireTransactionMut<'doc> {}
+
+impl<'doc> Future for AcquireTransactionMut<'doc> {
+    type Output = TransactionMut<'doc>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let pinned = unsafe { Pin::new_unchecked(&mut self.fut) };
+        match pinned.poll(cx) {
+            Poll::Ready(store) => {
+                let doc = self.doc.clone();
+                let origin = self.origin.take();
+                Poll::Ready(TransactionMut::new(doc, store, origin))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum TransactionAcqError {
+    #[error("Failed to acquire read-only transaction. Drop read-write transaction and retry.")]
+    SharedAcqFailed,
+    #[error("Failed to acquire read-write transaction. Drop other transactions and retry.")]
+    ExclusiveAcqFailed,
+    #[error("All references to a parent document containing this structure has been dropped.")]
+    DocumentDropped,
+}

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -900,7 +900,7 @@ pub(crate) fn event_change_set(txn: &TransactionMut, start: Option<ItemPtr>) -> 
         false
     }
 
-    let encoding = txn.store().options.offset_kind;
+    let encoding = txn.store().offset_kind;
     let mut current = start;
     loop {
         if current == curr_move_end && curr_move.is_some() {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -744,7 +744,7 @@ fn find_position(this: BranchPtr, txn: &mut TransactionMut, index: u32) -> Optio
 
     let mut format_ptrs = HashMap::new();
     let store = txn.store_mut();
-    let encoding = store.options.offset_kind;
+    let encoding = store.offset_kind;
     let mut remaining = index;
     while let Some(right) = pos.right {
         if remaining == 0 {
@@ -804,7 +804,7 @@ fn find_position(this: BranchPtr, txn: &mut TransactionMut, index: u32) -> Optio
 }
 
 fn remove(txn: &mut TransactionMut, pos: &mut ItemPosition, len: u32) {
-    let encoding = txn.store().options.offset_kind;
+    let encoding = txn.store().offset_kind;
     let mut remaining = len;
     let start = pos.right.clone();
     let start_attrs = pos.current_attrs.clone();
@@ -881,7 +881,7 @@ fn insert_format(
 ) {
     minimize_attr_changes(pos, &attrs);
     let mut negated_attrs = insert_attributes(this, txn, pos, attrs.clone()); //TODO: remove `attrs.clone()`
-    let encoding = txn.store().options.offset_kind;
+    let encoding = txn.store().offset_kind;
     // iterate until first non-format or null is found
     // delete all formats with attributes[format.key] != null
     // also check the attributes after the first non-format as we do not want to insert redundant
@@ -980,7 +980,7 @@ fn insert_attributes(
             // save negated attribute (set null if currentVal undefined)
             negated_attrs.insert(k.clone(), current_value.clone());
 
-            let client_id = store.options.client_id;
+            let client_id = store.client_id;
             let parent = this.into();
             let mut item = Item::new(
                 ID::new(client_id, store.blocks.get_clock(&client_id)),
@@ -1031,7 +1031,7 @@ fn insert_negated_attributes(
 
     let mut store = txn.store_mut();
     for (k, v) in attrs {
-        let client_id = store.options.client_id;
+        let client_id = store.client_id;
         let parent = this.into();
         let mut item = Item::new(
             ID::new(client_id, store.blocks.get_clock(&client_id)),
@@ -1318,7 +1318,7 @@ impl TextEvent {
             }
         }
 
-        let encoding = txn.store().options.offset_kind;
+        let encoding = txn.store().offset_kind;
         let mut old_attrs = HashMap::new();
         let mut asm = DeltaAssembler::default();
         let mut current = target.start;

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -716,7 +716,7 @@ pub trait Quotable: AsRef<Branch> + Sized {
             Bound::Unbounded => return Err(QuoteError::UnboundedRange),
         };
         let mut remaining = start;
-        let encoding = txn.store().options.offset_kind;
+        let encoding = txn.store().offset_kind;
         let mut i = this.start.to_iter().moved();
         // figure out the first ID
         let mut curr = i.next(txn);

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -6,12 +6,11 @@ use std::sync::Arc;
 
 use crate::block::ItemPtr;
 use crate::branch::{Branch, BranchPtr};
-use crate::doc::TransactionAcqError;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::sync::Clock;
 use crate::transaction::Origin;
-use crate::{DeleteSet, Doc, Observer, Transact, TransactionMut, ID};
+use crate::{DeleteSet, Doc, Observer, Transact, TransactionAcqError, TransactionMut, ID};
 
 /// Undo manager is a structure used to perform undo/redo operations over the associated shared
 /// type(s).

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -625,7 +625,7 @@ impl Update {
                 };
                 let cid = curr_block.id();
                 if cid.client != first_client || // check whether there is another decoder that has has updates from `firstClient`
-                                (iterated && cid.clock > curr_write_last)
+                    (iterated && cid.clock > curr_write_last)
                 // the above while loop was used and we are potentially missing updates
                 {
                     continue;
@@ -966,7 +966,7 @@ impl Into<Store> for Update {
     fn into(self) -> Store {
         use crate::doc::Options;
 
-        let mut store = Store::new(Options::with_client_id(0));
+        let mut store = Store::new(&Options::with_client_id(0));
         for (_, vec) in self.blocks.clients {
             for block in vec {
                 if let BlockCarrier::Item(block) = block {

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -108,17 +108,17 @@ impl YDoc {
     /// Gets globally unique identifier of this `YDoc` instance.
     #[wasm_bindgen(getter)]
     pub fn guid(&self) -> String {
-        self.options().guid.to_string()
+        self.0.guid().to_string()
     }
 
     #[wasm_bindgen(getter, js_name = shouldLoad)]
     pub fn should_load(&self) -> bool {
-        self.options().should_load
+        self.0.should_load()
     }
 
     #[wasm_bindgen(getter, js_name = autoLoad)]
     pub fn auto_load(&self) -> bool {
-        self.options().auto_load
+        self.0.auto_load()
     }
 
     /// Returns a new transaction for this document. Ywasm shared data types execute their
@@ -466,7 +466,7 @@ impl DocOptions {
             options.guid = value.into();
         }
         if let Some(value) = self.collection_id {
-            options.collection_id = Some(value);
+            options.collection_id = Some(value.into());
         }
         if let Some(value) = self.gc {
             options.skip_gc = !value;


### PR DESCRIPTION
This PR introduces serveral changes:
1. `Transact::transact` and `Transact::transact_mut` methods now won't panic when transaction couldn't be acquired. Instead they will block a thread. You can always simulate old behaviour by using `doc.try_transact().unwrap()`.
2. Introduces new trait `AsyncTransact` which has API similar to `Transact`, however it's versions of `transact` and `transact_mut` returns a Future that can we awaited within async functions.
3. Removed `Doc::options` since internally we had to wrap options in some dedicated arc-swap types (for subdocument options override behaviour). Instead `Doc::auto_load`/`Doc::should_load`/`Doc::collection_id` are now dedicated methods instead of being just fields of `Doc::options`.
4. `Doc::collection_id` type changed from `String` &rarr; `Arc<str>`.

## Cargo criterion benchmarks

Changes make some of the tests improve/regress within 12% threshold - I'd say this is a fair tradeoff and since the tests are very short they could be influenced by other factors (even my comp temperature).
```
[B1.1] Append N characters/6000
                        time:   [131.78 ms 132.50 ms 133.35 ms]
                        change: [-2.6588% -1.6267% -0.6511%] (p = 0.01 < 0.05)
                        Change within noise threshold.

[B1.2] Insert string of length N/1
                        time:   [5.4072 µs 5.4103 µs 5.4140 µs]
                        change: [-0.5335% +0.8567% +2.2592%] (p = 0.29 > 0.05)
                        No change in performance detected.

[B1.3] Prepend N characters/6000
                        time:   [5.5093 ms 5.5892 ms 5.6481 ms]
                        change: [+12.560% +14.283% +15.924%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B1.4] Insert N characters at random positions/6000
                        time:   [43.529 ms 43.634 ms 43.727 ms]
                        change: [+2.1378% +2.4059% +2.6693%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B1.5] Insert N words at random positions/6000
                        time:   [23.627 ms 23.827 ms 23.946 ms]
                        change: [-0.7381% -0.0743% +0.5748%] (p = 0.84 > 0.05)
                        No change in performance detected.

Benchmarking [B1.7] Insert/Delete strings at random positions/6000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.9s or enable flat sampling.
[B1.7] Insert/Delete strings at random positions/6000
                        time:   [552.32 ms 717.14 ms 811.62 ms]
                        change: [-24.636% +0.9969% +37.519%] (p = 0.96 > 0.05)
                        No change in performance detected.

[B1.8] Append N numbers/6000
                        time:   [6.1486 ms 6.1795 ms 6.2100 ms]
                        change: [+10.490% +11.172% +11.860%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B1.9] Insert Array of N numbers/1
                        time:   [64.187 µs 91.307 µs 104.28 µs]
                        change: [-42.309% -26.687% -7.1236%] (p = 0.02 < 0.05)
                        Performance has improved.

[B1.10] Prepend N numbers/6000
                        time:   [6.2866 ms 6.3501 ms 6.3853 ms]
                        change: [+10.805% +12.836% +14.955%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B1.11] Insert N numbers at random positions/6000
                        time:   [70.857 ms 71.069 ms 71.229 ms]
                        change: [+0.5209% +0.9703% +1.4776%] (p = 0.00 < 0.05)
                        Change within noise threshold.

[B2.1] Concurrently insert string of length N at index 0/6000
                        time:   [40.367 µs 42.353 µs 43.470 µs]
                        change: [-6.6637% -2.7265% +1.1902%] (p = 0.23 > 0.05)
                        No change in performance detected.

[B2.2] Concurrently insert N characters at random positions/6000
                        time:   [206.43 ms 207.25 ms 208.10 ms]
                        change: [-0.2272% +0.3025% +0.7328%] (p = 0.24 > 0.05)
                        No change in performance detected.

[B2.3] Concurrently insert N words at random positions/6000
                        time:   [396.76 ms 400.56 ms 404.51 ms]
                        change: [-1.9556% -0.4159% +1.0167%] (p = 0.62 > 0.05)
                        No change in performance detected.

Benchmarking [B2.4] Concurrently insert & delete/6000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.6s.
[B2.4] Concurrently insert & delete/6000
                        time:   [1.1474 s 1.2435 s 1.3388 s]
                        change: [-12.258% -1.8851% +10.038%] (p = 0.75 > 0.05)
                        No change in performance detected.

[B3.1] 20√N clients concurrently set number in Map/1540
                        time:   [28.295 ms 28.311 ms 28.336 ms]
                        change: [+3.2508% +3.5033% +3.7546%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B3.2] 20√N clients concurrently set Object in Map/1540
                        time:   [31.304 ms 31.341 ms 31.394 ms]
                        change: [+2.9713% +3.2347% +3.4520%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B3.3] 20√N clients concurrently set String in Map/1540
                        time:   [28.460 ms 28.481 ms 28.522 ms]
                        change: [-3.6167% -3.0504% -2.5945%] (p = 0.00 < 0.05)
                        Performance has improved.

[B3.4] 20√N clients concurrently insert text in Array/1540
                        time:   [29.049 ms 29.061 ms 29.081 ms]
                        change: [+5.6758% +5.9111% +6.1479%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B4.2] Apply real-world document snapshot of size/400972
                        time:   [2.3161 ms 2.3282 ms 2.3419 ms]
                        change: [+9.0464% +9.5220% +9.9660%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking [B4.1] Apply real-world editing dataset/259778: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 62.7s.
[B4.1] Apply real-world editing dataset/259778
                        time:   [6.2862 s 6.3292 s 6.3795 s]
                        change: [+0.3269% +1.3042% +2.2412%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```