### PR TITLE
implement async y-sync protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1207,7 @@ dependencies = [
  "arc-swap",
  "assert_matches2",
  "async-lock",
+ "async-trait",
  "criterion",
  "dashmap",
  "fastrand",

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -20,6 +20,7 @@ fastrand = { version = "2", features = ["js"] }
 smallstr = { version = "0.3", features = ["union"] }
 smallvec = { version = "1.13", features = ["union", "const_generics", "const_new"] }
 async-lock = "3.4"
+async-trait = "0.1"
 arc-swap = "1.7"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -735,8 +735,8 @@ mod test {
 
     #[test]
     fn awareness_summary() -> Result<(), Box<dyn std::error::Error>> {
-        let mut local = Awareness::new(Doc::with_client_id(1));
-        let mut remote = Awareness::new(Doc::with_client_id(2));
+        let local = Awareness::new(Doc::with_client_id(1));
+        let remote = Awareness::new(Doc::with_client_id(2));
 
         local.set_local_state(json!({"x":3})).unwrap();
         let update = local.update_with_clients([local.client_id()])?;


### PR DESCRIPTION
This PR introduces few changes:
1. y-sync `Protocol` now summarizes all message handlers under a single `handle` method. We previously avoided that since `Doc`/`Awareness` might have been hidden behind locks, that were not defined at protocol level but rather by users.
2. Introduces y-sync `AsyncProtocol` which is `Protocol` equivalent, however it acquires transactions using `AsyncTransact` API introduced before in #481 .