### PR TITLE
Enable force GC on all document items, regardles of skip_gc option.

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -1248,6 +1248,13 @@ YDoc **ytransaction_subdocs(YTransaction *txn, uint32_t *len);
 void ytransaction_commit(YTransaction *txn);
 
 /**
+ * Perform garbage collection of deleted blocks, even if a document was created with `skip_gc`
+ * option. This operation will scan over ALL deleted elements, NOT ONLY the ones that have been
+ * changed as part of this transaction scope.
+ */
+void ytransaction_force_gc(YTransaction *txn);
+
+/**
  * Returns `1` if current transaction is of read-write type.
  * Returns `0` if transaction is read-only.
  */

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -665,6 +665,17 @@ pub unsafe extern "C" fn ytransaction_commit(txn: *mut Transaction) {
     drop(Box::from_raw(txn)); // transaction is auto-committed when dropped
 }
 
+/// Perform garbage collection of deleted blocks, even if a document was created with `skip_gc`
+/// option. This operation will scan over ALL deleted elements, NOT ONLY the ones that have been
+/// changed as part of this transaction scope.
+#[no_mangle]
+pub unsafe extern "C" fn ytransaction_force_gc(txn: *mut Transaction) {
+    assert!(!txn.is_null());
+    let txn = txn.as_mut().unwrap();
+    let txn = txn.as_mut().unwrap();
+    txn.force_gc();
+}
+
 /// Returns `1` if current transaction is of read-write type.
 /// Returns `0` if transaction is read-only.
 #[no_mangle]

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -156,7 +156,7 @@ impl BlockCell {
 
     pub fn len(&self) -> u32 {
         match self {
-            BlockCell::GC(gc) => gc.end - gc.start,
+            BlockCell::GC(gc) => gc.end - gc.start + 1,
             BlockCell::Block(block) => block.len(),
         }
     }

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -124,6 +124,10 @@ impl ClientBlockList {
         ClientBlockListIter(self.list.iter())
     }
 
+    pub fn iter_mut(&mut self) -> ClientBlockListIterMut<'_> {
+        ClientBlockListIterMut(self.list.iter_mut())
+    }
+
     /// Attempts to squash block at a given `index` with a corresponding block on its left side.
     /// If this succeeds, block under a given `index` will be removed, and its contents will be
     /// squashed into its left neighbor. In such case a squash result will be returned in order to
@@ -183,6 +187,16 @@ impl<'a> Iterator for ClientBlockListIter<'a> {
     }
 }
 
