### PR TITLE
yffi: add operators to interact with JSON strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,6 +1197,7 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 name = "yffi"
 version = "0.19.2"
 dependencies = [
+ "serde_json",
  "yrs",
 ]
 

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -457,7 +457,7 @@ typedef struct YMapEntry {
    * A `YOutput` value representing containing variadic content that can be stored withing map's
    * entry.
    */
-  struct YOutput value;
+  const struct YOutput *value;
 } YMapEntry;
 
 /**

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -96,6 +96,12 @@ typedef struct YSubscription {} YSubscription;
 #include <stdlib.h>
 
 /**
+ * Flag used by `YInput` to pass JSON string for an object that should be deserialized and
+ * stored internally as fully fledged scalar type.
+ */
+#define Y_JSON -9
+
+/**
  * Flag used by `YInput` and `YOutput` to tag boolean values.
  */
 #define Y_JSON_BOOL -8
@@ -626,6 +632,7 @@ typedef struct YInput {
   /**
    * Tag describing, which `value` type is being stored by this input cell. Can be one of:
    *
+   * - [Y_JSON] for a UTF-8 encoded, NULL-terminated JSON string.
    * - [Y_JSON_BOOL] for boolean flags.
    * - [Y_JSON_NUM] for 64-bit floating point numbers.
    * - [Y_JSON_INT] for 64-bit signed integers.
@@ -1486,11 +1493,25 @@ uint32_t yarray_len(const Branch *array);
 
 /**
  * Returns a pointer to a `YOutput` value stored at a given `index` of a current `YArray`.
- * If `index` is outside of the bounds of an array, a null pointer will be returned.
+ * If `index` is outside the bounds of an array, a null pointer will be returned.
  *
  * A value returned should be eventually released using [youtput_destroy] function.
  */
 struct YOutput *yarray_get(const Branch *array, const YTransaction *txn, uint32_t index);
+
+/**
+ * Returns a UTF-8 encoded, NULL-terminated JSON string representing a value stored in a current
+ * YArray under a given index.
+ *
+ * This method will return `NULL` pointer if value was outside the bound of an array or couldn't be
+ * serialized into JSON string.
+ *
+ * This method will also try to serialize complex types that don't have native JSON representation
+ * like YMap, YArray, YText etc. in such cases their contents will be materialized into JSON values.
+ *
+ * A string returned should be eventually released using [ystring_destroy] function.
+ */
+char *yarray_get_json(const Branch *array, const YTransaction *txn, uint32_t index);
 
 /**
  * Inserts a range of `items` into current `YArray`, starting at given `index`. An `items_len`
@@ -1596,6 +1617,18 @@ uint8_t ymap_remove(const Branch *map, YTransaction *txn, const char *key);
  * A `key` must be a null-terminated UTF-8 encoded string.
  */
 struct YOutput *ymap_get(const Branch *map, const YTransaction *txn, const char *key);
+
+/**
+ * Returns a value stored under the provided `key` as UTF-8 encoded, NULL-terminated JSON string.
+ * Once not needed that string should be deallocated using `ystring_destroy`.
+ *
+ * This method will return `NULL` pointer if value was not found or value couldn't be serialized
+ * into JSON string.
+ *
+ * This method will also try to serialize complex types that don't have native JSON representation
+ * like YMap, YArray, YText etc. in such cases their contents will be materialized into JSON values.
+ */
+char *ymap_get_json(const Branch *map, const YTransaction *txn, const char *key);
 
 /**
  * Removes all entries from a current `map`.
@@ -1936,6 +1969,15 @@ struct YInput yinput_long(int64_t integer);
  * a structure is no longer needed.
  */
 struct YInput yinput_string(const char *str);
+
+/**
+ * Function constructor used to create aa `YInput` cell representing any JSON-like object.
+ * Provided parameter must be a null-terminated UTF-8 encoded JSON string.
+ *
+ * This function doesn't allocate any heap resources and doesn't release any on its own, therefore
+ * its up to a caller to free resources once a structure is no longer needed.
+ */
+struct YInput yinput_json(const char *str);
 
 /**
  * Function constructor used to create a binary `YInput` cell of a specified length.
@@ -2519,5 +2561,15 @@ Branch *ybranch_get(const struct YBranchId *branch_id, YTransaction *txn);
  * execute any functions using it.
  */
 uint8_t ybranch_alive(Branch *branch);
+
+/**
+ * Returns a UTF-8 encoded, NULL-terminated JSON string representation of the current branch
+ * contents. Once no longer needed, this string must be explicitly deallocated by user using
+ * `ystring_destroy`.
+ *
+ * If branch type couldn't be resolved (which usually happens for root-level types that were not
+ * initialized locally) or doesn't have JSON representation a NULL pointer can be returned.
+ */
+char *ybranch_json(Branch *branch, YTransaction *txn);
 
 #endif

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -2314,3 +2314,28 @@ TEST_CASE("YArray JSON input") {
     ytransaction_commit(txn);
     ydoc_destroy(doc);
 }
+
+TEST_CASE("JSON output") {
+    YDoc *doc = ydoc_new_with_id(1);
+    Branch *arr = yarray(doc, "array");
+    YTransaction *txn = ydoc_write_transaction(doc, 0, NULL);
+
+    // init doc -> 'array' = [{'key':'value'}]
+    char key[] = "key";
+    char *keyskeys[] = {key};
+    YInput value = yinput_string("value");
+    YInput in0 = yinput_ymap(keyskeys, &value, 1);
+    YInput in1 = yinput_float(3.14);
+    YInput in2 = yinput_long(100);
+    YInput in3 = yinput_string("hello");
+    YInput in4 = yinput_null();
+    YInput in5 = yinput_bool(Y_TRUE);
+    YInput in[6] = {in0, in1, in2, in3, in4, in5};
+    yarray_insert_range(arr, txn, 0, in, 6);
+
+    char *json = ybranch_json(arr, txn);
+    REQUIRE(strcmp(json, "[{\"key\":\"value\"},3.14,100,\"hello\",null,true]") == 0);
+
+    ytransaction_commit(txn);
+    ydoc_destroy(doc);
+}

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -13,6 +13,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 
 [dependencies]
 yrs = { path = "../yrs", version = "0.19.2", features = ["weak"] }
+serde_json = { version = "1.0" }
 
 [lib]
 crate-type = ["staticlib", "cdylib"]

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -1682,7 +1682,8 @@ pub unsafe extern "C" fn ymap_get(
     let map = MapRef::from_raw_branch(map);
 
     if let Some(value) = map.get(txn, key) {
-        Box::into_raw(Box::new(YOutput::from(value)))
+        let output = YOutput::from(value);
+        Box::into_raw(Box::new(output))
     } else {
         std::ptr::null_mut()
     }
@@ -2933,7 +2934,8 @@ impl<'a> From<&'a [Any]> for YOutput {
         let len = values.len() as u32;
         let mut array = Vec::with_capacity(values.len());
         for v in values.iter() {
-            array.push(YOutput::from(v));
+            let output = YOutput::from(v);
+            array.push(output);
         }
         let ptr = array.as_mut_ptr();
         forget(array);

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -17,7 +17,7 @@ use yrs::types::weak::{LinkSource, Unquote as NativeUnquote, WeakEvent, WeakRef}
 use yrs::types::xml::{Attributes as NativeAttributes, XmlOut};
 use yrs::types::xml::{TreeWalker as NativeTreeWalker, XmlFragment};
 use yrs::types::xml::{XmlEvent, XmlTextEvent};
-use yrs::types::{Attrs, Change, Delta, EntryChange, Event, PathSegment, TypeRef};
+use yrs::types::{Attrs, Change, Delta, EntryChange, Event, PathSegment, ToJson, TypeRef};
 use yrs::undo::EventKind;
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
@@ -27,6 +27,10 @@ use yrs::{
     SubdocsEvent, SubdocsEventIter, Text, TextRef, Transact, TransactionCleanupEvent, Update, Xml,
     XmlElementPrelim, XmlElementRef, XmlFragmentRef, XmlTextPrelim, XmlTextRef, ID,
 };
+
+/// Flag used by `YInput` to pass JSON string for an object that should be deserialized and
+/// stored internally as fully fledged scalar type.
+pub const Y_JSON: i8 = -9;
 
 /// Flag used by `YInput` and `YOutput` to tag boolean values.
 pub const Y_JSON_BOOL: i8 = -8;
@@ -1348,7 +1352,7 @@ pub unsafe extern "C" fn yarray_len(array: *const Branch) -> u32 {
 }
 
 /// Returns a pointer to a `YOutput` value stored at a given `index` of a current `YArray`.
-/// If `index` is outside of the bounds of an array, a null pointer will be returned.
+/// If `index` is outside the bounds of an array, a null pointer will be returned.
 ///
 /// A value returned should be eventually released using [youtput_destroy] function.
 #[no_mangle]
@@ -1364,6 +1368,39 @@ pub unsafe extern "C" fn yarray_get(
 
     if let Some(val) = array.get(txn, index as u32) {
         Box::into_raw(Box::new(YOutput::from(val)))
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+/// Returns a UTF-8 encoded, NULL-terminated JSON string representing a value stored in a current
+/// YArray under a given index.
+///
+/// This method will return `NULL` pointer if value was outside the bound of an array or couldn't be
+/// serialized into JSON string.
+///
+/// This method will also try to serialize complex types that don't have native JSON representation
+/// like YMap, YArray, YText etc. in such cases their contents will be materialized into JSON values.
+///
+/// A string returned should be eventually released using [ystring_destroy] function.
+#[no_mangle]
+pub unsafe extern "C" fn yarray_get_json(
+    array: *const Branch,
+    txn: *const Transaction,
+    index: u32,
+) -> *mut c_char {
+    assert!(!array.is_null());
+
+    let array = ArrayRef::from_raw_branch(array);
+    let txn = txn.as_ref().unwrap();
+
+    if let Some(val) = array.get(txn, index as u32) {
+        let any = val.to_json(txn);
+        let json = match serde_json::to_string(&any) {
+            Ok(json) => json,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        CString::new(json).unwrap().into_raw()
     } else {
         std::ptr::null_mut()
     }
@@ -1646,6 +1683,40 @@ pub unsafe extern "C" fn ymap_get(
 
     if let Some(value) = map.get(txn, key) {
         Box::into_raw(Box::new(YOutput::from(value)))
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+/// Returns a value stored under the provided `key` as UTF-8 encoded, NULL-terminated JSON string.
+/// Once not needed that string should be deallocated using `ystring_destroy`.
+///
+/// This method will return `NULL` pointer if value was not found or value couldn't be serialized
+/// into JSON string.
+///
+/// This method will also try to serialize complex types that don't have native JSON representation
+/// like YMap, YArray, YText etc. in such cases their contents will be materialized into JSON values.
+#[no_mangle]
+pub unsafe extern "C" fn ymap_get_json(
+    map: *const Branch,
+    txn: *const Transaction,
+    key: *const c_char,
+) -> *mut c_char {
+    assert!(!map.is_null());
+    assert!(!key.is_null());
+    assert!(!txn.is_null());
+
+    let txn = txn.as_ref().unwrap();
+    let key = CStr::from_ptr(key).to_str().unwrap();
+
+    let map = MapRef::from_raw_branch(map);
+
+    if let Some(value) = map.get(txn, key) {
+        let any = value.to_json(txn);
+        match serde_json::to_string(&any) {
+            Ok(json) => CString::new(json).unwrap().into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        }
     } else {
         std::ptr::null_mut()
     }
@@ -2431,6 +2502,7 @@ impl Drop for YChunk {
 pub struct YInput {
     /// Tag describing, which `value` type is being stored by this input cell. Can be one of:
     ///
+    /// - [Y_JSON] for a UTF-8 encoded, NULL-terminated JSON string.
     /// - [Y_JSON_BOOL] for boolean flags.
     /// - [Y_JSON_NUM] for 64-bit floating point numbers.
     /// - [Y_JSON_INT] for 64-bit signed integers.
@@ -2464,53 +2536,54 @@ impl YInput {
     fn into(self) -> Any {
         let tag = self.tag;
         unsafe {
-            if tag == Y_JSON_STR {
-                let str = CStr::from_ptr(self.value.str).to_str().unwrap().into();
-                Any::String(str)
-            } else if tag == Y_JSON_ARR {
-                let ptr = self.value.values;
-                let mut dst: Vec<Any> = Vec::with_capacity(self.len as usize);
-                let mut i = 0;
-                while i < self.len as isize {
-                    let value = ptr.offset(i).read();
-                    let any = value.into();
-                    dst.push(any);
-                    i += 1;
+            match tag {
+                Y_JSON_STR => {
+                    let str = CStr::from_ptr(self.value.str).to_str().unwrap().into();
+                    Any::String(str)
                 }
-                Any::from(dst)
-            } else if tag == Y_JSON_MAP {
-                let mut dst = HashMap::with_capacity(self.len as usize);
-                let keys = self.value.map.keys;
-                let values = self.value.map.values;
-                let mut i = 0;
-                while i < self.len as isize {
-                    let key = CStr::from_ptr(keys.offset(i).read())
-                        .to_str()
-                        .unwrap()
-                        .to_owned();
-                    let value = values.offset(i).read().into();
-                    dst.insert(key, value);
-                    i += 1;
+                Y_JSON => {
+                    let json_str = CStr::from_ptr(self.value.str).to_str().unwrap();
+                    serde_json::from_str(json_str).unwrap()
                 }
-                Any::from(dst)
-            } else if tag == Y_JSON_NULL {
-                Any::Null
-            } else if tag == Y_JSON_UNDEF {
-                Any::Undefined
-            } else if tag == Y_JSON_INT {
-                Any::BigInt(self.value.integer as i64)
-            } else if tag == Y_JSON_NUM {
-                Any::Number(self.value.num as f64)
-            } else if tag == Y_JSON_BOOL {
-                Any::Bool(if self.value.flag == 0 { false } else { true })
-            } else if tag == Y_JSON_BUF {
-                let slice =
-                    std::slice::from_raw_parts(self.value.buf as *mut u8, self.len as usize);
-                Any::from(slice)
-            } else if tag == Y_DOC {
-                Any::Undefined
-            } else {
-                panic!("Unrecognized YVal value tag.")
+                Y_JSON_NULL => Any::Null,
+                Y_JSON_UNDEF => Any::Undefined,
+                Y_JSON_INT => Any::BigInt(self.value.integer),
+                Y_JSON_NUM => Any::Number(self.value.num),
+                Y_JSON_BOOL => Any::Bool(if self.value.flag == 0 { false } else { true }),
+                Y_JSON_BUF => Any::from(std::slice::from_raw_parts(
+                    self.value.buf as *mut u8,
+                    self.len as usize,
+                )),
+                Y_JSON_ARR => {
+                    let ptr = self.value.values;
+                    let mut dst: Vec<Any> = Vec::with_capacity(self.len as usize);
+                    let mut i = 0;
+                    while i < self.len as isize {
+                        let value = ptr.offset(i).read();
+                        let any = value.into();
+                        dst.push(any);
+                        i += 1;
+                    }
+                    Any::from(dst)
+                }
+                Y_JSON_MAP => {
+                    let mut dst = HashMap::with_capacity(self.len as usize);
+                    let keys = self.value.map.keys;
+                    let values = self.value.map.values;
+                    let mut i = 0;
+                    while i < self.len as isize {
+                        let key = CStr::from_ptr(keys.offset(i).read())
+                            .to_str()
+                            .unwrap()
+                            .to_owned();
+                        let value = values.offset(i).read().into();
+                        dst.insert(key, value);
+                        i += 1;
+                    }
+                    Any::from(dst)
+                }
+                Y_DOC => Any::Undefined,
+                other => panic!("Cannot convert input - unknown tag: {}", other),
             }
         }
     }
@@ -3119,6 +3192,22 @@ pub unsafe extern "C" fn yinput_long(integer: i64) -> YInput {
 pub unsafe extern "C" fn yinput_string(str: *const c_char) -> YInput {
     YInput {
         tag: Y_JSON_STR,
+        len: 1,
+        value: YInputContent {
+            str: str as *mut c_char,
+        },
+    }
+}
+
+/// Function constructor used to create aa `YInput` cell representing any JSON-like object.
+/// Provided parameter must be a null-terminated UTF-8 encoded JSON string.
+///
+/// This function doesn't allocate any heap resources and doesn't release any on its own, therefore
+/// its up to a caller to free resources once a structure is no longer needed.
+#[no_mangle]
+pub unsafe extern "C" fn yinput_json(str: *const c_char) -> YInput {
+    YInput {
+        tag: Y_JSON,
         len: 1,
         value: YInputContent {
             str: str as *mut c_char,
@@ -5454,5 +5543,41 @@ pub unsafe extern "C" fn ybranch_alive(branch: *mut Branch) -> u8 {
         } else {
             Y_TRUE
         }
+    }
+}
+
+/// Returns a UTF-8 encoded, NULL-terminated JSON string representation of the current branch
+/// contents. Once no longer needed, this string must be explicitly deallocated by user using
+/// `ystring_destroy`.
+///
+/// If branch type couldn't be resolved (which usually happens for root-level types that were not
+/// initialized locally) or doesn't have JSON representation a NULL pointer can be returned.
+#[no_mangle]
+pub unsafe extern "C" fn ybranch_json(branch: *mut Branch, txn: *mut Transaction) -> *mut c_char {
+    if branch.is_null() {
+        std::ptr::null_mut()
+    } else {
+        let txn = txn.as_ref().unwrap();
+        let branch_ref = BranchPtr::from_raw_branch(branch);
+        let any = match branch_ref.type_ref() {
+            TypeRef::Array => ArrayRef::from_raw_branch(branch).to_json(txn),
+            TypeRef::Map => MapRef::from_raw_branch(branch).to_json(txn),
+            TypeRef::Text => TextRef::from_raw_branch(branch).get_string(txn).into(),
+            TypeRef::XmlElement(_) => XmlElementRef::from_raw_branch(branch)
+                .get_string(txn)
+                .into(),
+            TypeRef::XmlFragment => XmlFragmentRef::from_raw_branch(branch)
+                .get_string(txn)
+                .into(),
+            TypeRef::XmlText => XmlTextRef::from_raw_branch(branch).get_string(txn).into(),
+            TypeRef::SubDoc | TypeRef::XmlHook | TypeRef::WeakLink(_) | TypeRef::Undefined => {
+                return std::ptr::null_mut()
+            }
+        };
+        let json = match serde_json::to_string(&any) {
+            Ok(json) => json,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        CString::new(json).unwrap().into_raw()
     }
 }


### PR DESCRIPTION
This PR extends yffi API to enable working with JSON input and output data:

1. `yinput_json(*char)` can take any well-formed, utf-8 encoded, null-terminated JSON string. This kind of input will be internally serialized as `yrs::Any` type entry.
2. `ymap_get_json` and `yarray_get_json` will return a JSON string representation of their corresponding entries. Complex types like YMap, YArray, YText etc. will have their contents also serialized into JSON representation and returned as such.
3. `ybranch_json(*Branch, *Transaction)` will return a JSON string representation of any branch type.