### PR TITLE
Support JsonPath queries over UndefinedRef types

### DIFF
--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -751,6 +751,7 @@ impl std::fmt::Debug for EntryChange {
                     Out::YXmlFragment(_) => write!(f, "YXmlFragment")?,
                     Out::YXmlText(_) => write!(f, "YXmlText")?,
                     Out::YDoc(_) => write!(f, "YDoc")?,
+                    #[cfg(feature = "weak")]
                     Out::YWeakLink(_) => write!(f, "YWeakLink")?,
                     Out::UndefinedRef(_) => write!(f, "UndefinedRef")?,
                 }


### PR DESCRIPTION
This PR extends `transaction.json_path` to support cases when `Out::UndefinedRef` has been returned (which can be common occurence for docs to be recreated from scratch). We simply assume names to target MapRef, indexes to target ArrayRef, and things like wildcard iterators to target ArrayRef if list component was found and MapRefs otherwise.