+pub(crate) struct ClientBlockListIterMut<'a>(std::slice::IterMut<'a, BlockCell>);
+
+impl<'a> Iterator for ClientBlockListIterMut<'a> {
+    type Item = &'a mut BlockCell;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+
 /// Block store is a collection of all blocks known to a document owning instance of this type.
 /// Blocks are organized per client ID and contain a resizable list of all blocks inserted by that
 /// client.
@@ -192,6 +206,7 @@ pub(crate) struct BlockStore {
 }
 
 pub(crate) type Iter<'a> = std::collections::hash_map::Iter<'a, ClientID, ClientBlockList>;
+pub(crate) type IterMut<'a> = std::collections::hash_map::IterMut<'a, ClientID, ClientBlockList>;
 
 impl BlockStore {
     /// Checks if block store is empty. Empty block store doesn't contain any blocks, neither active
@@ -240,6 +255,11 @@ impl BlockStore {
     /// Returns an iterator over the client and block lists pairs known to a current block store.
     pub fn iter(&self) -> Iter<'_> {
         self.clients.iter()
+    }
+
+    /// Returns an iterator over the client and mutable block lists pairs known to a current block store.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        self.clients.iter_mut()
     }
 
     /// Returns a state vector, which is a compact representation of the state of blocks integrated

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1034,7 +1034,8 @@ impl DocAddr {
 
 #[cfg(test)]
 mod test {
-    use crate::block::ItemContent;
+    use crate::block::{BlockCell, ItemContent, GC};
+    use crate::branch::{Branch, BranchPtr};
     use crate::test_utils::exchange_updates;
     use crate::transaction::{ReadTxn, TransactionMut};
     use crate::types::ToJson;
@@ -1042,9 +1043,10 @@ mod test {
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{
-        any, Any, Array, ArrayPrelim, ArrayRef, DeleteSet, Doc, GetString, Map, MapPrelim, MapRef,
-        OffsetKind, Options, StateVector, Subscription, Text, TextRef, Transact, Uuid, WriteTxn,
-        XmlElementPrelim, XmlFragment, XmlFragmentRef, XmlTextPrelim, XmlTextRef, ID,
+        any, Any, Array, ArrayPrelim, ArrayRef, BranchID, DeleteSet, Doc, GetString, Map,
+        MapPrelim, MapRef, OffsetKind, Options, SharedRef, StateVector, Subscription, Text,
+        TextPrelim, TextRef, Transact, Uuid, WriteTxn, XmlElementPrelim, XmlFragment,
+        XmlFragmentRef, XmlTextPrelim, XmlTextRef, ID,
     };
     use arc_swap::ArcSwapOption;
     use assert_matches2::assert_matches;
@@ -2440,5 +2442,45 @@ mod test {
         txt1.insert(&mut d1.transact_mut(), 4, " the door");
         let actual = e.swap(None);
         assert!(actual.is_none());
+    }
+
+    #[test]
+    fn force_gc() {
+        let doc = Doc::with_options(Options {
+            client_id: 1,
+            skip_gc: true,
+            ..Default::default()
+        });
+        let map = doc.get_or_insert_map("map");
+
+        {
+            // create some initial data
+            let mut txn = doc.transact_mut();
+            let txt = map.insert(&mut txn, "text", TextPrelim::default()); // <1#0>
+            txt.insert(&mut txn, 0, "abc"); // <1#1..=3>
+
+            // drop nested type
+            map.remove(&mut txn, "text");
+        }
+
+        // verify that skip_gc works and we have access to an original text content
+        let mut txn = doc.transact_mut();
+        let block = txn
+            .store()
+            .blocks
+            .get_block(&ID::new(1, 1))
+            .unwrap()
+            .as_item()
+            .unwrap();
+        assert!(block.is_deleted(), "`abc` should be marked as deleted");
+        assert_eq!(&block.content, &ItemContent::String("abc".into()));
+
+        // force GC and check if original content is hard deleted
+        txn.force_gc();
+
+        let block = txn.store().blocks.get_block(&ID::new(1, 1)).unwrap();
+        assert!(block.is_deleted(), "`abc` should be deleted");
+        assert_matches!(&block, &BlockCell::GC(_));
+        assert_eq!(block.len(), 3);
     }
 }

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -8,13 +8,22 @@ pub(crate) struct GCCollector {
 }
 
 impl GCCollector {
+    /// Garbage collect all blocks deleted within current transaction scope.
     pub fn collect(txn: &mut TransactionMut) {
+        let mut gc = Self::default();
+        gc.mark_in_scope(txn);
+        gc.collect_all_marked(txn);
+    }
+
+    /// Garbage collect all deleted blocks from current transaction's document store.
+    pub fn collect_all(txn: &mut TransactionMut) {
         let mut gc = Self::default();
         gc.mark_all(txn);
         gc.collect_all_marked(txn);
     }
 
-    fn mark_all(&mut self, txn: &mut TransactionMut) {
+    /// Mark deleted items based on a current transaction delete set.
+    fn mark_in_scope(&mut self, txn: &mut TransactionMut) {
         for (client, range) in txn.delete_set.iter() {
             if let Some(blocks) = txn.store.blocks.get_client_mut(client) {
                 for delete_item in range.iter().rev() {
@@ -33,6 +42,18 @@ impl GCCollector {
                                 i += 1;
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    fn mark_all(&mut self, txn: &mut TransactionMut) {
+        for (_, client_blocks) in txn.store.blocks.iter_mut() {
+            for block in client_blocks.iter_mut() {
+                if let BlockCell::Block(item) = block {
+                    if item.is_deleted() {
+                        item.gc(self, false);
                     }
                 }
             }

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -54,6 +54,7 @@ impl GCCollector {
                 if let BlockCell::Block(item) = block {
                     if item.is_deleted() {
                         item.gc(self, false);
+                        txn.merge_blocks.push(item.id);
                     }
                 }
             }

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -995,6 +995,13 @@ impl<'doc> TransactionMut<'doc> {
         }
     }
 
+    /// Perform garbage collection of deleted blocks, even if a document was created with `skip_gc`
+    /// option. This operation will scan over ALL deleted elements, NOT ONLY the ones that have been
+    /// changed as part of this transaction scope.
+    pub fn force_gc(&mut self) {
+        GCCollector::collect_all(self);
+    }
+
     pub(crate) fn add_changed_type(&mut self, parent: BranchPtr, parent_sub: Option<Arc<str>>) {
         let trigger = if let Some(ptr) = parent.item {
             (ptr.id().clock < self.before_state.get(&ptr.id().client)) && !ptr.is_deleted()

--- a/ywasm/src/transaction.rs
+++ b/ywasm/src/transaction.rs
@@ -422,6 +422,15 @@ impl YTransaction {
         let payload = txn.encode_update_v2();
         Uint8Array::from(payload.as_slice())
     }
+
+    /// Force garbage collection of the deleted elements, regardless of a parent doc was created
+    /// with `gc` option turned on or off.
+    #[wasm_bindgen(js_name = gc)]
+    pub fn gc(&mut self) -> Result<()> {
+        let txn = self.as_mut()?;
+        txn.force_gc();
+        Ok(())
+    }
 }
 
 impl<'doc> From<TransactionMut<'doc>> for YTransaction {


### PR DESCRIPTION
This option enables `TransactionMut::force_gc` method, that can be used to ie. in scenarios where we want to keep GC for some documents, but eventually we want to compact the document's state without having to go through encode/decode/apply cycle on the new document state.