### PR TITLE
align Skip encoding with Yjs format

### DIFF
--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -944,7 +944,8 @@ impl BlockCarrier {
             }
             BlockCarrier::Skip(x) => {
                 encoder.write_info(BLOCK_SKIP_REF_NUMBER);
-                encoder.write_len(x.len - offset);
+                // write as VarUint because Skips can't make use of predictable length-encoding
+                encoder.write_var(x.len - offset);
             }
             BlockCarrier::GC(x) => {
                 encoder.write_info(BLOCK_GC_REF_NUMBER);


### PR DESCRIPTION
Hey, thanks for the great work on Yjs — we’ve been able to add real-time collaboration to our product because of it!

We’ve recently been trying to migrate our Yjs server over to yrs. During testing, we hit a panic when loading updates into YDoc. After digging in, it looks like yrs isn’t able to decode updates created with encode_state_as_update_v2.

I spent a few hours comparing things between Yjs and Yrs and found that the encoding of Skip differs. After tweaking the code to match Yjs’s behavior, the binary output matched and the panic was gone.

I’ve attached the update file that was causing the issue (encoded with`encode_state_as_update_v1` and write it with `std::fs::write`), in case it helps.

Also, fair warning — I’m pretty new to Rust and still learning my way around Yjs/Yrs, I don't known how to write the tests, so let me know if anything looks off. 