### PR TITLE
Add support for JSON Path expressions

### DIFF
--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -338,3 +338,38 @@ export const testIds = tc => {
     // check if first doc has correctly updated values
     t.compare(a1.toJson(), ['abc', {'key1': 'value2'}])
 }
+
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testSelectAll = tc => {
+    const doc = new Y.YDoc({clientID: 1})
+    const store = doc.getMap('store')
+    store.set('book', new Y.YArray([
+        new Y.YMap({
+            "author": "Nigel Rees",
+            "title": "Sayings of the Century",
+            "price": 8.95
+        }),
+        new Y.YMap({
+            "author": "J. R. R. Tolkien",
+            "title": "The Lord of the Rings",
+            "isbn": "0-395-19395-8",
+            "price": 22.99
+        })
+    ]))
+    store.set('bicycle', {
+        "color": "red",
+        "price": 399
+    })
+
+    let result = doc.selectAll('$.store.book[*].price')
+    t.compare(result, [8.95, 22.99])
+
+    result = doc.selectAll('$...price')
+    t.compare(result, [8.95, 22.99, 399])
+
+    result = doc.selectOne('$.store.book[1].price')
+    t.compare(result, 22.99)
+}

--- a/yffi/cbindgen.toml
+++ b/yffi/cbindgen.toml
@@ -73,6 +73,11 @@ typedef struct YArrayIter {} YArrayIter;
 typedef struct YMapIter {} YMapIter;
 
 /**
+ * Iterator structure used by shared JSON Path expressions over document content.
+ */
+typedef struct YJsonPathIter {} YJsonPathIter;
+
+/**
  * Iterator structure used by XML nodes (elements and text) to iterate over node's attributes.
  * Attribute iterators are unordered - there's no specific order in which map entries will be
  * returned during consecutive iterator calls.
@@ -107,6 +112,7 @@ exclude = [
     "WeakIter",
     "ArrayIter",
     "MapIter",
+    "JsonPathIter",
     "Attributes",
     "TreeWalker",
     "YUndoManager",
@@ -124,6 +130,7 @@ exclude = [
 "XmlText" = "YXmlText"
 "MapIter" = "YMapIter"
 "ArrayIter" = "YArrayIter"
+"JsonPathIter" = "YJsonPathIter"
 "WeakIter" = "YWeakIter"
 "TreeWalker" = "YXmlTreeWalker"
 "Attributes" = "YXmlAttrIter"

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -124,6 +124,7 @@ impl std::fmt::Debug for BlockCell {
 }
 
 impl BlockCell {
+    /// Returns the first clock sequence number of a current block.
     pub fn clock_start(&self) -> u32 {
         match self {
             BlockCell::GC(gc) => gc.start,
@@ -131,6 +132,7 @@ impl BlockCell {
         }
     }
 
+    /// Returns the last clock sequence number of a current block.
     pub fn clock_end(&self) -> u32 {
         match self {
             BlockCell::GC(gc) => gc.end,

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -427,9 +427,7 @@ impl BlockIter {
             }
         }
         self.next_item = next_item;
-        if len < 0 {
-            self.index -= len;
-        }
+        self.index -= len;
         read
     }
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1034,8 +1034,7 @@ impl DocAddr {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockCell, ItemContent, GC};
-    use crate::branch::{Branch, BranchPtr};
+    use crate::block::{BlockCell, ItemContent};
     use crate::test_utils::exchange_updates;
     use crate::transaction::{ReadTxn, TransactionMut};
     use crate::types::ToJson;
@@ -1043,10 +1042,9 @@ mod test {
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{
-        any, Any, Array, ArrayPrelim, ArrayRef, BranchID, DeleteSet, Doc, GetString, Map,
-        MapPrelim, MapRef, OffsetKind, Options, SharedRef, StateVector, Subscription, Text,
-        TextPrelim, TextRef, Transact, Uuid, WriteTxn, XmlElementPrelim, XmlFragment,
-        XmlFragmentRef, XmlTextPrelim, XmlTextRef, ID,
+        any, Any, Array, ArrayPrelim, ArrayRef, DeleteSet, Doc, GetString, Map, MapRef, OffsetKind,
+        Options, StateVector, Subscription, Text, TextPrelim, TextRef, Transact, Uuid, WriteTxn,
+        XmlElementPrelim, XmlFragment, XmlFragmentRef, XmlTextPrelim, XmlTextRef, ID,
     };
     use arc_swap::ArcSwapOption;
     use assert_matches2::assert_matches;

--- a/yrs/src/encoding/mod.rs
+++ b/yrs/src/encoding/mod.rs
@@ -9,6 +9,7 @@ mod test {
     use crate::encoding::write::Write;
     use crate::Any;
     use proptest::prelude::*;
+    use proptest_derive::Arbitrary;
 
     pub fn arb_any() -> impl Strategy<Value = Any> {
         let leaf = prop_oneof![
@@ -41,7 +42,7 @@ mod test {
         }
     }
 
-    #[derive(Debug, proptest_derive::Arbitrary)]
+    #[derive(Debug, Arbitrary)]
     enum EncodingTypes {
         Byte(u8),
         Uint8(u8),

--- a/yrs/src/encoding/serde/de.rs
+++ b/yrs/src/encoding/serde/de.rs
@@ -214,12 +214,6 @@ pub struct AnyDeserializer<'a> {
     value: &'a Any,
 }
 
-impl<'a> AnyDeserializer<'a> {
-    pub(crate) fn new(value: &'a Any) -> Self {
-        AnyDeserializer { value }
-    }
-}
-
 impl<'de, 'a: 'de> IntoDeserializer<'de, Error> for &'a Any {
     type Deserializer = AnyDeserializer<'de>;
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -11,7 +11,7 @@ use crate::ReadTxn;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
-use std::ops::{Range, RangeInclusive};
+use std::ops::Range;
 // Note: use native Rust [Range](https://doc.rust-lang.org/std/ops/struct.Range.html)
 // as it's left-inclusive/right-exclusive and defines the exact capabilities we care about here.
 
@@ -169,13 +169,11 @@ impl IdRange {
             IdRange::Fragmented(ranges) => {
                 let mut i = ranges.iter();
                 if let Some(r) = i.next() {
-                    let mut prev_start = r.start;
                     let mut prev_end = r.end;
                     while let Some(r) = i.next() {
                         if r.start < prev_end {
                             return false;
                         }
-                        prev_start = r.start;
                         prev_end = r.end;
                     }
                     true

--- a/yrs/src/json_path/iter_any.rs
+++ b/yrs/src/json_path/iter_any.rs
@@ -3,6 +3,31 @@ use crate::{Any, JsonPathEval};
 
 impl JsonPathEval for Any {
     type Iter<'a> = JsonPathIter<'a>;
+
+    /// Evaluate JSON path on the current object.
+    ///
+    /// # Example
+    /// ```rust
+    /// use yrs::{any, Any, JsonPath, JsonPathEval};
+    ///
+    /// let root = any!({
+    ///    "users": [
+    ///       {
+    ///         "name": "Alice",
+    ///         "surname": "Smith",
+    ///         "age": 25,
+    ///         "friends": [
+    ///           { "name": "Bob", "nick": "boreas" },
+    ///           { "nick": "crocodile91" }
+    ///         ]
+    ///      },
+    ///    ]
+    /// });
+    ///
+    /// let query = JsonPath::parse("$.users..friends.*.nick").unwrap();
+    /// let values: Vec<&Any> = root.json_path(&query).collect();
+    /// assert_eq!(values, vec![&any!("boreas"), &any!("crocodile91")]);
+    /// ```
     fn json_path<'a>(&'a self, path: &'a JsonPath<'a>) -> Self::Iter<'a> {
         JsonPathIter::new(self, path.as_ref())
     }

--- a/yrs/src/json_path/iter_any.rs
+++ b/yrs/src/json_path/iter_any.rs
@@ -1,0 +1,126 @@
+use super::{JsonPath, JsonPathToken};
+use crate::Any;
+
+impl Any {
+    pub fn json_path<'a>(&'a self, path: &'a JsonPath<'a>) -> JsonPathIter<'a> {
+        JsonPathIter::new(path, self)
+    }
+}
+
+pub struct JsonPathIter<'a> {
+    root: &'a Any,
+    current: &'a Any,
+    tokens: &'a [JsonPathToken<'a>],
+    index: usize,
+    stack: Vec<IterItem<'a>>,
+}
+
+impl<'a> JsonPathIter<'a> {
+    fn new(path: &'a JsonPath<'a>, root: &'a Any) -> Self {
+        Self {
+            root,
+            current: root,
+            tokens: &path.tokens,
+            index: 0,
+            stack: Vec::default(),
+        }
+    }
+}
+
+impl<'a> Iterator for JsonPathIter<'a> {
+    type Item = &'a Any;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index > self.tokens.len() {
+            None // reached the end
+        } else if self.index == self.tokens.len() {
+            self.index += 1;
+            Some(self.current)
+        } else {
+            match &self.tokens[self.index] {
+                JsonPathToken::Root => {
+                    self.current = self.root;
+                }
+                JsonPathToken::Current => { /* do nothing */ }
+                JsonPathToken::Member(key) => {
+                    if let Any::Map(map) = self.current {
+                        self.current = map.get(*key)?;
+                    }
+                }
+                JsonPathToken::Index(index) => {
+                    if let Any::Array(array) = self.current {
+                        let mut index = *index;
+                        if index < 0 {
+                            index = array.len() as i32 + index;
+                        }
+                        self.current = array.get(index as usize)?;
+                    }
+                }
+                JsonPathToken::Wildcard => {
+                    // do nothing
+                }
+                JsonPathToken::Descend => {
+                    // do nothing
+                }
+                JsonPathToken::Slice(slice) => {
+                    // do nothing
+                }
+            }
+            self.index += 1;
+            return self.next();
+        }
+    }
+}
+
+struct IterItem<'a> {
+    index: usize,
+    current: &'a Any,
+    state: IterState,
+}
+
+enum IterState {}
+
+#[cfg(test)]
+mod test {
+    use crate::json_path::JsonPath;
+    use crate::{any, Any};
+
+    fn sample() -> Any {
+        any!({
+          "friends": [
+            { "name": "Alice" },
+            { "name": "Bob" }
+          ]
+        })
+    }
+
+    #[test]
+    fn eval_member_partial() {
+        let any = sample();
+        let path = JsonPath::parse("$.friends").unwrap();
+        let values: Vec<_> = any.json_path(&path).collect();
+        assert_eq!(
+            values,
+            vec![&any!([
+              { "name": "Alice" },
+              { "name": "Bob" }
+            ])]
+        );
+    }
+
+    #[test]
+    fn eval_member_full() {
+        let any = sample();
+        let path = JsonPath::parse("$.friends[1].name").unwrap();
+        let values: Vec<_> = any.json_path(&path).collect();
+        assert_eq!(values, vec![&any!("Bob")]);
+    }
+
+    #[test]
+    fn eval_member_negative_index() {
+        let any = sample();
+        let path = JsonPath::parse("$.friends[-2].name").unwrap();
+        let values: Vec<_> = any.json_path(&path).collect();
+        assert_eq!(values, vec![&any!("Alice")]);
+    }
+}

