### PR TITLE
Clarify Transact panic behavior

### DIFF
--- a/yrs/src/transact.rs
+++ b/yrs/src/transact.rs
@@ -54,36 +54,33 @@ pub trait Transact {
     /// # Errors
     ///
     /// Only one read-write transaction can be active at the same time. If any other transaction -
-    /// be it a read-write or read-only one - is active at the same time, this method will panic.
+    /// be it a read-write or read-only one - is active at the same time, this method will
+    /// block the thread until exclusive access can be acquired, unless building for wasm
+    /// which panics. If blocking is undesirable, use `try_transact_mut_with(origin).unwrap()` instead`.
     fn transact_mut_with<T>(&self, origin: T) -> TransactionMut
     where
-        T: Into<Origin>,
-    {
-        self.try_transact_mut_with(origin).unwrap()
-    }
+        T: Into<Origin>;
 
     /// Creates and returns a lightweight read-only transaction.
     ///
-    /// # Panics
+    /// # Errors
     ///
     /// While it's possible to have multiple read-only transactions active at the same time,
-    /// this method will panic whenever called while a read-write transaction
-    /// (see: [Self::transact_mut]) is active at the same time.
-    fn transact(&self) -> Transaction {
-        self.try_transact().unwrap()
-    }
+    /// this method will block the thread until exclusive access can be acquired, unless building for wasm
+    /// which panics. If blocking is undesirable, use `try_transact(origin).unwrap()` instead`.
+    fn transact(&self) -> Transaction;
 
     /// Creates and returns a read-write capable transaction. This transaction can be used to
     /// mutate the contents of underlying document store and upon dropping or committing it may
     /// subscription callbacks.
     ///
-    /// # Panics
+    /// # Errors
     ///
     /// Only one read-write transaction can be active at the same time. If any other transaction -
-    /// be it a read-write or read-only one - is active at the same time, this method will panic.
-    fn transact_mut(&self) -> TransactionMut {
-        self.try_transact_mut().unwrap()
-    }
+    /// be it a read-write or read-only one - is active at the same time, this method will block
+    /// the thread until exclusive access can be acquired, unless building for wasm
+    /// which panics. If blocking is undesirable, use `try_transact_mut(origin).unwrap()` instead`.
+    fn transact_mut(&self) -> TransactionMut;
 }
 
 impl Transact for Doc {


### PR DESCRIPTION
This PR clarifies `Transact`'s documentation regarding panics/errors and removes  default trait method implementations for `transact`, `transact_mut` and `transact_mut_with` that conflict (panic instead of block) with the implementation on `Doc`.

Following https://github.com/y-crdt/y-crdt/pull/481, the `Doc` implementation of the `Transact` trait no longer panics when write locks are already held and instead blocks. There's an exception - wasm will panic instead of blocking ([code](https://github.com/y-crdt/y-crdt/blob/826d15908105a349eb4a52e327e33cbc4720eda3/yrs/src/store.rs#L460)).

I updated the documentation, feel free to reword. I also removed the default function implementations in Transact which conflict with those implemented for Doc. This might annoy anyone who implemented the Transact trait themselves. I can't find a single instance of this in public Github repos though 