### PR TITLE
yffi: add yweak_read to convert WeakRef back to indexes

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -2740,6 +2740,12 @@ void yweak_destroy(const Weak *weak);
 
 struct YOutput *yweak_deref(const Branch *map_link, const YTransaction *txn);
 
+void yweak_read(const Branch *text_link,
+                const YTransaction *txn,
+                Branch **out_branch,
+                uint32_t *out_start_index,
+                uint32_t *out_end_index);
+
 YWeakIter *yweak_iter(const Branch *array_link, const YTransaction *txn);
 
 void yweak_iter_destroy(YWeakIter *iter);

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -5585,6 +5585,39 @@ pub unsafe extern "C" fn yweak_deref(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn yweak_read(text_link: *const Branch,
+    txn: *const Transaction,
+    out_branch: *mut *mut Branch,
+    out_start_index: *mut u32,
+    out_end_index: *mut u32,
+) {
+    assert!(!text_link.is_null());
+    assert!(!txn.is_null());
+
+    let txn = txn.as_ref().unwrap();
+    let weak: WeakRef<BranchPtr> = WeakRef::from_raw_branch(text_link);
+    if let Some(id) = weak.start_id() {
+        // Assoc must be After to get the same values back
+        let start = StickyIndex::from_id(*id, Assoc::After);
+        assert!(weak.end_id() != None);
+        let end = StickyIndex::from_id(*weak.end_id().unwrap(), Assoc::After);
+        if let Some(start_pos) = start.get_offset(txn) {
+            *out_branch = start_pos.branch.as_ref() as *const Branch as *mut Branch;
+            *out_start_index = start_pos.index as u32;
+            if let Some(end_pos) = end.get_offset(txn) {
+                assert!(*out_branch == end_pos.branch.as_ref() as *const Branch as *mut Branch);
+                *out_end_index = end_pos.index as u32;
+            }
+        }
+    } else {
+        assert!(weak.end_id() == None); // both
+        // unforunately no Branch in this case?
+        *out_start_index = 0; // empty text
+        *out_end_index = 0; // empty text
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn yweak_iter(
     array_link: *const Branch,
     txn: *const Transaction,


### PR DESCRIPTION
Currently it's possible to get or iterate the content of the WeakRef, but not to get the current indexes into a YText back.

[This is an implementation that doesn't change the core yrs crate, only yffi; not sure if it's the best way to do it, or if i interpret the "no start_id()" case correctly...] 