### PR TITLE
Make StickyIndex JSON compatible with Yjs

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -2661,9 +2661,26 @@ YStickyIndex *ysticky_index_from_index(const Branch *branch,
 char *ysticky_index_encode(const YStickyIndex *pos, uint32_t *len);
 
 /**
- * Deserializes `YStickyIndex` from the payload previously serialized using `ysticky_index_encode`.
+ * Serializes `YStickyIndex` into JSON representation. `len` parameter is updated with byte
+ * length of the generated binary. Returned binary can be free'd using `ybinary_destroy`.
  */
 YStickyIndex *ysticky_index_decode(const char *binary, uint32_t len);
+
+/**
+ * Serialize `YStickyIndex` into null-terminated UTF-8 encoded JSON string, that's compatible with
+ * Yjs RelativePosition serialization format. The `len` parameter is updated with byte length of
+ * of the output JSON string.
+ * Returns null pointer if serialization failed.
+ */
+char *ysticky_index_to_json(const YStickyIndex *pos, uint32_t *len);
+
+/**
+ * Deserializes `YStickyIndex` from the payload previously serialized using `ysticky_index_to_json`.
+ * The input `json` parameter is a NULL-terminated UTF-8 encoded string containing a JSON
+ * compatible with Yjs RelativePosition serialization format.
+ * Returns null pointer if deserialization failed.
+ */
+YStickyIndex *ysticky_index_from_json(const char *json, uint32_t len);
 
 /**
  * Given `YStickyIndex` and transaction reference, if computes a human-readable index in a

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -2669,18 +2669,21 @@ YStickyIndex *ysticky_index_decode(const char *binary, uint32_t len);
 /**
  * Serialize `YStickyIndex` into null-terminated UTF-8 encoded JSON string, that's compatible with
  * Yjs RelativePosition serialization format. The `len` parameter is updated with byte length of
- * of the output JSON string.
- * Returns null pointer if serialization failed.
+ * of the output JSON string. This string can be freed using `ystring_destroy`.
  */
-char *ysticky_index_to_json(const YStickyIndex *pos, uint32_t *len);
+char *ysticky_index_to_json(const YStickyIndex *pos);
 
 /**
  * Deserializes `YStickyIndex` from the payload previously serialized using `ysticky_index_to_json`.
  * The input `json` parameter is a NULL-terminated UTF-8 encoded string containing a JSON
  * compatible with Yjs RelativePosition serialization format.
+ *
  * Returns null pointer if deserialization failed.
+ *
+ * This function DOESN'T release the `json` parameter: it needs to be done manually - if JSON
+ * string was created using `ysticky_index_to_json` function, it can be freed using `ystring_destroy`.
  */
-YStickyIndex *ysticky_index_from_json(const char *json, uint32_t len);
+YStickyIndex *ysticky_index_from_json(const char *json);
 
 /**
  * Given `YStickyIndex` and transaction reference, if computes a human-readable index in a

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -14,6 +14,11 @@
         "zlib": "^1.0.5"
       }
     },
+    "../ywasm/pkg": {
+      "name": "ywasm",
+      "version": "0.21.3",
+      "license": "MIT"
+    },
     "node_modules/isomorphic.js": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.4.tgz",
@@ -39,9 +44,8 @@
       }
     },
     "node_modules/ywasm": {
-      "version": "0.20.0",
-      "resolved": "file:../ywasm/pkg",
-      "license": "MIT"
+      "resolved": "../ywasm/pkg",
+      "link": true
     },
     "node_modules/zlib": {
       "version": "1.0.5",
@@ -68,7 +72,7 @@
       }
     },
     "ywasm": {
-      "version": "0.20.0"
+      "version": "file:../ywasm/pkg"
     },
     "zlib": {
       "version": "1.0.5",

--- a/tests-wasm/sticky-index.tests.js
+++ b/tests-wasm/sticky-index.tests.js
@@ -10,10 +10,10 @@ const checkStickyIndex = (ydoc, ytext) => {
     for (let i = 0; i < ytext.length; i++) {
         // for all types of associations..
         for (let assoc = -1; assoc < 2; assoc++) {
-            const rpos = Y.createStickyIndexFromType(ytext, i, assoc)
+            const rpos = Y.createRelativePositionFromTypeIndex(ytext, i, assoc)
             const encodedRpos = Y.encodeStickyIndex(rpos)
             const decodedRpos = Y.decodeStickyIndex(encodedRpos)
-            const absPos = (Y.createOffsetFromStickyIndex(decodedRpos, ydoc))
+            const absPos = (Y.createRelativePositionFromTypeIndex(decodedRpos, ydoc))
             t.assert(absPos.index === i)
             t.assert(absPos.assoc === assoc)
         }
@@ -94,11 +94,11 @@ export const testStickyIndexAssociationDifference = tc => {
     const ytext = ydoc.getText('test')
     ytext.insert(0, '2')
     ytext.insert(0, '1')
-    const rposRight = Y.createStickyIndexFromType(ytext, 1, 0)
-    const rposLeft = Y.createStickyIndexFromType(ytext, 1, -1)
+    const rposRight = Y.createRelativePositionFromTypeIndex(ytext, 1, 0)
+    const rposLeft = Y.createRelativePositionFromTypeIndex(ytext, 1, -1)
     ytext.insert(1, 'x')
-    const posRight = Y.createOffsetFromStickyIndex(rposRight, ydoc)
-    const posLeft = Y.createOffsetFromStickyIndex(rposLeft, ydoc)
+    const posRight = Y.createAbsolutePositionFromRelativePosition(rposRight, ydoc)
+    const posLeft = Y.createAbsolutePositionFromRelativePosition(rposLeft, ydoc)
     t.assert(posRight != null && posRight.index === 2)
     t.assert(posLeft != null && posLeft.index === 1)
 }

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -374,7 +374,7 @@ pub fn encode_state_from_snapshot_v2(doc: &Doc, snapshot: JsValue) -> Result<Vec
 ///
 /// If association is >= 0, the resulting position will point to location **after** the referenced index.
 /// If association is < 0, the resulting position will point to location **before** the referenced index.
-#[wasm_bindgen(js_name=createStickyIndexFromType)]
+#[wasm_bindgen(js_name=createRelativePositionFromTypeIndex)]
 pub fn create_sticky_index_from_type(
     ytype: &JsValue,
     index: u32,
@@ -416,7 +416,7 @@ pub fn create_sticky_index_from_type(
 
 /// Converts a sticky index (see: `createStickyIndexFromType`) into an object
 /// containing human-readable index.
-#[wasm_bindgen(js_name=createOffsetFromStickyIndex)]
+#[wasm_bindgen(js_name=createAbsolutePositionFromRelativePosition)]
 pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &Doc) -> Result<JsValue> {
     let pos: StickyIndex =
         JsValue::into_serde(rpos).map_err(|e| JsValue::from_str(&e.to_string()))?;
@@ -439,7 +439,7 @@ pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &Doc) -> Result<JsVa
 
 /// Serializes sticky index created by `createStickyIndexFromType` into a binary
 /// payload.
-#[wasm_bindgen(js_name=encodeStickyIndex)]
+#[wasm_bindgen(js_name=encodeRelativePosition)]
 pub fn encode_sticky_index(rpos: &JsValue) -> Result<Uint8Array> {
     let pos: StickyIndex =
         JsValue::into_serde(rpos).map_err(|e| JsValue::from_str(&e.to_string()))?;
@@ -448,11 +448,18 @@ pub fn encode_sticky_index(rpos: &JsValue) -> Result<Uint8Array> {
 }
 
 /// Deserializes sticky index serialized previously by `encodeStickyIndex`.
-#[wasm_bindgen(js_name=decodeStickyIndex)]
+#[wasm_bindgen(js_name=decodeRelativePosition)]
 pub fn decode_sticky_index(bin: Uint8Array) -> Result<JsValue> {
     let data: Vec<u8> = bin.to_vec();
     match StickyIndex::decode_v1(&data) {
         Ok(index) => JsValue::from_serde(&index).map_err(|e| JsValue::from_str(&e.to_string())),
         Err(err) => Err(JsValue::from_str(&err.to_string())),
     }
+}
+
+#[wasm_bindgen(js_name=compareRelativePositions)]
+pub fn sticky_index_cmp(a: JsValue, b: JsValue) -> bool {
+    let a: Option<StickyIndex> = a.into_serde().unwrap();
+    let b: Option<StickyIndex> = b.into_serde().unwrap();
+    a == b
 }


### PR DESCRIPTION
This PR changes the way how `StickyIndex` is serialised to bring it closer in compatibility with Yjs. It also renames the ywasm method names to make it compatible with Yjs and exposes its JSON serialisation/deserialization methods into yffi.