### PR TITLE
Enable GC of specific blocks on demand

### DIFF
--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1034,7 +1034,8 @@ impl DocAddr {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockCell, ItemContent};
+    use crate::block::{BlockCell, ClientID, ItemContent, GC};
+    use crate::error::Error;
     use crate::test_utils::exchange_updates;
     use crate::transaction::{ReadTxn, TransactionMut};
     use crate::types::ToJson;
@@ -1043,8 +1044,9 @@ mod test {
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{
         any, uuid_v4, Any, Array, ArrayPrelim, ArrayRef, DeleteSet, Doc, GetString, Map, MapRef,
-        OffsetKind, Options, StateVector, Subscription, Text, TextPrelim, TextRef, Transact, Uuid,
-        WriteTxn, XmlElementPrelim, XmlFragment, XmlFragmentRef, XmlTextPrelim, XmlTextRef, ID,
+        OffsetKind, Options, Snapshot, StateVector, Subscription, Text, TextPrelim, TextRef,
+        Transact, Uuid, WriteTxn, XmlElementPrelim, XmlFragment, XmlFragmentRef, XmlTextPrelim,
+        XmlTextRef, ID,
     };
     use arc_swap::ArcSwapOption;
     use assert_matches2::assert_matches;
@@ -2400,6 +2402,15 @@ mod test {
         assert!(actual.is_none());
     }
 
+    fn init_test_data<const N: usize>(txn: &mut TransactionMut, data: [&str; N]) -> TextRef {
+        let map = txn.get_or_insert_map("map");
+        let txt = map.insert(txn, "text", TextPrelim::default());
+        for ch in data {
+            txt.insert(txn, 0, ch);
+        }
+        txt
+    }
+
     #[test]
     fn force_gc() {
         let doc = Doc::with_options(Options {
@@ -2412,10 +2423,7 @@ mod test {
         {
             // create some initial data
             let mut txn = doc.transact_mut();
-            let txt = map.insert(&mut txn, "text", TextPrelim::default()); // <1#0>
-            txt.insert(&mut txn, 0, "c"); // <1#1>
-            txt.insert(&mut txn, 0, "b"); // <1#2>
-            txt.insert(&mut txn, 0, "a"); // <1#3>
+            init_test_data(&mut txn, ["c", "b", "a"]);
 
             // drop nested type
             map.remove(&mut txn, "text");
@@ -2440,13 +2448,100 @@ mod test {
         }
 
         // force GC and check if original content is hard deleted
-        doc.transact_mut().force_gc();
+        doc.transact_mut().force_gc(None);
 
         let txn = doc.transact();
         let block = txn.store().blocks.get_block(&ID::new(1, 1)).unwrap();
         assert_eq!(block.len(), 3, "GCed blocks should be squashed");
         assert!(block.is_deleted(), "`abc` should be deleted");
         assert_matches!(&block, &BlockCell::GC(_));
+    }
+
+    #[test]
+    fn force_gc_with_delete_set() {
+        let doc = Doc::with_options(Options {
+            client_id: 1,
+            skip_gc: true,
+            ..Default::default()
+        });
+        let m0 = doc.get_or_insert_map("map");
+        let s1 = {
+            let mut tx = doc.transact_mut();
+            let t1 = init_test_data(&mut tx, ["c", "b", "a"]); // <1#1..3>
+            assert_eq!(t1.get_string(&tx), "abc");
+            tx.snapshot()
+        };
+
+        let s2 = {
+            let mut tx = doc.transact_mut();
+            let t2 = init_test_data(&mut tx, ["f", "e", "d"]); // <1#5..7>
+            assert_eq!(t2.get_string(&tx), "def");
+            tx.snapshot()
+        };
+
+        // restore data to s1
+        {
+            let doc_restored = restore_from_snapshot(&doc, &s1).unwrap();
+            let txn = doc_restored.transact();
+            let m0_restored = txn.get_map("map").unwrap();
+            let txt = m0_restored
+                .get(&txn, "text")
+                .unwrap()
+                .cast::<TextRef>()
+                .unwrap();
+            assert_eq!(txt.get_string(&txn), "abc");
+        }
+
+        // verify that blocks 'abc' are not GCed and available
+        {
+            let txn = doc.transact();
+            let mut i = 1;
+            for c in ["c", "b", "a"] {
+                let block = txn
+                    .store()
+                    .blocks
+                    .get_block(&ID::new(1, i))
+                    .unwrap()
+                    .as_item()
+                    .unwrap();
+                assert!(block.is_deleted(), "`abc` should be marked as deleted");
+                assert_eq!(&block.content, &ItemContent::String(c.into()));
+                i += 1;
+            }
+        }
+
+        // garbage collect anything below s2
+        doc.transact_mut().force_gc(Some(&s2.delete_set));
+
+        // verify that we GC 'abc' blocks and compressed them
+        let txn = doc.transact();
+        let block = txn.store().blocks.get_block(&ID::new(1, 1)).unwrap();
+        assert_eq!(
+            block,
+            &BlockCell::GC(GC::new(1, 3)),
+            "block should be GCed & compressed"
+        );
+
+        // try to restore data to s1 again
+        let doc_restored = restore_from_snapshot(&doc, &s1).unwrap();
+        let txn = doc_restored.transact();
+        let m0_restored = txn.get_map("map").unwrap();
+        let txt = m0_restored.get(&txn, "text");
+        assert!(
+            txt.is_none(),
+            "we restored snapshot s1, but it's content should be already GCed"
+        );
+    }
+
+    fn restore_from_snapshot(doc: &Doc, snapshot: &Snapshot) -> Result<Doc, Error> {
+        let mut encoder = EncoderV1::new();
+        doc.transact()
+            .encode_state_from_snapshot(&snapshot, &mut encoder)?;
+        let doc = Doc::new();
+        doc.transact_mut()
+            .apply_update(Update::decode_v1(&encoder.to_vec()).unwrap())
+            .unwrap();
+        Ok(doc)
     }
 
     #[test]

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -1,31 +1,39 @@
 use crate::block::{BlockCell, ClientID, GC};
-use crate::{TransactionMut, ID};
+use crate::{DeleteSet, Store, TransactionMut, ID};
 use std::collections::HashMap;
 
 #[derive(Default)]
 pub(crate) struct GCCollector {
-    items: HashMap<ClientID, Vec<u32>>,
+    marked: HashMap<ClientID, Vec<u32>>,
 }
 
 impl GCCollector {
     /// Garbage collect all blocks deleted within current transaction scope.
     pub fn collect(txn: &mut TransactionMut) {
         let mut gc = Self::default();
-        gc.mark_in_scope(txn);
-        gc.collect_all_marked(txn);
+        gc.mark_in_scope(&mut txn.store, None, &txn.delete_set);
+        gc.collect_marked(txn);
     }
 
     /// Garbage collect all deleted blocks from current transaction's document store.
-    pub fn collect_all(txn: &mut TransactionMut) {
+    pub fn collect_all(txn: &mut TransactionMut, delete_set: Option<&DeleteSet>) {
         let mut gc = Self::default();
-        gc.mark_all(txn);
-        gc.collect_all_marked(txn);
+        match delete_set {
+            None => gc.mark_all(txn),
+            Some(ds) => gc.mark_in_scope(&mut txn.store, Some(&mut txn.merge_blocks), ds),
+        }
+        gc.collect_marked(txn);
     }
 
-    /// Mark deleted items based on a current transaction delete set.
-    fn mark_in_scope(&mut self, txn: &mut TransactionMut) {
-        for (client, range) in txn.delete_set.iter() {
-            if let Some(blocks) = txn.store.blocks.get_client_mut(client) {
+    /// Mark deleted items based on a provided delete set.
+    fn mark_in_scope(
+        &mut self,
+        store: &mut Store,
+        mut merge_blocks: Option<&mut Vec<ID>>,
+        delete_set: &DeleteSet,
+    ) {
+        for (client, range) in delete_set.iter() {
+            if let Some(blocks) = store.blocks.get_client_mut(client) {
                 for delete_item in range.iter().rev() {
                     let mut start = delete_item.start;
                     if let Some(mut i) = blocks.find_pivot(start) {
@@ -38,6 +46,9 @@ impl GCCollector {
                             } else {
                                 if let BlockCell::Block(item) = block {
                                     item.gc(self, false);
+                                    if let Some(merge_blocks) = merge_blocks.as_deref_mut() {
+                                        merge_blocks.push(item.id);
+                                    }
                                 }
                                 i += 1;
                             }
@@ -63,13 +74,13 @@ impl GCCollector {
 
     /// Marks item with a given [ID] as a candidate for being GCed.
     pub(crate) fn mark(&mut self, id: &ID) {
-        let client = self.items.entry(id.client).or_default();
+        let client = self.marked.entry(id.client).or_default();
         client.push(id.clock);
     }
 
     /// Garbage collects all items marked for GC.
-    fn collect_all_marked(self, txn: &mut TransactionMut) {
-        for (client_id, clocks) in self.items.into_iter() {
+    fn collect_marked(self, txn: &mut TransactionMut) {
+        for (client_id, clocks) in self.marked.into_iter() {
             let client = txn.store.blocks.get_client_blocks_mut(client_id);
             for clock in clocks {
                 if let Some(index) = client.find_pivot(clock) {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1094,8 +1094,12 @@ impl<'doc> TransactionMut<'doc> {
     /// Perform garbage collection of deleted blocks, even if a document was created with `skip_gc`
     /// option. This operation will scan over ALL deleted elements, NOT ONLY the ones that have been
     /// changed as part of this transaction scope.
-    pub fn force_gc(&mut self) {
-        GCCollector::collect_all(self);
+    ///
+    /// If `delete_set` is provided, it will be used to limit the scope of garbage collection
+    /// to only those blocks that are present in the delete set. If `delete_set` is `None`, all
+    /// deleted blocks will be considered for garbage collection.
+    pub fn force_gc(&mut self, delete_set: Option<&DeleteSet>) {
+        GCCollector::collect_all(self, delete_set);
     }
 
     pub(crate) fn add_changed_type(&mut self, parent: BranchPtr, parent_sub: Option<Arc<str>>) {


### PR DESCRIPTION
This PR expands `TransactionMut::force_gc` to optionally accept an argument, that is a `DeleteSet` specifying which specific blocks do we want to garbage collect. This is useful mostly in combination with snapshots, where we can specify ie. to GC only data that was already deleted from perspective of a given snapshot but not later snapshots.