### PR TITLE
Unbounded quote

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -2766,15 +2766,15 @@ const Weak *ymap_link(const Branch *map, const YTransaction *txn, const char *ke
 
 const Weak *ytext_quote(const Branch *text,
                         YTransaction *txn,
-                        const uint32_t *start_index,
-                        const uint32_t *end_index,
+                        uint32_t *start_index,
+                        uint32_t *end_index,
                         int8_t start_exclusive,
                         int8_t end_exclusive);
 
 const Weak *yarray_quote(const Branch *array,
                          YTransaction *txn,
-                         uint32_t start_index,
-                         uint32_t end_index,
+                         uint32_t *start_index,
+                         uint32_t *end_index,
                          int8_t start_exclusive,
                          int8_t end_exclusive);
 

--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -2766,8 +2766,8 @@ const Weak *ymap_link(const Branch *map, const YTransaction *txn, const char *ke
 
 const Weak *ytext_quote(const Branch *text,
                         YTransaction *txn,
-                        uint32_t start_index,
-                        uint32_t end_index,
+                        const uint32_t *start_index,
+                        const uint32_t *end_index,
                         int8_t start_exclusive,
                         int8_t end_exclusive);
 

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1872,7 +1872,7 @@ TEST_CASE("Weak link references") {
     ytext_insert(txt, txn, 0, "hello world!", NULL);
 
     // create a text quotation and put it into map
-    YInput value = yinput_weak(ytext_quote(txt, txn, 2, 10, Y_FALSE, Y_FALSE));
+    YInput value = yinput_weak(ytext_quote(txt, txn, &2, &10, Y_FALSE, Y_FALSE));
     ymap_insert(map, txn, "text-txt_link", &value);
     Branch *txt_link = youtput_read_yweak(ymap_get(map, txn, "text-txt_link"));
 
@@ -1903,7 +1903,7 @@ TEST_CASE("Weak link references") {
         yinput_long(4),
     };
     yarray_insert_range(arr, txn, 0, items, 4);
-    value = yinput_weak(yarray_quote(arr, txn, 1, 3, Y_FALSE, Y_TRUE));
+    value = yinput_weak(yarray_quote(arr, txn, &1, &3, Y_FALSE, Y_TRUE));
     ymap_insert(map, txn, "array-txt_link", &value);
     Branch *array_link = youtput_read_yweak(ymap_get(map, txn, "array-txt_link"));
 

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1872,7 +1872,9 @@ TEST_CASE("Weak link references") {
     ytext_insert(txt, txn, 0, "hello world!", NULL);
 
     // create a text quotation and put it into map
-    YInput value = yinput_weak(ytext_quote(txt, txn, &2, &10, Y_FALSE, Y_FALSE));
+    uint32_t start = 2;
+    uint32_t end = 10;
+    YInput value = yinput_weak(ytext_quote(txt, txn, &start, &end, Y_FALSE, Y_FALSE));
     ymap_insert(map, txn, "text-txt_link", &value);
     Branch *txt_link = youtput_read_yweak(ymap_get(map, txn, "text-txt_link"));
 
@@ -1903,7 +1905,9 @@ TEST_CASE("Weak link references") {
         yinput_long(4),
     };
     yarray_insert_range(arr, txn, 0, items, 4);
-    value = yinput_weak(yarray_quote(arr, txn, &1, &3, Y_FALSE, Y_TRUE));
+    start = 1;
+    end = 3;
+    value = yinput_weak(yarray_quote(arr, txn, &start, &end, Y_FALSE, Y_TRUE));
     ymap_insert(map, txn, "array-txt_link", &value);
     Branch *array_link = youtput_read_yweak(ymap_get(map, txn, "array-txt_link"));
 

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -14,11 +14,6 @@
         "zlib": "^1.0.5"
       }
     },
-    "../ywasm/pkg": {
-      "name": "ywasm",
-      "version": "0.23.4",
-      "license": "MIT"
-    },
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
@@ -51,8 +46,9 @@
       }
     },
     "node_modules/ywasm": {
-      "resolved": "../ywasm/pkg",
-      "link": true
+      "version": "0.23.4",
+      "resolved": "file:../ywasm/pkg",
+      "license": "MIT"
     },
     "node_modules/zlib": {
       "version": "1.0.5",

--- a/tests-wasm/y-weak-link.tests.js
+++ b/tests-wasm/y-weak-link.tests.js
@@ -968,3 +968,35 @@ export const testArrayUpperBoundary = tc => {
     t.compare(linkInclusive.unquote(), ['b', 'c', 'd', 'e'])
     t.compare(linkExclusive.unquote(), ['b', 'c', 'd', 'e', 'x', 'y', 'z'])
 }
+
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testTextUnbounded = tc => {
+    const doc0 = new Y.YDoc({clientID: 1})
+    const text0 = doc0.getText('text')
+    const array0 = doc0.getArray('array')
+    const doc1 = new Y.YDoc({clientID: 2})
+    const text1 = doc1.getText('text')
+
+    text0.insert(0, 'def')
+
+    exchangeUpdates([doc0, doc1])
+
+    // everything up to ..de
+    const linkInclusive = text0.quote(null, 1, false, false)
+    // everything from ef..
+    const linkExclusive = text0.quote(1, null, false, false)
+    array0.insert(0, [linkInclusive, linkExclusive])
+    t.compare(linkInclusive.toString(), 'de')
+    t.compare(linkExclusive.toString(), 'ef')
+
+    text1.insert(0, 'abc')
+    text1.insert(text1.length(), 'ghi')
+
+    exchangeUpdates([doc0, doc1])
+
+    t.compare(linkInclusive.toString(), 'abcde')
+    t.compare(linkExclusive.toString(), 'efghi')
+}

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -5721,8 +5721,8 @@ pub unsafe extern "C" fn ymap_link(
 pub unsafe extern "C" fn ytext_quote(
     text: *const Branch,
     txn: *mut Transaction,
-    start_index: *const u32,
-    end_index: *const u32,
+    start_index: *mut u32,
+    end_index: *mut u32,
     start_exclusive: i8,
     end_exclusive: i8,
 ) -> *const Weak {
@@ -5755,8 +5755,8 @@ pub unsafe extern "C" fn ytext_quote(
 pub unsafe extern "C" fn yarray_quote(
     array: *const Branch,
     txn: *mut Transaction,
-    start_index: *const u32,
-    end_index: *const u32,
+    start_index: *mut u32,
+    end_index: *mut u32,
     start_exclusive: i8,
     end_exclusive: i8,
 ) -> *const Weak {

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/y-crdt/y-crdt/"
 readme = "./README.md"
 
 [features]
+default = []
 weak = []
 sync = []
 

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -437,6 +437,36 @@ impl StickyIndex {
         &self.scope
     }
 
+    /// Scope refers to root collection.
+    #[inline]
+    pub fn is_root(&self) -> bool {
+        if let IndexScope::Root(_) = &self.scope {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Scope refers to nested shared collection.
+    #[inline]
+    pub fn is_nested(&self) -> bool {
+        if let IndexScope::Nested(_) = &self.scope {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Scope refers to a position relative to another block.
+    #[inline]
+    pub fn is_relative(&self) -> bool {
+        if let IndexScope::Relative(_) = &self.scope {
+            true
+        } else {
+            false
+        }
+    }
+
     /// Returns an [ID] of the block position which is used as a reference to keep track the location
     /// of current [StickyIndex] even in face of changes performed by different peers.
     ///

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -14,8 +14,8 @@ use crate::iter::{
 };
 use crate::types::{AsPrelim, Branch, BranchPtr, Out, Path, SharedRef, TypeRef};
 use crate::{
-    Array, Assoc, DeepObservable, GetString, In, Map, Observable, ReadTxn, StickyIndex, TextRef,
-    TransactionMut, XmlTextRef, ID,
+    Array, Assoc, BranchID, DeepObservable, GetString, In, IndexScope, Map, Observable, ReadTxn,
+    StickyIndex, TextRef, TransactionMut, XmlTextRef, ID,
 };
 
 /// Weak link reference represents a reference to a single element or consecutive range of elements
@@ -497,9 +497,10 @@ impl LinkSource {
         }
     }
 
+    #[inline]
     pub fn is_single(&self) -> bool {
-        match (self.quote_start.id(), self.quote_end.id()) {
-            (Some(x), Some(y)) => x == y,
+        match (self.quote_start.scope(), self.quote_end.scope()) {
+            (IndexScope::Relative(x), IndexScope::Relative(y)) => x == y,
             _ => false,
         }
     }
@@ -586,20 +587,24 @@ impl LinkSource {
     pub fn to_string<T: ReadTxn>(&self, txn: &T) -> String {
         let mut result = String::new();
         let mut curr = self.quote_start.get_item(txn);
-        let end = self.quote_end.id().unwrap();
+        let end = self.quote_end.id();
         while let Some(item) = curr.as_deref() {
-            if self.quote_end.assoc == Assoc::Before && &item.id == end {
-                // right side is open (last item excluded)
-                break;
+            if let Some(end) = end {
+                if self.quote_end.assoc == Assoc::Before && &item.id == end {
+                    // right side is open (last item excluded)
+                    break;
+                }
             }
             if !item.is_deleted() {
                 if let ItemContent::String(s) = &item.content {
                     result.push_str(s.as_str());
                 }
             }
-            if self.quote_end.assoc == Assoc::After && &item.last_id() == end {
-                // right side is closed (last item included)
-                break;
+            if let Some(end) = end {
+                if self.quote_end.assoc == Assoc::After && &item.last_id() == end {
+                    // right side is closed (last item included)
+                    break;
+                }
             }
             curr = item.right;
         }
@@ -692,71 +697,86 @@ pub trait Quotable: AsRef<Branch> + Sized {
         R: RangeBounds<u32>,
     {
         let this = BranchPtr::from(self.as_ref());
-        let (start, assoc_start) = match range.start_bound() {
-            Bound::Included(&i) => (i, Assoc::Before),
-            Bound::Excluded(&i) => (i, Assoc::After),
-            Bound::Unbounded => return Err(QuoteError::UnboundedRange),
+        let start = match range.start_bound() {
+            Bound::Included(&i) => Some((i, Assoc::Before)),
+            Bound::Excluded(&i) => Some((i, Assoc::After)),
+            Bound::Unbounded => None,
         };
-        let (end, assoc_end) = match range.end_bound() {
-            Bound::Included(&i) => (i, Assoc::After),
-            Bound::Excluded(&i) => (i, Assoc::Before),
-            Bound::Unbounded => return Err(QuoteError::UnboundedRange),
+        let end = match range.end_bound() {
+            Bound::Included(&i) => Some((i, Assoc::After)),
+            Bound::Excluded(&i) => Some((i, Assoc::Before)),
+            Bound::Unbounded => None,
         };
-        let mut remaining = start;
         let encoding = txn.store().offset_kind;
+        let mut start_index = 0;
+        let mut remaining = start_index;
+        let mut curr = None;
         let mut i = this.start.to_iter().moved();
-        // figure out the first ID
-        let mut curr = i.next(txn);
-        while let Some(item) = curr.as_deref() {
-            if remaining == 0 {
-                break;
-            }
-            if !item.is_deleted() && item.is_countable() {
-                let len = item.content_len(encoding);
-                if remaining < len {
+
+        let start = if let Some((start_i, assoc_start)) = start {
+            start_index = start_i;
+            remaining = start_index;
+            // figure out the first ID
+            curr = i.next(txn);
+            while let Some(item) = curr.as_deref() {
+                if remaining == 0 {
                     break;
                 }
-                remaining -= len;
-            }
-            curr = i.next(txn);
-        }
-        let start_id = if let Some(item) = curr.as_deref() {
-            let mut id = item.id.clone();
-            id.clock += if let ItemContent::String(s) = &item.content {
-                s.block_offset(remaining, encoding)
-            } else {
-                remaining
-            };
-            id
-        } else {
-            return Err(QuoteError::OutOfBounds);
-        };
-        // figure out the last ID
-        remaining = end - start + remaining;
-        while let Some(item) = curr.as_deref() {
-            if !item.is_deleted() && item.is_countable() {
-                let len = item.content_len(encoding);
-                if remaining < len {
-                    break;
+                if !item.is_deleted() && item.is_countable() {
+                    let len = item.content_len(encoding);
+                    if remaining < len {
+                        break;
+                    }
+                    remaining -= len;
                 }
-                remaining -= len;
+                curr = i.next(txn);
             }
-            curr = i.next(txn);
-        }
-        let end_id = if let Some(item) = curr.as_deref() {
-            let mut id = item.id.clone();
-            id.clock += if let ItemContent::String(s) = &item.content {
-                s.block_offset(remaining, encoding)
+            let start_id = if let Some(item) = curr.as_deref() {
+                let mut id = item.id.clone();
+                id.clock += if let ItemContent::String(s) = &item.content {
+                    s.block_offset(remaining, encoding)
+                } else {
+                    remaining
+                };
+                id
             } else {
-                remaining
+                return Err(QuoteError::OutOfBounds);
             };
-            id
+            StickyIndex::new(IndexScope::Relative(start_id), assoc_start)
         } else {
-            return Err(QuoteError::OutOfBounds);
+            curr = i.next(txn);
+            StickyIndex::new(IndexScope::from_branch(this), Assoc::Before)
         };
 
-        let start = StickyIndex::from_id(start_id, assoc_start);
-        let end = StickyIndex::from_id(end_id, assoc_end);
+        let end = if let Some((end_index, assoc_end)) = end {
+            // figure out the last ID
+            remaining = end_index - start_index + remaining;
+            while let Some(item) = curr.as_deref() {
+                if !item.is_deleted() && item.is_countable() {
+                    let len = item.content_len(encoding);
+                    if remaining < len {
+                        break;
+                    }
+                    remaining -= len;
+                }
+                curr = i.next(txn);
+            }
+            let end_id = if let Some(item) = curr.as_deref() {
+                let mut id = item.id.clone();
+                id.clock += if let ItemContent::String(s) = &item.content {
+                    s.block_offset(remaining, encoding)
+                } else {
+                    remaining
+                };
+                id
+            } else {
+                return Err(QuoteError::OutOfBounds);
+            };
+            StickyIndex::new(IndexScope::Relative(end_id), assoc_end)
+        } else {
+            StickyIndex::new(IndexScope::from_branch(this), Assoc::After)
+        };
+
         let source = LinkSource::new(start, end);
         Ok(WeakPrelim::with_source(Arc::new(source)))
     }
@@ -859,7 +879,7 @@ mod test {
     use crate::Assoc::{After, Before};
     use crate::{
         Array, ArrayRef, DeepObservable, Doc, GetString, Map, MapPrelim, MapRef, Observable,
-        Quotable, ReadTxn, StateVector, Text, TextRef, Transact, Update, WriteTxn, XmlTextRef,
+        Quotable, ReadTxn, Text, TextRef, Transact, WriteTxn, XmlTextRef,
     };
 
     #[test]
@@ -2232,7 +2252,7 @@ mod test {
         exchange_updates(&[&d1, &d2]);
 
         let mut txn = d2.transact_mut();
-        let txt2 = txn.get_or_insert_text("text");
+        let _txt2 = txn.get_or_insert_text("text");
         let arr2 = txn.get_or_insert_array("array");
 
         let link2 = arr2
@@ -2242,5 +2262,40 @@ mod test {
             .unwrap();
         let str = link2.get_string(&txn);
         assert_eq!(str, "uwvxy");
+    }
+
+    #[test]
+    fn quote_both_sides_unbounded_text() {
+        let d1 = Doc::with_client_id(1);
+        let mut txn = d1.transact_mut();
+        let txt1 = txn.get_or_insert_text("text");
+        let arr1 = txn.get_or_insert_array("array");
+        txt1.insert(&mut txn, 0, "xyz");
+        let link1 = txt1.quote(&txn, ..).unwrap();
+        let link1 = arr1.insert(&mut txn, 0, link1);
+        let str = link1.get_string(&txn);
+        assert_eq!(str, "xyz");
+
+        txt1.insert(&mut txn, 0, "uwv"); // 'uwvxyz'
+        txt1.push(&mut txn, "abc"); // 'uwvxyzabc'
+        let str = link1.get_string(&txn);
+        assert_eq!(str, "uwvxyzabc");
+        drop(txn);
+
+        let d2 = Doc::with_client_id(2);
+
+        exchange_updates(&[&d1, &d2]);
+
+        let mut txn = d2.transact_mut();
+        let txt2 = txn.get_or_insert_text("text");
+        let arr2 = txn.get_or_insert_array("array");
+
+        let link2 = arr2
+            .get(&txn, 0)
+            .unwrap()
+            .cast::<WeakRef<TextRef>>()
+            .unwrap();
+        let str = link2.get_string(&txn);
+        assert_eq!(str, "uwvxyzabc");
     }
 }

--- a/ywasm/src/array.rs
+++ b/ywasm/src/array.rs
@@ -208,8 +208,8 @@ impl YArray {
     #[wasm_bindgen(js_name = quote)]
     pub fn quote(
         &self,
-        lower: u32,
-        upper: u32,
+        lower: Option<u32>,
+        upper: Option<u32>,
         lower_open: Option<bool>,
         upper_open: Option<bool>,
         txn: &ImplicitTransaction,

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -481,15 +481,20 @@ impl Prelim for Shared {
 }
 
 pub(crate) struct YRange {
-    lower: u32,
-    upper: u32,
+    lower: Option<u32>,
+    upper: Option<u32>,
     lower_open: bool,
     upper_open: bool,
 }
 
 impl YRange {
     #[inline]
-    pub fn new(lower: u32, upper: u32, lower_open: Option<bool>, upper_open: Option<bool>) -> Self {
+    pub fn new(
+        lower: Option<u32>,
+        upper: Option<u32>,
+        lower_open: Option<bool>,
+        upper_open: Option<bool>,
+    ) -> Self {
         YRange {
             lower,
             upper,
@@ -501,18 +506,18 @@ impl YRange {
 
 impl RangeBounds<u32> for YRange {
     fn start_bound(&self) -> Bound<&u32> {
-        if self.lower_open {
-            Bound::Excluded(&self.lower)
-        } else {
-            Bound::Included(&self.lower)
+        match (&self.lower, self.lower_open) {
+            (None, _) => Bound::Unbounded,
+            (Some(i), true) => Bound::Excluded(i),
+            (Some(i), false) => Bound::Included(i),
         }
     }
 
     fn end_bound(&self) -> Bound<&u32> {
-        if self.upper_open {
-            Bound::Excluded(&self.upper)
-        } else {
-            Bound::Included(&self.upper)
+        match (&self.upper, self.upper_open) {
+            (None, _) => Bound::Unbounded,
+            (Some(i), true) => Bound::Excluded(i),
+            (Some(i), false) => Bound::Included(i),
         }
     }
 }

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -277,8 +277,8 @@ impl YText {
     #[wasm_bindgen(js_name = quote)]
     pub fn quote(
         &self,
-        lower: u32,
-        upper: u32,
+        lower: Option<u32>,
+        upper: Option<u32>,
         lower_open: Option<bool>,
         upper_open: Option<bool>,
         txn: &ImplicitTransaction,

--- a/ywasm/src/xml_text.rs
+++ b/ywasm/src/xml_text.rs
@@ -155,8 +155,8 @@ impl YXmlText {
     #[wasm_bindgen(js_name = quote)]
     pub fn quote(
         &self,
-        lower: u32,
-        upper: u32,
+        lower: Option<u32>,
+        upper: Option<u32>,
         lower_open: Option<bool>,
         upper_open: Option<bool>,
         txn: &ImplicitTransaction,


### PR DESCRIPTION
This PR enables unbounded quotations for weak link feature. Example:

```rust
let doc = Doc::new(1);
let mut txn = doc.transact_mut();
// text that we want to quote
let current_paragraph = txn.get_or_insert_text("id");
let quotes = txn.get_or_insert_array("quotes");
current_paragraph.insert(&mut txn, 0, "abc");
// quote everything from index 1 until the end of paragraph
let quote_prelim = current_paragraph.quote(&txn, 1..).unwrap();
let quote = quotes.insert(&mut txn, 0, quote_prelim);

quote.get_string(&txn); // "bc"

// expand the quoted paragraph
current_paragraph.push(&mut txn, "def");
quote.get_string(&txn); // "bcdef"
```