### PR TITLE
Add support for full JSON values in XML attribute methods

### DIFF
--- a/tests-wasm/y-xml.tests.js
+++ b/tests-wasm/y-xml.tests.js
@@ -2,6 +2,7 @@ import {exchangeUpdates} from './testHelper.js' // eslint-disable-line
 
 import * as Y from 'ywasm'
 import * as t from 'lib0/testing'
+import {YXmlElement} from "ywasm";
 
 /**
  * @param {t.TestCase} tc
@@ -58,6 +59,109 @@ export const testAttributes = tc => {
     t.compareObjects(actual, {
         key1: undefined,
         key2: 'value2'
+    })
+}
+
+export const testAttributesAny = tc => {
+    const d1 = new Y.YDoc()
+    const root = d1.getXmlFragment('test')
+    const xml = new Y.YXmlElement('div', {}, [])
+    root.push(xml)
+    let actual = d1.transact(txn => {
+        xml.setAttribute('key1', true, txn)
+        xml.setAttribute('key2', 42, txn)
+        xml.setAttribute('key3', null, txn)
+
+        let obj = {}
+        let attrs = xml.attributes(txn);
+        for (let key in attrs) {
+            // we test iterator here
+            obj[key] = attrs[key]
+        }
+        return obj
+    });
+
+    t.compareObjects(actual, {
+        key1: true,
+        key2: 42,
+        key3: null
+    })
+
+    actual = d1.transact(txn => {
+        xml.removeAttribute('key1', txn)
+        return {
+            key1: xml.getAttribute('key1', txn),
+            key2: xml.getAttribute('key2', txn),
+            key3: xml.getAttribute('key3', txn)
+        }
+    })
+
+    t.compareObjects(actual, {
+        key1: undefined,
+        key2: 42,
+        key3: null
+    })
+}
+
+export const testAttributesPrelim = tc => {
+    const d1 = new Y.YDoc()
+    const root = d1.getXmlFragment('test')
+
+    let xml
+    let actual = d1.transact(txn => {
+        xml  = new Y.YXmlElement('div', {}, [])
+        xml.setAttribute('key1', true, txn)
+        xml.setAttribute('key2', 42, txn)
+        xml.setAttribute('key3', null, txn)
+
+        root.push(xml, txn)
+
+        let obj = {}
+        let attrs = xml.attributes(txn);
+        for (let key in attrs) {
+            // we test iterator here
+            obj[key] = attrs[key]
+        }
+        return obj
+    });
+
+    t.compareObjects(actual, {
+        key1: true,
+        key2: 42,
+        key3: null
+    })
+
+    actual = d1.transact(txn => {
+        xml.removeAttribute('key1', txn)
+        return {
+            key1: xml.getAttribute('key1', txn),
+            key2: xml.getAttribute('key2', txn),
+            key3: xml.getAttribute('key3', txn)
+        }
+    })
+
+    t.compareObjects(actual, {
+        key1: undefined,
+        key2: 42,
+        key3: null
+    })
+}
+
+export const testAttributesCtor = tc => {
+    const d1 = new Y.YDoc()
+    const root = d1.getXmlFragment('test')
+    const xml = new Y.YXmlElement('div', { "key1": false}, [])
+    root.push(xml)
+
+    let attrs = xml.attributes();
+    let obj = {}
+    for (let key in attrs) {
+        // we test iterator here
+        obj[key] = attrs[key]
+    }
+
+    t.compareObjects(attrs, {
+        key1: false,
     })
 }
 

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -401,7 +401,7 @@ impl XmlElementPrelim {
     pub fn new<S, I>(tag: S, iter: I) -> Self
     where
         S: Into<Arc<str>>,
-        I: IntoIterator<Item = XmlIn>,
+        I: IntoIterator<Item=XmlIn>,
     {
         XmlElementPrelim {
             tag: tag.into(),
@@ -908,7 +908,7 @@ pub struct XmlFragmentPrelim(Vec<XmlIn>);
 impl XmlFragmentPrelim {
     pub fn new<I, T>(iter: I) -> Self
     where
-        I: IntoIterator<Item = XmlIn>,
+        I: IntoIterator<Item=XmlIn>,
     {
         XmlFragmentPrelim(iter.into_iter().collect())
     }
@@ -1002,7 +1002,7 @@ pub trait Xml: AsRef<Branch> {
     fn insert_attribute<K, V>(&self, txn: &mut TransactionMut, attr_name: K, attr_value: V)
     where
         K: Into<Arc<str>>,
-        V: Into<String>,
+        V: Into<Any>,
     {
         let key = attr_name.into();
         let value = attr_value.into();
@@ -1029,10 +1029,27 @@ pub trait Xml: AsRef<Branch> {
         Some(value.to_string(txn))
     }
 
+    /// Returns a value of an attribute given its `attr_name` as Any type. Returns `None` if no such attribute
+    /// can be found inside of a current XML element.
+    fn get_attribute_any<T: ReadTxn>(&self, txn: &T, attr_name: &str) -> Option<Any> {
+        let branch = self.as_ref();
+        let value = branch.get(txn, attr_name)?;
+        match value {
+            Out::Any(any) => Some(any),
+            _ => Some(Any::String(Arc::from(value.to_string(txn)))),
+        }
+    }
+
     /// Returns an unordered iterator over all attributes (key-value pairs), that can be found
     /// inside of a current XML element.
     fn attributes<'a, T: ReadTxn>(&'a self, txn: &'a T) -> Attributes<'a, &'a T, T> {
         Attributes(Entries::new(&self.as_ref().map, txn))
+    }
+
+    /// Returns an unordered iterator over all attributes (key-value pairs with Any values), that can be found
+    /// inside of a current XML element.
+    fn attributes_any<'a, T: ReadTxn>(&'a self, txn: &'a T) -> AttributesAny<'a, &'a T, T> {
+        AttributesAny(Entries::new(&self.as_ref().map, txn))
     }
 
     fn siblings<'a, T: ReadTxn>(&self, txn: &'a T) -> Siblings<'a, T> {
@@ -1205,6 +1222,42 @@ where
             .get_last()
             .map(|v| v.to_string(txn))
             .unwrap_or(String::default());
+        Some((key.as_ref(), value))
+    }
+}
+
+/// Iterator over the attributes (key-value pairs with Any values) of an [XmlElement].
+pub struct AttributesAny<'a, B, T>(Entries<'a, B, T>);
+
+impl<'a, B, T> AttributesAny<'a, B, T>
+where
+    B: Borrow<T>,
+    T: ReadTxn,
+{
+    pub fn new(branch: &'a Branch, txn: B) -> Self {
+        let entries = Entries::new(&branch.map, txn);
+        AttributesAny(entries)
+    }
+}
+
+impl<'a, B, T> Iterator for AttributesAny<'a, B, T>
+where
+    B: Borrow<T>,
+    T: ReadTxn,
+{
+    type Item = (&'a str, Any);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (key, block) = self.0.next()?;
+        let txn = self.0.txn.borrow();
+        let value = block
+            .content
+            .get_last()
+            .map(|v| match v {
+                Out::Any(any) => any,
+                _ => Any::String(Arc::from(v.to_string(txn))),
+            })
+            .unwrap_or(Any::Null);
         Some((key.as_ref(), value))
     }
 }
@@ -1513,7 +1566,7 @@ impl XmlEvent {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     use arc_swap::ArcSwapOption;
@@ -1598,8 +1651,29 @@ mod test {
         txt.insert_attribute(&mut txn, "test", 42.to_string());
 
         assert_eq!(txt.get_attribute(&txn, "test"), Some("42".to_string()));
-        let actual: Vec<_> = txt.attributes(&txn).collect();
-        assert_eq!(actual, vec![("test", "42".to_string())]);
+        let actual: HashSet<_> = txt.attributes(&txn).collect();
+        let expected: HashSet<_> = vec![("test", "42".to_string())].into_iter().collect();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn text_attributes_any() {
+        let doc = Doc::with_client_id(1);
+        let f = doc.get_or_insert_xml_fragment("test");
+        let mut txn = doc.transact_mut();
+        let txt = f.push_back(&mut txn, XmlTextPrelim::new(""));
+        txt.insert_attribute(&mut txn, "test", Any::BigInt(42));
+        txt.insert_attribute(&mut txn, "test_true", true);
+        txt.insert_attribute(&mut txn, "test_null", Any::Null);
+
+        assert_eq!(txt.get_attribute_any(&txn, "test"), Some(Any::BigInt(42)));
+        assert_eq!(txt.get_attribute_any(&txn, "test_true"), Some(Any::Bool(true)));
+        assert_eq!(txt.get_attribute_any(&txn, "test_null"), Some(Any::Null));
+
+        // Collect attributes into a HashSet of keys to verify all expected keys are present
+        let actual_keys: HashSet<&str> = txt.attributes_any(&txn).map(|(k, _)| k).collect();
+        let expected_keys: HashSet<&str> = vec!["test", "test_true", "test_null"].into_iter().collect();
+        assert_eq!(actual_keys, expected_keys);
     }
 
     #[test]

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -24,6 +24,7 @@ mod weak;
 mod xml_elem;
 mod xml_frag;
 mod xml_text;
+mod xml;
 
 type Result<T> = std::result::Result<T, JsValue>;
 

--- a/ywasm/src/xml.rs
+++ b/ywasm/src/xml.rs
@@ -1,0 +1,50 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use js_sys::Object;
+use crate::js::{Js, ValueRef};
+use wasm_bindgen::JsValue;
+use yrs::Any;
+use yrs::types::Attrs;
+
+pub struct XmlAttrs;
+
+impl XmlAttrs {
+    pub(crate) fn from_attrs(attributes: HashMap<Arc<str>, Any>) -> Object {
+        let map = js_sys::Object::new();
+        for (name, value) in &attributes {
+            js_sys::Reflect::set(
+                &map,
+                &JsValue::from_str(name),
+                &Js::from_any(value).into(),
+            ).unwrap();
+        }
+
+        map
+    }
+
+    pub(crate) fn parse_attrs_any(attributes: JsValue) -> crate::Result<Attrs> {
+        if attributes.is_undefined() || attributes.is_null() {
+            Ok(Attrs::new())
+        } else if attributes.is_object() {
+            let mut map = Attrs::new();
+            let object = js_sys::Object::from(attributes);
+            let entries = js_sys::Object::entries(&object);
+            for tuple in entries.iter() {
+                let tuple = js_sys::Array::from(&tuple);
+                if let Some(key) = tuple.get(0).as_string() {
+                    let value = Js::new(tuple.get(1));
+                    if let Ok(ValueRef::Any(any)) = value.as_value() {
+                        map.insert(key.into(), any);
+                    } else {
+                        return Err(JsValue::from_str(crate::js::errors::INVALID_XML_ATTRS));
+                    }
+                } else {
+                    return Err(JsValue::from_str(crate::js::errors::INVALID_XML_ATTRS));
+                }
+            }
+            Ok(map)
+        } else {
+            Err(JsValue::from_str(crate::js::errors::INVALID_XML_ATTRS))
+        }
+    }
+}


### PR DESCRIPTION
See #568 for context and discussion on JSON attribute support in XML methods.

yrs
 
- Added support for attributes with Any type via new get_attribute_any and attributes_any methods

 - Preserved existing attribute* methods for backward compatibility

 - Enhanced internal logic to support Any-typed attributes across XML elements

ywasm

 - Extended xml.attrs* to handle Any-typed attributes

 - Added test coverage for the new functionality