### PR TITLE
release v0.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,6 @@ jobs:
         env:
           CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: cargo publish ywasm
-        run: sleep 20 && cd ./ywasm && cargo publish --token ${CRATES_TOKEN}
-        env:
-          CRATES_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   release-npm:
     name: release to npmjs.org
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,7 +1195,7 @@ checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "yffi"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "serde_json",
  "yrs",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arc-swap",
  "assert_matches2",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.20.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.21.0", features = ["weak"] }
 serde_json = { version = "1.0" }
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.20.0"
+version = "0.21.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.20.0"
+version = "0.21.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.20.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.21.0", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
# Changes and breaking changes

- Biggest breaking change: `TransactionMut::apply_update` now returns a result, which can be errors for cases that previously caused panics.
- `UndoManager`
    - instead of `undo`/`redo`, now we have 3 variants of each `try_undo`/`undo_blocking`/`undo`(async) to reflect new capabilities of asynchronous transactions.
    - yffi: `yundo_manager_can_undo` and `yundo_manager_can_redo` are now replaced by `yundo_manager_undo_stack_len` and `yundo_manager_redo_stack_len` - these methods can be used pretty much the same way but they are more capable and carrt more information.