### PR TITLE
Modify EntryChange::Removed Debug formatting to avoid panics

### DIFF
--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -270,7 +270,7 @@ impl Branch {
         } else if let Some(name) = &self.name {
             BranchID::Root(name.clone())
         } else {
-            unreachable!()
+            unreachable!("Could not get ID for branch")
         }
     }
 

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -721,7 +721,7 @@ pub enum Change {
 }
 
 /// A single change done over a map-component of shared data type.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum EntryChange {
     /// Informs about a new value inserted under specified entry.
     Inserted(Out),
@@ -732,6 +732,32 @@ pub enum EntryChange {
 
     /// Informs about a removal of a corresponding entry - contains a removed value.
     Removed(Out),
+}
+
+impl std::fmt::Debug for EntryChange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EntryChange::Inserted(out) => write!(f, "Inserted({out:?})"),
+            EntryChange::Updated(old, new) => write!(f, "Updated({old:?}, {new:?})"),
+            EntryChange::Removed(out) => {
+                f.write_str("Removed(")?;
+                // To avoid panicking on removed references, output the type name rather than the reference.
+                match out {
+                    Out::Any(any) => write!(f, "{any:?}")?,
+                    Out::YText(_) => write!(f, "YText")?,
+                    Out::YArray(_) => write!(f, "YArray")?,
+                    Out::YMap(_) => write!(f, "YMap")?,
+                    Out::YXmlElement(_) => write!(f, "YXmlElement")?,
+                    Out::YXmlFragment(_) => write!(f, "YXmlFragment")?,
+                    Out::YXmlText(_) => write!(f, "YXmlText")?,
+                    Out::YDoc(_) => write!(f, "YDoc")?,
+                    Out::YWeakLink(_) => write!(f, "YWeakLink")?,
+                    Out::UndefinedRef(_) => write!(f, "UndefinedRef")?,
+                }
+                f.write_str(")")
+            }
+        }
+    }
 }
 
 /// A single change done over a text-like types: [Text] or [XmlText].


### PR DESCRIPTION
Since the value is already removed, debug formatting would panic calling the Branch::id method on the reference. The best we can do is print the type, it's better than nothing.

```
internal error: entered unreachable code
stack backtrace:
   0: rust_begin_unwind
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:695:5
   1: core::panicking::panic_fmt
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/panicking.rs:75:14
   2: core::panicking::panic
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/panicking.rs:145:5
   3: yrs::branch::Branch::id
             at /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/yrs-0.23.0/src/branch.rs:273:13
   4: <yrs::branch::BranchPtr as core::fmt::Debug>::fmt
             at /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/yrs-0.23.0/src/branch.rs:168:27
```

Fixes https://github.com/y-crdt/y-crdt/issues/538