### PR TITLE
Undo manager transactions

### DIFF
--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -14,11 +14,6 @@
         "zlib": "^1.0.5"
       }
     },
-    "../ywasm/pkg": {
-      "name": "ywasm",
-      "version": "0.19.2",
-      "license": "MIT"
-    },
     "node_modules/isomorphic.js": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.4.tgz",
@@ -44,8 +39,9 @@
       }
     },
     "node_modules/ywasm": {
-      "resolved": "../ywasm/pkg",
-      "link": true
+      "version": "0.20.0",
+      "resolved": "file:../ywasm/pkg",
+      "license": "MIT"
     },
     "node_modules/zlib": {
       "version": "1.0.5",
@@ -72,7 +68,7 @@
       }
     },
     "ywasm": {
-      "version": "file:../ywasm/pkg"
+      "version": "0.20.0"
     },
     "zlib": {
       "version": "1.0.5",

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -331,11 +331,11 @@
 //! assert_eq!(text1.get_string(&local.transact()), "hello worldeveryone"); // remote changes synced
 //!
 //! // undo last performed change on local
-//! mgr.undo().unwrap();
+//! mgr.undo_blocking();
 //! assert_eq!(text1.get_string(&local.transact()), "hello everyone");
 //!
 //! // redo change we undone
-//! mgr.redo().unwrap();
+//! mgr.redo_blocking();
 //! assert_eq!(text1.get_string(&local.transact()), "hello worldeveryone");
 //! ```
 //!

--- a/ywasm/src/undo.rs
+++ b/ywasm/src/undo.rs
@@ -87,12 +87,8 @@ impl YUndoManager {
     }
 
     #[wasm_bindgen(js_name = clear)]
-    pub fn clear(&mut self) -> Result<()> {
-        if let Err(_) = self.0.clear() {
-            Err(JsValue::from_str(crate::js::errors::ANOTHER_TX))
-        } else {
-            Ok(())
-        }
+    pub fn clear(&mut self) {
+        self.0.clear();
     }
 
     #[wasm_bindgen(js_name = stopCapturing)]
@@ -102,7 +98,7 @@ impl YUndoManager {
 
     #[wasm_bindgen(js_name = undo)]
     pub fn undo(&mut self) -> Result<()> {
-        if let Err(_) = self.0.undo() {
+        if let Err(_) = self.0.try_undo() {
             Err(JsValue::from_str(crate::js::errors::ANOTHER_TX))
         } else {
             Ok(())
@@ -111,7 +107,7 @@ impl YUndoManager {
 
     #[wasm_bindgen(js_name = redo)]
     pub fn redo(&mut self) -> Result<()> {
-        if let Err(_) = self.0.redo() {
+        if let Err(_) = self.0.try_redo() {
             Err(JsValue::from_str(crate::js::errors::ANOTHER_TX))
         } else {
             Ok(())


### PR DESCRIPTION
This PR applies several changes:

1. `UndoManager` undo/redo methods are now split to resemble new async capabilities of document store: 
    - `try_undo`/`try_redo` will try to obtain underlying document store transaction and return error on failure.
    - `undo_blocking`/`redo_blocking` will obtain transactions, waiting by blocking the thread if necessary.
    - `undo`/`redo` now returns futures that will obtain transactions asynchronously.
2. `yundo_manager_can_undo` and `yundo_manager_can_redo` are now replaced by `yundo_manager_undo_stack_len` and `yundo_manager_redo_stack_len`.