### PR TITLE
Add unreachable check to slice encode method when item has invalid parent branch

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -881,7 +881,7 @@ impl Item {
                         encoder.write_parent_info(true);
                         encoder.write_string(name);
                     } else {
-                        unreachable!()
+                        unreachable!("Could not get parent branch info for item")
                     }
                 }
                 TypePtr::Named(name) => {

--- a/yrs/src/slice.rs
+++ b/yrs/src/slice.rs
@@ -226,6 +226,8 @@ impl ItemSlice {
                     } else if let Some(name) = branch.name.as_deref() {
                         encoder.write_parent_info(true);
                         encoder.write_string(name);
+                    } else {
+                        unreachable!("Could not get parent branch info for item")
                     }
                 }
                 TypePtr::Named(name) => {


### PR DESCRIPTION
The library should panic when it fails to write the parent info for an item with a branch parent. This was done in block.rs, but was missing in slice. Add a message to `unreachable` in both places to make it easier to identify if it occurs.

I ran into this when incorrectly writing to a YMap that had just been removed from the document, resulting in a malformed update message being sent to the client.

Let me know if you prefer a different message/style, happy to make any changes.
