### PR TITLE
release v0.23.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Release packages
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,7 +1233,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yffi"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "serde_json",
  "yrs",
@@ -1241,7 +1241,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "arc-swap",
  "assert_matches2",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -14,11 +14,6 @@
         "zlib": "^1.0.5"
       }
     },
-    "../ywasm/pkg": {
-      "name": "ywasm",
-      "version": "0.22.0",
-      "license": "MIT"
-    },
     "node_modules/isomorphic.js": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.4.tgz",
@@ -44,8 +39,9 @@
       }
     },
     "node_modules/ywasm": {
-      "resolved": "../ywasm/pkg",
-      "link": true
+      "version": "0.23.0",
+      "resolved": "file:../ywasm/pkg",
+      "license": "MIT"
     },
     "node_modules/zlib": {
       "version": "1.0.5",
@@ -72,7 +68,7 @@
       }
     },
     "ywasm": {
-      "version": "file:../ywasm/pkg"
+      "version": "0.23.0"
     },
     "zlib": {
       "version": "1.0.5",

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.22.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.23.0", features = ["weak"] }
 serde_json = { version = "1.0" }
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.22.0"
+version = "0.23.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.22.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.23.0", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
- JSON Path support for Any and Doc
- Update:EMPTY_V1 and Update::EMPTY_V2 byte arrays for empty content
- Update::state_vector now doesn't include disjoined update blocks