--- a/yrs/src/json_path/iter_any.rs
+++ b/yrs/src/json_path/iter_any.rs
@@ -4,155 +4,129 @@ use proptest::num::usize;
 
 impl Any {
     pub fn json_path<'a>(&'a self, path: &'a JsonPath<'a>) -> JsonPathIter<'a> {
-        JsonPathIter::new(&path.tokens, self)
-    }
-}
-
-pub struct JsonPathIter<'a> {
-    /// Root object to start from.
-    root: &'a Any,
-    /// Current object we're at.
-    current: &'a Any,
-    /// JsonPath tokens to evaluate.
-    tokens: &'a [JsonPathToken<'a>],
-    /// Offset to tokens array, pointing to currently evaluated token.
-    index: usize,
-    /// Context used for recursive iterating, ie. recursive descent, wildcard or slices.
-    context: Option<Box<IterScope<'a>>>,
-}
-
-impl<'a> JsonPathIter<'a> {
-    fn new(tokens: &'a [JsonPathToken<'a>], root: &'a Any) -> Self {
-        Self {
-            root,
-            current: root,
-            tokens,
-            index: 0,
-            context: None,
-        }
+        let mut acc = Vec::new();
+        let root = self;
+        let current = root;
+        Self::json_path_internal(root, current, path.as_ref(), &mut acc, false);
+        Box::new(acc.into_iter())
     }
 
