### PR TITLE
Bump this error to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,18 +930,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -15,7 +15,7 @@ weak = []
 sync = []
 
 [dependencies]
-thiserror = "1"
+thiserror = "2"
 fastrand = { version = "2", features = ["js"] }
 smallstr = { version = "0.3", features = ["union"] }
 smallvec = { version = "1.13", features = ["union", "const_generics", "const_new"] }


### PR DESCRIPTION
Bump this error to v2. None of the major version [release notes](https://github.com/dtolnay/thiserror/releases/tag/2.0.0) apply [here](https://github.com/search?q=repo%3Ay-crdt%2Fy-crdt+%22%23%5Berror%28%22&type=code).
