### PR TITLE
release v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "yffi"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "serde_json",
  "yrs",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "arc-swap",
  "assert_matches2",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.19.2"
+version = "0.20.0"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.19.2"
+version = "0.20.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.19.2", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.20.0", features = ["weak"] }
 serde_json = { version = "1.0" }
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.19.2"
+version = "0.20.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.19.2"
+version = "0.20.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.19.2", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.20.0", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
## New features

- #481: introduced `yrs::AsyncTransact` trait which works in similar way to `yrs::Transact` except transaction factory methods now return futures that can be awaited on.
- #482: `Awareness` operations now can be executed **without** `&mut Awareness` reference and are thread-safe.
- #483: y-sync `AsyncProtocol`  introduced works just like `Protocol` except it uses new `AsyncTransact` API to handle transactions required for y-sync protocol message handling in asynchronous way.
- #480: `XmlDeltaPrelim` fields are now exposed.
- `yffi`:
  - #484: fixed issue when reading JSON map outputs caused segfaults.
  - #485: introduced new API functions that allow to use JSON string as input types (`yinput_json`), and reading any shared ref contents back as JSON (`ybranch_json`). Additionally `ymap_get_json` and `yarray_get_json` can be used to read individual contents of YArray and YMap as JSON strings.
  - #486: exposes ability to perform many sequential operations defined as deltas through `ytext_insert_delta` function - especially usefull when copy/pasting long sequences of rich-formatted text.

## Breaking changes
- `yffi`: renamed `YDelta` &rarr; `YDeltaOut`.
- `yrs::Doc::options` is no longer available. Instead options fields like `auto_load`/`should_load` etc. are now dedicated methods on `Doc` object.
- `Doc::collection_id` type changed: `String` &rarr; `Arc<str>`.
- `yrs::Transact`: `transact`/`transact_mut`/`transact_mut_with` methods will no longer panic when transaction cannot be acquired. Instead we'll force waiting at the current thread (which can potentially cause a deadlock). If previous behavior is desired, it can be achieved via `doc.try_transact().unwrap()` call.
- y-sync `Protocol` methods no longer use `&mut Awareness` parameter: due to #482 all Awareness method can be called on `&Awareness` alone.
- `Awareness` no longer exposes `clients` and `meta` hashmaps. If you need to access all clients or metas, you can use `Awareness::iter` instead.
- `Awareness::local_state`/`Awareness::state` generic constraint changed: `Deserialize<'de>` &rarr; `DeserializeOwned`.