### PR TITLE
Weak links: remove reference to an item

### DIFF
--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -364,10 +364,11 @@ export const testSelectAll = tc => {
         "price": 399
     })
 
-    let result = doc.selectAll('$.store.book[*].price')
-    t.compare(result, [8.95, 22.99])
+    t.compare([8.95, 22.99], doc.selectAll('$.store.book[*].price'))
 
-    result = doc.selectAll('$...price')
+    let result = doc.selectAll('$...price')
+    // we sort results because YMap doesn't guarantee order
+    result.sort((a, b) => a - b)
     t.compare(result, [8.95, 22.99, 399])
 
     result = doc.selectOne('$.store.book[1].price')

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,5 +1,4 @@
 use crate::block::{BlockCell, BlockRange, ClientID, Item, ItemPtr, GC, ID};
-use crate::encoding::read::Error;
 use crate::slice::ItemSlice;
 use crate::types::TypePtr;
 use crate::utils::client_hasher::ClientHasher;

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -3,7 +3,7 @@ use crate::branch::BranchPtr;
 use crate::encoding::read::Error;
 use crate::event::{SubdocsEvent, TransactionCleanupEvent, UpdateEvent};
 use crate::store::{DocStore, StoreInner};
-use crate::transaction::{Origin, Transaction, TransactionMut};
+use crate::transaction::{Origin, TransactionMut};
 use crate::types::{RootRef, ToJson};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
@@ -21,7 +21,7 @@ use std::sync::Arc;
 /// A Yrs document type. Documents are the most important units of collaborative resources management.
 /// All shared collections live within a scope of their corresponding documents. All updates are
 /// generated on per-document basis (rather than individual shared type). All operations on shared
-/// collections happen via [Transaction], which lifetime is also bound to a document.
+/// collections happen via [Transaction](crate::Transaction), which lifetime is also bound to a document.
 ///
 /// Document manages so-called root types, which are top-level shared types definitions (as opposed
 /// to recursively nested types).

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -606,6 +606,37 @@ impl StickyIndex {
             true
         }
     }
+
+    pub(crate) fn get_item<T: ReadTxn>(&self, txn: &T) -> Option<ItemPtr> {
+        let branch = match &self.scope {
+            IndexScope::Relative(id) => {
+                // position relative to existing block
+                return txn.store().blocks.get_item(id);
+            }
+            IndexScope::Nested(id) => {
+                // position at the beginning/end of a nested type
+                let item = txn.store().blocks.get_item(id)?;
+                item.as_branch()?
+            }
+            IndexScope::Root(name) => {
+                // position at the beginning/end of a root type
+                let branch = txn.store().types.get(name.as_ref())?;
+                BranchPtr::from(branch)
+            }
+        };
+        match &self.assoc {
+            // get first item of a branch
+            Assoc::Before => branch.start,
+            // get last item of a branch
+            Assoc::After => {
+                let mut item = branch.item?;
+                while let Some(right) = item.right {
+                    item = right;
+                }
+                Some(item)
+            }
+        }
+    }
 }
 
 impl Encode for StickyIndex {

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -611,7 +611,12 @@ impl StickyIndex {
         let branch = match &self.scope {
             IndexScope::Relative(id) => {
                 // position relative to existing block
-                return txn.store().blocks.get_item(id);
+                let item = txn.store().blocks.get_item(id)?;
+                return if self.assoc == Assoc::After && &item.last_id() == id {
+                    item.right
+                } else {
+                    Some(item)
+                };
             }
             IndexScope::Nested(id) => {
                 // position at the beginning/end of a nested type

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1060,7 +1060,7 @@ impl<'doc> TransactionMut<'doc> {
         }
     }
 
-    //#[cfg(feature = "weak")]
+    #[cfg(feature = "weak")]
     pub(crate) fn unlink(&mut self, mut source: ItemPtr, link: BranchPtr) {
         let all_links = &mut self.store.linked_by;
         let prune = if let Some(linked_by) = all_links.get_mut(&source) {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -676,12 +676,6 @@ impl<'doc> TransactionMut<'doc> {
                 if let Some(linked_by) = self.store.linked_by.remove(&item) {
                     for link in linked_by {
                         self.add_changed_type(link, item.parent_sub.clone());
-                        #[cfg(feature = "weak")]
-                        if let crate::types::TypeRef::WeakLink(source) = &link.type_ref {
-                            if source.is_single() {
-                                source.first_item.take();
-                            }
-                        }
                     }
                 }
             }
@@ -1066,7 +1060,7 @@ impl<'doc> TransactionMut<'doc> {
         }
     }
 
-    #[cfg(feature = "weak")]
+    //#[cfg(feature = "weak")]
     pub(crate) fn unlink(&mut self, mut source: ItemPtr, link: BranchPtr) {
         let all_links = &mut self.store.linked_by;
         let prune = if let Some(linked_by) = all_links.get_mut(&source) {

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -299,7 +299,7 @@ where
     P: SharedRef + Array,
 {
     /// Returns an iterator over [Out]s existing in a scope of the current [WeakRef] quotation
-    /// range.  
+    /// range.
     pub fn unquote<'a, T: ReadTxn>(&self, txn: &'a T) -> Unquote<'a, T> {
         if let Some(source) = self.try_source() {
             source.unquote(txn)
@@ -361,7 +361,7 @@ where
     P: SharedRef + Array,
 {
     /// Returns an iterator over [Out]s existing in a scope of the current [WeakPrelim] quotation
-    /// range.  
+    /// range.
     pub fn unquote<'a, T: ReadTxn>(&self, txn: &'a T) -> Unquote<'a, T> {
         self.source.unquote(txn)
     }
@@ -1101,6 +1101,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(target_os = "windows", ignore)]
     fn delete_weak_link() {
         let d1 = Doc::new();
         let m1 = d1.get_or_insert_map("map");

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1132,8 +1132,8 @@ mod test {
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::Encode;
     use crate::{
-        Any, DeleteSet, Doc, GetString, Options, ReadTxn, StateVector, Text, Transact, WriteTxn,
-        XmlFragment, XmlOut, ID,
+        Any, DeleteSet, Doc, GetString, Options, ReadTxn, StateVector, Text, Transact, XmlFragment,
+        XmlOut, ID,
     };
 
     #[test]
@@ -1449,14 +1449,14 @@ mod test {
 
     #[test]
     fn empty_update_v1() {
-        let mut u = Update::new();
+        let u = Update::new();
         let binary = u.encode_v1();
         assert_eq!(&binary, Update::EMPTY_V1)
     }
 
     #[test]
     fn empty_update_v2() {
-        let mut u = Update::new();
+        let u = Update::new();
         let binary = u.encode_v2();
         assert_eq!(&binary, Update::EMPTY_V2)
     }


### PR DESCRIPTION
This PR removes a relation to `ItemPtr` from within WeakRef `LinkSource`. This should fix #536 . We used item pointers cache for faster access, but in retrospect it doesn't help a lot while introducing risk of stale memory pointers.