-    /// If current iterator works in the context of multi-value retrieval like wildcard or slice,
-    /// once a value was retrieved in current branch, we need to iterate to the next value from
-    /// the last place where wildcard or slice was located.
-    fn advance(&mut self) -> bool {
-        if let Some(item) = &mut self.context {
-            self.index = item.index;
-            let finished = match &mut item.state {
-                ScopeIterator::Iter(iter) => {
-                    if let Some(next) = iter.next() {
-                        self.current = next;
-                        false
-                    } else {
-                        true
-                    }
-                }
-            };
-            if finished {
-                // end of iterator, rollback to the previous context
-                self.current = item.current;
-                self.context = item.next.take();
-                self.index = usize::MAX; // force rollback in the next iteration
-            }
-            true
-        } else {
-            false
-        }
-    }
-
-    fn foreach(&mut self) -> Option<Box<dyn Iterator<Item = &'a Any> + 'a>> {
-        let iter: Box<dyn Iterator<Item = &'a Any> + 'a> = match self.current {
-            Any::Array(array) => Box::new(array.iter()),
-            Any::Map(map) => Box::new(map.values()),
-            _ => return None,
-        };
-        Some(iter)
-    }
-}
-
-impl<'a> Iterator for JsonPathIter<'a> {
-    type Item = &'a Any;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index > self.tokens.len() {
-            if self.advance() {
-                return self.next();
-            }
-            None // reached the end
-        } else if self.index == self.tokens.len() {
-            self.index += 1;
-            Some(self.current)
-        } else {
-            match &self.tokens[self.index] {
-                JsonPathToken::Root => self.current = self.root,
+    fn json_path_internal<'a>(
+        root: &'a Self,
+        mut current: &'a Self,
+        pattern: &'a [JsonPathToken<'a>],
+        acc: &mut Vec<&'a Any>,
+        is_descending: bool,
+    ) {
+        let mut early_return = false;
+        for i in 0..pattern.len() {
+            let segment = &pattern[i];
+            match segment {
+                JsonPathToken::Root => current = root,
                 JsonPathToken::Current => { /* do nothing */ }
                 JsonPathToken::Member(key) => {
-                    if let Any::Map(map) = self.current {
-                        println!("pick key: {} from {}", key, self.current);
-                        self.current = match map.get(*key) {
-                            Some(child) => child,
+                    if let Any::Map(map) = current {
+                        current = match map.get(*key) {
+                            Some(value) => value,
                             None => {
-                                //TODO: if we didn't match the key and we're descending, just allocate next
-                                // scope, self.index-- and continue
-                                todo!()
+                                early_return = true;
+                                break;
+                            }
+                        }
+                    } else {
+                        early_return = true;
+                    }
+                }
+                JsonPathToken::Index(idx) => {
+                    if let Any::Array(array) = current {
+                        let idx = if *idx < 0 {
+                            array.len() as i32 + idx
+                        } else {
+                            *idx
+                        } as usize;
+                        current = match array.get(idx) {
+                            Some(value) => value,
+                            None => {
+                                early_return = true;
+                                break;
                             }
                         };
+                    } else {
+                        early_return = true;
                     }
                 }
-                JsonPathToken::Index(index) => {
-                    if let Any::Array(array) = self.current {
-                        let mut index = *index;
-                        if index < 0 {
-                            index = array.len() as i32 + index;
-                        }
-                        println!("pick index: {} from {}", index, self.current);
-                        self.current = array.get(index as usize)?;
-                        //TODO: if we didn't match the key and we're descending, just allocate next
-                        // scope, self.index-- and continue
-                    }
-                }
-                JsonPathToken::Wildcard => {
-                    if let Some(mut iter) = self.foreach() {
-                        if let Some(next) = iter.next() {
-                            let context = IterScope {
-                                next: self.context.take(),
-                                index: self.index,
-                                current: self.current,
-                                state: ScopeIterator::Iter(iter),
-                            };
-                            self.current = next;
-                            self.context = Some(Box::new(context));
+                JsonPathToken::Wildcard => match current {
+                    Any::Array(array) => {
+                        let pattern = &pattern[i + 1..];
+                        for any in array.iter() {
+                            Self::json_path_internal(root, any, pattern, acc, false);
                         }
                     }
-                }
+                    Any::Map(map) => {
+                        let pattern = &pattern[i + 1..];
+                        for any in map.values() {
+                            Self::json_path_internal(root, any, pattern, acc, false);
+                        }
+                    }
+                    _ => early_return = true,
+                },
+                JsonPathToken::RecursiveDescend => match current {
+                    Any::Array(array) => {
+                        let pattern = &pattern[i + 1..];
+                        for any in array.iter() {
+                            Self::json_path_internal(root, any, pattern, acc, true);
+                        }
+                    }
+                    Any::Map(map) => {
+                        let pattern = &pattern[i + 1..];
+                        for any in map.values() {
+                            Self::json_path_internal(root, any, pattern, acc, true);
+                        }
+                    }
+                    _ => early_return = true,
+                },
                 JsonPathToken::Slice(from, to, by) => {
-                    if let Some(mut iter) = self.foreach() {
-                        iter = Box::new(
-                            iter.skip(*from as usize)
-                                .take((*to - *from) as usize)
-                                .step_by(*by as usize),
-                        );
-                        if let Some(next) = iter.next() {
-                            let context = IterScope {
-                                next: self.context.take(),
-                                index: self.index,
-                                current: self.current,
-                                state: ScopeIterator::Iter(iter),
-                            };
-                            self.current = next;
-                            self.context = Some(Box::new(context));
+                    if let Any::Array(array) = current {
+                        let from = *from as usize;
+                        let to = array.len().min(*to as usize);
+                        let by = *by;
+                        let mut iter = array.iter().skip(from).take(to - from).step_by(by as usize);
+                        let pattern = &pattern[i + 1..];
+                        for any in iter {
+                            Self::json_path_internal(root, any, pattern, acc, false);
                         }
+                    } else {
+                        early_return = true;
                     }
-                }
-                JsonPathToken::Descend => {
-                    todo!("recursive descent");
                 }
             }
-            self.index += 1;
-            return self.next();
+
+            if early_return {
+                break;
+            }
+        }
+
+        if !early_return {
+            acc.push(current);
+        } else if is_descending {
+            match current {
+                Any::Array(array) => {
+                    for any in array.iter() {
+                        Self::json_path_internal(root, any, pattern, acc, true);
+                    }
+                }
+                Any::Map(map) => {
+                    for any in map.values() {
+                        Self::json_path_internal(root, any, pattern, acc, true);
+                    }
+                }
+                _ => { /* do nothing */ }
+            }
         }
     }
 }
+
+pub type JsonPathIter<'a> = Box<dyn Iterator<Item = &'a Any> + 'a>;
 
 /// Scope used for recursive iteration, i.e. wildcard, descent or slice.
 struct IterScope<'a> {
@@ -179,37 +153,79 @@ mod test {
 
     fn mixed_sample() -> Any {
         any!({
-          "friends": [
-            { "name": "Alice" },
-            { "nick": "boreas" },
-            { "nick": "crocodile91" },
-            { "name": "Damian" },
-            { "name": "Elise" },
-          ]
+            "users": [
+                {
+                    "name": "Alice",
+                    "surname": "Smith",
+                    "age": 25,
+                    "friends": [
+                        { "name": "Bob", "nick": "boreas" },
+                        { "nick": "crocodile91" }
+                    ]
+                },
+                {
+                    "name": "Bob",
+                    "nick": "boreas",
+                    "age": 30
+                },
+                {
+                    "nick": "crocodile91",
+                    "age": 35
+                },
+                {
+                    "name": "Damian",
+                    "surname": "Smith",
+                    "age": 30
+                },
+                {
+                    "name": "Elise",
+                    "age": 35
+                }
+            ]
         })
     }
 
     #[test]
     fn eval_member_partial() {
         let any = mixed_sample();
-        let path = JsonPath::parse("$.friends").unwrap();
+        let path = JsonPath::parse("$.users").unwrap();
         let values: Vec<_> = any.json_path(&path).collect();
-        assert_eq!(
-            values,
-            vec![&any!([
-              { "name": "Alice" },
-              { "nick": "boreas" },
-              { "nick": "crocodile91" },
-              { "name": "Damian" },
-              { "name": "Elise" },
-            ])]
-        );
+        let expected = any!([
+            {
+                "name": "Alice",
+                "surname": "Smith",
+                "age": 25,
+                "friends": [
+                    { "name": "Bob", "nick": "boreas" },
+                    { "nick": "crocodile91" }
+                ]
+            },
+            {
+                "name": "Bob",
+                "nick": "boreas",
+                "age": 30
+            },
+            {
+                "nick": "crocodile91",
+                "age": 35
+            },
+            {
+                "name": "Damian",
+                "surname": "Smith",
+                "age": 30
+            },
+            {
+                "name": "Elise",
+                "age": 35
+            }
+        ]);
+        assert_eq!(values, vec![&expected]);
     }
 
     #[test]
     fn eval_member_full() {
         let any = mixed_sample();
-        let path = JsonPath::parse("$.friends[0].name").unwrap();
+        let path = JsonPath::parse("$.users[0].name").unwrap();
         let values: Vec<_> = any.json_path(&path).collect();
         assert_eq!(values, vec![&any!("Alice")]);
     }
@@ -217,7 +233,7 @@ mod test {
     #[test]
     fn eval_member_negative_index() {
         let any = mixed_sample();
-        let path = JsonPath::parse("$.friends[-1].name").unwrap();
+        let path = JsonPath::parse("$.users[-1].name").unwrap();
         let values: Vec<_> = any.json_path(&path).collect();
         assert_eq!(values, vec![&any!("Elise")]);
     }
@@ -225,14 +241,13 @@ mod test {
     #[test]
     fn eval_member_wildcard_array() {
         let any = mixed_sample();
-        let path = JsonPath::parse("$.friends[*].name").unwrap();
+        let path = JsonPath::parse("$.users[*].name").unwrap();
         let values: Vec<_> = any.json_path(&path).collect();
         assert_eq!(
             values,
             vec![
                 &any!("Alice"),
-                &Any::Undefined,
-                &Any::Undefined,
+                &any!("Bob"),
                 &any!("Damian"),
                 &any!("Elise")
             ]
@@ -242,8 +257,53 @@ mod test {
     #[test]
     fn eval_member_slice() {
         let any = mixed_sample();
-        let path = JsonPath::parse("$.friends[1:3].nick").unwrap();
+        let path = JsonPath::parse("$.users[1:3].nick").unwrap();
         let values: Vec<_> = any.json_path(&path).collect();
         assert_eq!(values, vec![&any!("boreas"), &any!("crocodile91")]);
+    }
+
+    #[test]
+    fn eval_descent_flat() {
+        let any = mixed_sample();
+        let path = JsonPath::parse("$.users..name").unwrap();
+        let values: Vec<_> = any.json_path(&path).collect();
+        assert_eq!(
+            values,
+            vec![
+                &any!("Alice"),
+                &any!("Bob"),
+                &any!("Damian"),
+                &any!("Elise")
+            ]
+        );
+    }
+
+    #[test]
+    fn eval_descent_multi_level() {
+        let any = any!({
+            "a": {
+                "b1": {
+                    "c": {
+                        "f": {
+                            "name": "Alice"
+                        }
+                    }
+                },
+                "b2": {
+                    "d": {
+                        "c": {
+                            "g": {
+                                "h": {
+                                    "name": "Bob"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let path = JsonPath::parse("$..c..name").unwrap();
+        let values: Vec<_> = any.json_path(&path).collect();
+        assert_eq!(values, vec![&any!("Alice"), &any!("Bob")]);
     }
 }

--- a/yrs/src/json_path/iter_txn.rs
+++ b/yrs/src/json_path/iter_txn.rs
@@ -1,6 +1,6 @@
 use crate::any::AnyArrayIter;
 use crate::json_path::JsonPathToken;
-use crate::{Any, Array, JsonPath, JsonPathEval, Map, Out, ReadTxn, Transact, Xml, XmlFragment};
+use crate::{Any, Array, JsonPath, JsonPathEval, Map, Out, ReadTxn, Xml, XmlFragment};
 
 impl<T> JsonPathEval for T
 where
@@ -367,7 +367,7 @@ type ScopeIterator<'a> = Box<dyn Iterator<Item = Out> + 'a>;
 #[cfg(test)]
 mod test {
     use crate::{
-        any, Array, ArrayPrelim, Doc, In, JsonPath, JsonPathEval, Map, MapPrelim, Out, ReadTxn,
+        any, Array, ArrayPrelim, Doc, In, JsonPath, JsonPathEval, MapPrelim, Out, ReadTxn,
         Transact, WriteTxn,
     };
 

--- a/yrs/src/json_path/iter_txn.rs
+++ b/yrs/src/json_path/iter_txn.rs
@@ -10,6 +10,36 @@ where
         = JsonPathIter<'a, T>
     where
         T: 'a;
+
+    /// Evaluate JSON path on the current transaction, starting from current transaction [Doc] as
+    /// its root.
+    ///
+    /// # Example
+    /// ```rust
+    /// use yrs::{any, Array, ArrayPrelim, Doc, In, JsonPath, JsonPathEval, Map, MapPrelim, Out, Transact, WriteTxn};
+    ///
+    /// let doc = Doc::new();
+    /// let mut txn = doc.transact_mut();
+    /// let users = txn.get_or_insert_array("users");
+    ///
+    /// // populate the document with some data to query
+    /// users.insert(&mut txn, 0, MapPrelim::from([
+    ///     ("name".to_string(), In::Any(any!("Alice"))),
+    ///     ("surname".into(), In::Any(any!("Smith"))),
+    ///     ("age".into(), In::Any(any!(25))),
+    ///     (
+    ///         "friends".into(),
+    ///         In::from(ArrayPrelim::from([
+    ///             any!({ "name": "Bob", "nick": "boreas" }),
+    ///             any!({ "nick": "crocodile91" }),
+    ///         ])),
+    ///     ),
+    /// ]));
+    ///
+    /// let query = JsonPath::parse("$.users..friends.*.nick").unwrap();
+    /// let values: Vec<Out> = txn.json_path(&query).collect();
+    /// assert_eq!(values, vec![Out::Any(any!("boreas")), Out::Any(any!("crocodile91"))]);
+    /// ```
     fn json_path<'a>(&'a self, path: &'a JsonPath<'a>) -> Self::Iter<'a> {
         JsonPathIter::new(self, path.as_ref())
     }

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -1,4 +1,3 @@
-use crate::json_path::iter_any::JsonPathIter;
 use std::fmt::{Display, Formatter};
 
 mod iter_any;

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -1,7 +1,17 @@
+use crate::json_path::iter_any::JsonPathIter;
 use std::fmt::{Display, Formatter};
 
 mod iter_any;
+mod iter_txn;
 mod parse;
+
+/// Trait implemented by types capable of evaluating JSON Paths.
+pub trait JsonPathEval {
+    type Iter<'a>
+    where
+        Self: 'a;
+    fn json_path<'a>(&'a self, path: &'a JsonPath<'a>) -> Self::Iter<'a>;
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct JsonPath<'a> {

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Formatter};
-use std::ops::Range;
 
 mod iter_any;
 mod parse;

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -22,7 +22,7 @@ pub(super) enum JsonPathToken<'a> {
     Member(&'a str),
     Index(i32),
     Wildcard,
-    Descend,
+    RecursiveDescend,
     Slice(u32, u32, u32),
 }
 
@@ -40,7 +40,7 @@ impl<'a> Display for JsonPathToken<'a> {
             }
             JsonPathToken::Index(index) => write!(f, "[{}]", index),
             JsonPathToken::Wildcard => write!(f, ".*"),
-            JsonPathToken::Descend => write!(f, ".."),
+            JsonPathToken::RecursiveDescend => write!(f, ".."),
             JsonPathToken::Slice(from, to, by) => write!(f, "[{}:{}:{}]", from, to, by),
         }
     }

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -23,7 +23,7 @@ pub(super) enum JsonPathToken<'a> {
     Index(i32),
     Wildcard,
     Descend,
-    Slice(Range<u32>),
+    Slice(u32, u32, u32),
 }
 
 impl<'a> Display for JsonPathToken<'a> {
@@ -41,7 +41,7 @@ impl<'a> Display for JsonPathToken<'a> {
             JsonPathToken::Index(index) => write!(f, "[{}]", index),
             JsonPathToken::Wildcard => write!(f, ".*"),
             JsonPathToken::Descend => write!(f, ".."),
-            JsonPathToken::Slice(slice) => write!(f, "[{}:{}]", slice.start, slice.end),
+            JsonPathToken::Slice(from, to, by) => write!(f, "[{}:{}:{}]", from, to, by),
         }
     }
 }

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -4,6 +4,8 @@ mod iter_any;
 mod iter_txn;
 mod parse;
 
+pub use iter_txn::JsonPathIter;
+
 /// Trait implemented by types capable of evaluating JSON Paths.
 pub trait JsonPathEval {
     type Iter<'a>

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -24,6 +24,8 @@ pub(super) enum JsonPathToken<'a> {
     Wildcard,
     RecursiveDescend,
     Slice(u32, u32, u32),
+    MemberUnion(Vec<&'a str>),
+    IndexUnion(Vec<i32>),
 }
 
 impl<'a> Display for JsonPathToken<'a> {
@@ -42,6 +44,28 @@ impl<'a> Display for JsonPathToken<'a> {
             JsonPathToken::Wildcard => write!(f, ".*"),
             JsonPathToken::RecursiveDescend => write!(f, ".."),
             JsonPathToken::Slice(from, to, by) => write!(f, "[{}:{}:{}]", from, to, by),
+            JsonPathToken::MemberUnion(members) => {
+                let mut i = members.iter();
+                write!(f, "[")?;
+                if let Some(m) = i.next() {
+                    write!(f, "{}", m)?;
+                }
+                while let Some(m) = i.next() {
+                    write!(f, ", {}", m)?;
+                }
+                write!(f, "]")
+            }
+            JsonPathToken::IndexUnion(indices) => {
+                let mut i = indices.iter();
+                write!(f, "[")?;
+                if let Some(m) = i.next() {
+                    write!(f, "{}", m)?;
+                }
+                while let Some(m) = i.next() {
+                    write!(f, ", {}", m)?;
+                }
+                write!(f, "]")
+            }
         }
     }
 }

--- a/yrs/src/json_path/mod.rs
+++ b/yrs/src/json_path/mod.rs
@@ -1,0 +1,53 @@
+use std::fmt::{Display, Formatter};
+use std::ops::Range;
+
+mod iter_any;
+mod parse;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsonPath<'a> {
+    tokens: Vec<JsonPathToken<'a>>,
+}
+
+impl<'a> AsRef<[JsonPathToken<'a>]> for JsonPath<'a> {
+    fn as_ref(&self) -> &[JsonPathToken<'a>] {
+        &self.tokens
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum JsonPathToken<'a> {
+    Root,
+    Current,
+    Member(&'a str),
+    Index(i32),
+    Wildcard,
+    Descend,
+    Slice(Range<u32>),
+}
+
+impl<'a> Display for JsonPathToken<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonPathToken::Root => write!(f, r#"$"#),
+            JsonPathToken::Current => write!(f, "@"),
+            JsonPathToken::Member(key) => {
+                if key.chars().any(char::is_whitespace) {
+                    write!(f, "['{}']", key)
+                } else {
+                    write!(f, ".{}", key)
+                }
+            }
+            JsonPathToken::Index(index) => write!(f, "[{}]", index),
+            JsonPathToken::Wildcard => write!(f, ".*"),
+            JsonPathToken::Descend => write!(f, ".."),
+            JsonPathToken::Slice(slice) => write!(f, "[{}:{}]", slice.start, slice.end),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("{0}")]
+    InvalidJsonPath(String),
+}

--- a/yrs/src/json_path/parse.rs
+++ b/yrs/src/json_path/parse.rs
@@ -1,5 +1,4 @@
 use super::{JsonPath, JsonPathToken, ParseError};
-use std::fmt::Display;
 use std::str::FromStr;
 
 impl<'a> JsonPath<'a> {
@@ -191,7 +190,6 @@ fn invalid_char(c: char, path: &str) -> ParseError {
 #[cfg(test)]
 mod test {
     use crate::json_path::parse::{JsonPath, JsonPathToken};
-    use fastrand::u32;
 
     #[test]
     fn parse_root() {

--- a/yrs/src/json_path/parse.rs
+++ b/yrs/src/json_path/parse.rs
@@ -1,0 +1,228 @@
+use super::{JsonPath, JsonPathToken, ParseError};
+use std::fmt::Display;
+use std::str::FromStr;
+
+impl<'a> JsonPath<'a> {
+    pub fn parse(path: &'a str) -> Result<Self, ParseError> {
+        let mut tokens = Vec::new();
+        let mut i = 0;
+        let mut iter = path.chars().peekable();
+        while let Some(c) = iter.next() {
+            i += c.len_utf8();
+            match c {
+                '$' => tokens.push(JsonPathToken::Root),
+                '@' => tokens.push(JsonPathToken::Current),
+                '.' => {
+                    let c = iter.peek();
+                    match c {
+                        Some('.') => {
+                            tokens.push(JsonPathToken::Descend);
+                            iter.next();
+                            i += 1;
+                        }
+                        Some('*') => {
+                            tokens.push(JsonPathToken::Wildcard);
+                            iter.next();
+                            i += 1;
+                        }
+                        Some(a) if a.is_alphabetic() => {
+                            let start = i;
+                            while let Some(a) = iter.peek() {
+                                if a.is_alphanumeric() || a == &'_' {
+                                    i += a.len_utf8();
+                                    iter.next();
+                                } else {
+                                    break;
+                                }
+                            }
+                            let end = i;
+                            let member = &path[start..end];
+                            tokens.push(JsonPathToken::Member(member));
+                        }
+                        Some(a) => {
+                            return Err(invalid_char(*a, path));
+                        }
+                        None => {
+                            return Err(ParseError::InvalidJsonPath(format!(
+                                "Path cannot end with '.': '{}'",
+                                path
+                            )))
+                        }
+                    }
+                }
+                '[' => {
+                    let start = i;
+                    let mut slice = &path[i..];
+                    let mut quote_start = false;
+                    for c in iter.by_ref() {
+                        i += c.len_utf8();
+                        if c == ']' && !quote_start {
+                            slice = &slice[..(i - start - 1)];
+                            break;
+                        }
+                        if c == '\'' {
+                            quote_start = !quote_start;
+                        }
+                    }
+                    if slice == "*" {
+                        tokens.push(JsonPathToken::Wildcard);
+                    } else if let Ok(index) = slice.parse::<i32>() {
+                        tokens.push(JsonPathToken::Index(index));
+                    } else if slice.contains(':') {
+                        let mut split = slice.split(':');
+                        let start = split
+                            .next()
+                            .and_then(|s| u32::from_str(s).ok())
+                            .unwrap_or(0);
+                        let end = split
+                            .next()
+                            .and_then(|s| u32::from_str(s).ok())
+                            .unwrap_or(u32::MAX);
+                        tokens.push(JsonPathToken::Slice(start..end));
+                    } else if slice.starts_with('\'') && slice.ends_with('\'') {
+                        let member = &slice[1..slice.len() - 1];
+                        tokens.push(JsonPathToken::Member(member));
+                    } else {
+                        return Err(ParseError::InvalidJsonPath(format!(
+                            "substring '{}' is not supported: '{}'",
+                            slice, path
+                        )));
+                    }
+                }
+                '*' => tokens.push(JsonPathToken::Wildcard),
+                c if c.is_alphabetic() => {}
+                _ => {
+                    return Err(invalid_char(c, path));
+                }
+            }
+        }
+        Ok(JsonPath { tokens })
+    }
+}
+
+fn invalid_char(c: char, path: &str) -> ParseError {
+    ParseError::InvalidJsonPath(format!("Invalid character '{}' in path: '{}'", c, path))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::json_path::parse::{JsonPath, JsonPathToken};
+    use fastrand::u32;
+
+    #[test]
+    fn parse_root() {
+        let path = JsonPath::parse("$").unwrap();
+        assert_eq!(path.tokens, vec![JsonPathToken::Root]);
+    }
+
+    #[test]
+    fn parse_current() {
+        let path = JsonPath::parse("@").unwrap();
+        assert_eq!(path.tokens, vec![JsonPathToken::Current]);
+    }
+
+    #[test]
+    fn parse_wildcard() {
+        let path = JsonPath::parse("$.*").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Wildcard]
+        );
+    }
+
+    #[test]
+    fn parse_wildcard_quoted() {
+        let path = JsonPath::parse("$[*]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Wildcard]
+        );
+    }
+
+    #[test]
+    fn parse_descend() {
+        let path = JsonPath::parse("$..").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Descend]
+        );
+    }
+
+    #[test]
+    fn parse_dot_member() {
+        let path = JsonPath::parse("$.key").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Member("key")]
+        );
+    }
+
+    #[test]
+    fn parse_quote_member() {
+        let path = JsonPath::parse("$['key']").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Member("key")]
+        );
+    }
+
+    #[test]
+    fn parse_index() {
+        let path = JsonPath::parse("$[0]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Index(0)]
+        );
+    }
+
+    #[test]
+    fn parse_negative_index() {
+        let path = JsonPath::parse("$[-3]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Index(-3)]
+        );
+    }
+
+    #[test]
+    fn parse_slice_bounded() {
+        let path = JsonPath::parse("$[1:3]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Slice(1..3)]
+        );
+    }
+
+    #[test]
+    fn parse_slice_left_unbounded() {
+        let path = JsonPath::parse("$[:3]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Slice(0..3)]
+        );
+    }
+
+    #[test]
+    fn parse_slice_right_unbounded() {
+        let path = JsonPath::parse("$[3:]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![JsonPathToken::Root, JsonPathToken::Slice(3..u32::MAX)]
+        );
+    }
+
+    #[test]
+    fn parse_complex() {
+        let path = JsonPath::parse("$.key_1[0].key2[*]").unwrap();
+        assert_eq!(
+            path.tokens,
+            vec![
+                JsonPathToken::Root,
+                JsonPathToken::Member("key_1"),
+                JsonPathToken::Index(0),
+                JsonPathToken::Member("key2"),
+                JsonPathToken::Wildcard
+            ]
+        );
+    }
+}

--- a/yrs/src/json_path/parse.rs
+++ b/yrs/src/json_path/parse.rs
@@ -16,7 +16,7 @@ impl<'a> JsonPath<'a> {
                     let c = iter.peek();
                     match c {
                         Some('.') => {
-                            tokens.push(JsonPathToken::Descend);
+                            tokens.push(JsonPathToken::RecursiveDescend);
                             iter.next();
                             i += 1;
                         }
@@ -162,7 +162,7 @@ mod test {
         let path = JsonPath::parse("$..").unwrap();
         assert_eq!(
             path.tokens,
-            vec![JsonPathToken::Root, JsonPathToken::Descend]
+            vec![JsonPathToken::Root, JsonPathToken::RecursiveDescend]
         );
     }
 
@@ -173,7 +173,7 @@ mod test {
             path.tokens,
             vec![
                 JsonPathToken::Root,
-                JsonPathToken::Descend,
+                JsonPathToken::RecursiveDescend,
                 JsonPathToken::Member("name")
             ]
         );

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -563,6 +563,38 @@
 //! }
 //! ```
 //!
+//! # Querying document state
+//!
+//! Starting from version 0.23.0 Yrs provides a way to query document state using [JsonPath] queries.
+//! These are available for transactions and [Any] types. They allow to extract specific parts of
+//! the document state in a way similar to [JSONPath](https://en.wikipedia.org/wiki/JSONPath):
+//!
+//! ```rust
+//! use yrs::{any, Array, ArrayPrelim, Doc, In, JsonPath, JsonPathEval, Map, MapPrelim, Out, Transact, WriteTxn};
+//!
+//! let doc = Doc::new();
+//! let mut txn = doc.transact_mut();
+//! let users = txn.get_or_insert_array("users");
+//!
+//! // populate the document with some data to query
+//! users.insert(&mut txn, 0, MapPrelim::from([
+//!     ("name".to_string(), In::Any(any!("Alice"))),
+//!     ("surname".into(), In::Any(any!("Smith"))),
+//!     ("age".into(), In::Any(any!(25))),
+//!     (
+//!         "friends".into(),
+//!         In::from(ArrayPrelim::from([
+//!             any!({ "name": "Bob", "nick": "boreas" }),
+//!             any!({ "nick": "crocodile91" }),
+//!         ])),
+//!     ),
+//! ]));
+//!
+//! let query = JsonPath::parse("$.users..friends.*.nick").unwrap();
+//! let values: Vec<Out> = txn.json_path(&query).collect();
+//! assert_eq!(values, vec![Out::Any(any!("boreas")), Out::Any(any!("crocodile91"))]);
+//! ```
+//!
 //! # External learning materials
 //!
 //! - [A short walkthrough over YATA](https://bartoszsypytkowski.com/yata/) - a conflict resolution

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -624,7 +624,7 @@ pub mod error;
 mod gc;
 mod input;
 pub mod iter;
-mod json_path;
+pub mod json_path;
 mod moving;
 pub mod observer;
 mod out;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -592,6 +592,7 @@ pub mod error;
 mod gc;
 mod input;
 pub mod iter;
+mod json_path;
 mod moving;
 pub mod observer;
 mod out;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -622,6 +622,7 @@ pub use crate::doc::Options;
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
 pub use crate::id_set::DeleteSet;
 pub use crate::input::In;
+pub use crate::json_path::{JsonPath, JsonPathEval};
 pub use crate::moving::Assoc;
 pub use crate::moving::IndexScope;
 pub use crate::moving::IndexedSequence;

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -1082,14 +1082,14 @@ mod test {
         );
         let json2 = serde_json::to_value(&data).unwrap();
         assert_eq!(
-            json["cursor"]["anchor"]["item"],
+            json2["cursor"]["anchor"]["item"],
             serde_json::json!({"client":3731284436u32,"clock":20})
         );
-        assert_eq!(json["cursor"]["anchor"]["assoc"], serde_json::json!(-1));
+        assert_eq!(json2["cursor"]["anchor"]["assoc"], serde_json::json!(-1));
         assert_eq!(
-            json["cursor"]["head"]["item"],
+            json2["cursor"]["head"]["item"],
             serde_json::json!({"client":3731284436u32,"clock":20})
         );
-        assert_eq!(json["cursor"]["head"]["assoc"], serde_json::json!(-1));
+        assert_eq!(json2["cursor"]["head"]["assoc"], serde_json::json!(-1));
     }
 }

--- a/yrs/src/slice.rs
+++ b/yrs/src/slice.rs
@@ -142,24 +142,6 @@ impl ItemSlice {
         self.end -= count;
     }
 
-    /// Attempts to trim current block slice to provided range of IDs.
-    /// Returns true if current block slice range has been modified as a result of this action.
-    pub fn try_trim(&mut self, from: &ID, to: &ID) -> bool {
-        let id = self.ptr.id;
-        let mut changed = false;
-        let start_clock = id.clock + self.start;
-        let end_clock = id.clock + self.end;
-        if id.client == from.client && from.clock > start_clock && from.clock <= end_clock {
-            self.start = from.clock - start_clock;
-            changed = true;
-        }
-        if id.client == to.client && to.clock >= start_clock && to.clock < end_clock {
-            self.end = end_clock - to.clock;
-            changed = true;
-        }
-        changed
-    }
-
     /// Returns true when current [ItemSlice] left boundary is equal to the boundary of the
     /// [ItemPtr] this slice wraps.
     pub fn adjacent_left(&self) -> bool {

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -120,7 +120,7 @@ impl Store {
     ) -> BranchPtr {
         let key = key.into();
         match self.types.entry(key.clone()) {
-            Entry::Occupied(mut e) => {
+            Entry::Occupied(e) => {
                 let mut branch = BranchPtr::from(e.get());
                 branch.repair_type_ref(type_ref);
                 branch

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1067,13 +1067,6 @@ impl<'doc> TransactionMut<'doc> {
     }
 
     #[cfg(feature = "weak")]
-    fn link(&mut self, mut source: ItemPtr, link: BranchPtr) {
-        source.info.set_linked();
-        let links = self.store.linked_by.entry(source).or_default();
-        links.insert(link);
-    }
-
-    #[cfg(feature = "weak")]
     pub(crate) fn unlink(&mut self, mut source: ItemPtr, link: BranchPtr) {
         let all_links = &mut self.store.linked_by;
         let prune = if let Some(linked_by) = all_links.get_mut(&source) {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -8,7 +8,7 @@ use crate::id_set::DeleteSet;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::store::{Store, StoreEvents, SubdocGuids, SubdocsIter};
-use crate::types::{Event, Events, RootRef, SharedRef, TypePtr, TypeRef};
+use crate::types::{Event, Events, RootRef, TypePtr, TypeRef};
 use crate::update::Update;
 use crate::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use crate::utils::OptionExt;

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -8,13 +8,13 @@ use crate::id_set::DeleteSet;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::store::{Store, StoreEvents, SubdocGuids, SubdocsIter};
-use crate::types::{Event, Events, RootRef, SharedRef, TypePtr};
+use crate::types::{Event, Events, RootRef, SharedRef, TypePtr, TypeRef};
 use crate::update::Update;
 use crate::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use crate::utils::OptionExt;
 use crate::{
     merge_updates_v1, merge_updates_v2, ArrayRef, BranchID, Doc, MapRef, Out, Snapshot,
-    StateVector, TextRef, Transact, XmlFragmentRef,
+    StateVector, TextRef, Transact, XmlElementRef, XmlFragmentRef, XmlTextRef,
 };
 use async_lock::{RwLockReadGuard, RwLockWriteGuard};
 use smallvec::SmallVec;
@@ -171,6 +171,24 @@ pub trait ReadTxn: Sized {
     #[inline]
     fn get_xml_fragment<N: Into<Arc<str>>>(&self, name: N) -> Option<XmlFragmentRef> {
         XmlFragmentRef::root(name).get(self)
+    }
+
+    fn get<S: AsRef<str>>(&self, name: S) -> Option<Out> {
+        let value = self.store().types.get(name.as_ref())?;
+        let ptr = BranchPtr::from(&*value);
+        match &ptr.type_ref {
+            TypeRef::Array => Some(Out::YArray(ArrayRef::from(ptr))),
+            TypeRef::Map => Some(Out::YMap(MapRef::from(ptr))),
+            TypeRef::Text => Some(Out::YText(TextRef::from(ptr))),
+            TypeRef::XmlElement(_) => Some(Out::YXmlElement(XmlElementRef::from(ptr))),
+            TypeRef::XmlFragment => Some(Out::YXmlFragment(XmlFragmentRef::from(ptr))),
+            TypeRef::XmlHook => None,
+            TypeRef::XmlText => Some(Out::YXmlText(XmlTextRef::from(ptr))),
+            TypeRef::SubDoc => Some(Out::YDoc(ptr.as_subdoc()?)),
+            #[cfg(feature = "weak")]
+            TypeRef::WeakLink(_) => Some(Out::YWeakLink(crate::WeakRef::from(ptr))),
+            TypeRef::Undefined => Some(Out::UndefinedRef(ptr)),
+        }
     }
 
     /// If current document has been inserted as a sub-document, returns a reference to a parent

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -423,14 +423,14 @@ where
 }
 
 pub struct MapIntoIter<'a, T> {
-    txn: &'a T,
+    _txn: &'a T,
     entries: std::collections::hash_map::IntoIter<Arc<str>, ItemPtr>,
 }
 
 impl<'a, T: ReadTxn> MapIntoIter<'a, T> {
     fn new(map: BranchPtr, txn: &'a T) -> Self {
         let entries = map.map.clone().into_iter();
-        MapIntoIter { txn, entries }
+        MapIntoIter { _txn: txn, entries }
     }
 }
 

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -588,15 +588,6 @@ where
     }
 }
 
-impl<'a, T: ReadTxn> Entries<'a, T, T>
-where
-    T: Borrow<T> + ReadTxn,
-{
-    pub fn from(source: &'a HashMap<Arc<str>, ItemPtr>, txn: T) -> Self {
-        Entries::new(source, txn)
-    }
-}
-
 impl<'a, T: ReadTxn> Entries<'a, &'a T, T>
 where
     T: Borrow<T> + ReadTxn,

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -613,27 +613,6 @@ where
     }
 }
 
-pub(crate) struct Iter<'a, T> {
-    ptr: Option<&'a ItemPtr>,
-    _txn: &'a T,
-}
-
-impl<'a, T: ReadTxn> Iter<'a, T> {
-    fn new(ptr: Option<&'a ItemPtr>, txn: &'a T) -> Self {
-        Iter { ptr, _txn: txn }
-    }
-}
-
-impl<'a, T: ReadTxn> Iterator for Iter<'a, T> {
-    type Item = &'a Item;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let item = self.ptr.take()?;
-        self.ptr = item.right.as_ref();
-        Some(item)
-    }
-}
-
 /// Type pointer - used to localize a complex [Branch] node within a scope of a document store.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum TypePtr {

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -202,6 +202,16 @@ impl TryFrom<Out> for XmlOut {
     }
 }
 
+impl From<XmlOut> for Out {
+    fn from(value: XmlOut) -> Self {
+        match value {
+            XmlOut::Element(xml) => Out::YXmlElement(xml),
+            XmlOut::Fragment(xml) => Out::YXmlFragment(xml),
+            XmlOut::Text(xml) => Out::YXmlText(xml),
+        }
+    }
+}
+
 impl TryFrom<ItemPtr> for XmlOut {
     type Error = ItemPtr;
 

--- a/ywasm/src/array.rs
+++ b/ywasm/src/array.rs
@@ -148,7 +148,7 @@ impl YArray {
 
     /// Deletes a range of items of given `length` from current `YArray` instance,
     /// starting from given `index`.
-    #[wasm_bindgen(method, js_name = "delete")]
+    #[wasm_bindgen(js_name = "delete")]
     pub fn delete(
         &mut self,
         index: u32,

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -389,6 +389,48 @@ impl YDoc {
             }
         }
     }
+
+    /// Evaluates a JSON path expression (see: https://en.wikipedia.org/wiki/JSONPath) on
+    /// the document and returns an array of values matching that query.
+    ///
+    /// Currently, this method supports the following syntax:
+    /// - `$` - root object
+    /// - `@` - current object
+    /// - `.field` or `['field']` - member accessor
+    /// - `[1]` - array index (also supports negative indices)
+    /// - `.*` or `[*]` - wildcard (matches all members of an object or array)
+    /// - `..` - recursive descent (matches all descendants not only direct children)
+    /// - `[start:end:step]` - array slice operator (requires positive integer arguments)
+    /// - `['a', 'b', 'c']` - union operator (returns an array of values for each query)
+    /// - `[1, -1, 3]` - multiple indices operator (returns an array of values for each index)
+    ///
+    /// At the moment, JSON Path does not support filter predicates.
+    #[wasm_bindgen(js_name = selectAll)]
+    pub fn select_all(&self, json_path: &str) -> Result<js_sys::Array> {
+        let txn = self.transaction(JsValue::UNDEFINED);
+        txn.select_all(json_path)
+    }
+
+    /// Evaluates a JSON path expression (see: https://en.wikipedia.org/wiki/JSONPath) on
+    /// the document and returns first value matching that query.
+    ///
+    /// Currently, this method supports the following syntax:
+    /// - `$` - root object
+    /// - `@` - current object
+    /// - `.field` or `['field']` - member accessor
+    /// - `[1]` - array index (also supports negative indices)
+    /// - `.*` or `[*]` - wildcard (matches all members of an object or array)
+    /// - `..` - recursive descent (matches all descendants not only direct children)
+    /// - `[start:end:step]` - array slice operator (requires positive integer arguments)
+    /// - `['a', 'b', 'c']` - union operator (returns an array of values for each query)
+    /// - `[1, -1, 3]` - multiple indices operator (returns an array of values for each index)
+    ///
+    /// At the moment, JSON Path does not support filter predicates.
+    #[wasm_bindgen(js_name = selectOne)]
+    pub fn select_one(&self, json_path: &str) -> Result<JsValue> {
+        let txn = self.transaction(JsValue::UNDEFINED);
+        txn.select_one(json_path)
+    }
 }
 
 #[wasm_bindgen]

--- a/ywasm/src/map.rs
+++ b/ywasm/src/map.rs
@@ -129,7 +129,7 @@ impl YMap {
     }
 
     /// Removes an entry identified by a given `key` from this instance of `YMap`, if such exists.
-    #[wasm_bindgen(method, js_name = delete)]
+    #[wasm_bindgen(js_name = delete)]
     pub fn delete(&mut self, key: &str, txn: ImplicitTransaction) -> crate::Result<()> {
         match &mut self.0 {
             SharedCollection::Prelim(c) => {

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -253,9 +253,9 @@ impl YText {
         }
     }
 
-    /// Deletes a specified range of of characters, starting at a given `index`.
+    /// Deletes a specified range of characters, starting at a given `index`.
     /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
-    #[wasm_bindgen(method, js_name = delete)]
+    #[wasm_bindgen(js_name = delete)]
     pub fn delete(
         &mut self,
         index: u32,

--- a/ywasm/src/xml_elem.rs
+++ b/ywasm/src/xml_elem.rs
@@ -181,7 +181,7 @@ impl YXmlElement {
         }
     }
 
-    #[wasm_bindgen(method, js_name = delete)]
+    #[wasm_bindgen(js_name = delete)]
     pub fn delete(
         &mut self,
         index: u32,

--- a/ywasm/src/xml_frag.rs
+++ b/ywasm/src/xml_frag.rs
@@ -106,7 +106,7 @@ impl YXmlFragment {
         }
     }
 
-    #[wasm_bindgen(method, js_name = delete)]
+    #[wasm_bindgen(js_name = delete)]
     pub fn delete(
         &mut self,
         index: u32,

--- a/ywasm/src/xml_text.rs
+++ b/ywasm/src/xml_text.rs
@@ -293,9 +293,9 @@ impl YXmlText {
         }
     }
 
-    /// Deletes a specified range of of characters, starting at a given `index`.
+    /// Deletes a specified range of characters, starting at a given `index`.
     /// Both `index` and `length` are counted in terms of a number of UTF-8 character bytes.
-    #[wasm_bindgen(method, js_name = delete)]
+    #[wasm_bindgen(js_name = delete)]
     pub fn delete(
         &mut self,
         index: u32,


### PR DESCRIPTION
This PR add support to JSON Path on two levels:
1. `Any` type which is our version of JSON super-type, which has extra support to ie. binary data. Example: `any!({"foo": "bar"}).json_path(&JsonPath:parse("$.foo"))`. This one is very cheap, non-copying and returns only references.
2. `Transaction` level support, which works across yrs shared collections AND nested `Any` types within these collections, meaning if part of the JSON Path reaches into `Any` object stored within shared collection, the evaluator will continue picking up only these values that JSONPath picked. This one is copying `Any` values and may occasionally copy contents as well.

Currently supported experssions:
- [x] Root `$` and current `@` pointers.
- [x] MapRef/Any::Map member access i.e. `$.member` or `$['member']`
- [x] MapRef/Any::Map member unions i.e. `$['a', 'b', 'c']`
- [x] ArrayRef/Any::Array index access i.e. `$[1]` (also  supports negative indexes like `$[-1]`).
- [x] ArrayRef/Any::Array index unions i.e. `$[1, 3, -1]`
- [x] ArrayRef/Any::Array slices with steps i.e. `$[1:]`, `$[:2]`, `$[1:3]` and `$[1:10:2]`. Requires positive indexes.
- [x] ArrayRef/MapRef/Any::Array/Any::Map wildcard operators i.e. `$.*`, `$[*]`
- [x] Recursive descent i.e. `$.member...inner`
- [ ] Predicates are **NOT supported** at the moment. *They require more time to evaluate how to support them properly and will be implemented in the future*