### PR TITLE
allow XML attributes to work with any Prelim type

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -476,7 +476,7 @@ typedef struct YMapEntry {
  */
 typedef struct YXmlAttr {
   const char *name;
-  const char *value;
+  const struct YOutput *value;
 } YXmlAttr;
 
 /**
@@ -1799,7 +1799,7 @@ char *yxmlelem_string(const Branch *xml, const YTransaction *txn);
 void yxmlelem_insert_attr(const Branch *xml,
                           YTransaction *txn,
                           const char *attr_name,
-                          const char *attr_value);
+                          const struct YInput *attr_value);
 
 /**
  * Removes an attribute from a current `YXmlElement`, given its name.
@@ -1815,7 +1815,9 @@ void yxmlelem_remove_attr(const Branch *xml, YTransaction *txn, const char *attr
  *
  * An `attr_name` must be a null-terminated UTF-8 encoded string.
  */
-char *yxmlelem_get_attr(const Branch *xml, const YTransaction *txn, const char *attr_name);
+struct YOutput *yxmlelem_get_attr(const Branch *xml,
+                                  const YTransaction *txn,
+                                  const char *attr_name);
 
 /**
  * Returns an iterator over the `YXmlElement` attributes.
@@ -2031,7 +2033,7 @@ void yxmltext_remove_range(const Branch *txt, YTransaction *txn, uint32_t idx, u
 void yxmltext_insert_attr(const Branch *txt,
                           YTransaction *txn,
                           const char *attr_name,
-                          const char *attr_value);
+                          const struct YInput *attr_value);
 
 /**
  * Removes an attribute from a current `YXmlText`, given its name.
@@ -2047,7 +2049,9 @@ void yxmltext_remove_attr(const Branch *txt, YTransaction *txn, const char *attr
  *
  * An `attr_name` must be a null-terminated UTF-8 encoded string.
  */
-char *yxmltext_get_attr(const Branch *txt, const YTransaction *txn, const char *attr_name);
+struct YOutput *yxmltext_get_attr(const Branch *txt,
+                                  const YTransaction *txn,
+                                  const char *attr_name);
 
 /**
  * Returns a collection of chunks representing pieces of `YText` rich text string grouped together

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -276,8 +276,10 @@ TEST_CASE("YXmlElement basic") {
     Branch *xml = yxmlelem_insert_elem(frag, txn, 0, "div");
 
     // XML attributes API
-    yxmlelem_insert_attr(xml, txn, "key1", "value1");
-    yxmlelem_insert_attr(xml, txn, "key2", "value2");
+    YInput attr_value = yinput_string("value1");
+    yxmlelem_insert_attr(xml, txn, "key1", &attr_value);
+    attr_value = yinput_string("value2");
+    yxmlelem_insert_attr(xml, txn, "key2", &attr_value);
 
     YXmlAttrIter *i = yxmlelem_attr_iter(xml, txn);
     YXmlAttr *attr;
@@ -295,12 +297,12 @@ TEST_CASE("YXmlElement basic") {
         switch (attr->name[3]) {
             case '1': {
                 REQUIRE(!strcmp(attr->name, "key1"));
-                REQUIRE(!strcmp(attr->value, "value1"));
+                REQUIRE(!strcmp(youtput_read_string(attr->value), "value1"));
                 break;
             }
             case '2': {
                 REQUIRE(!strcmp(attr->name, "key2"));
-                REQUIRE(!strcmp(attr->value, "value2"));
+                REQUIRE(!strcmp(youtput_read_string(attr->value), "value2"));
                 break;
             }
             default: {
@@ -980,8 +982,10 @@ TEST_CASE("YXmlElement observe") {
     YSubscription *sub = yxmlelem_observe(xml, (void *) t, &yxml_test_observe);
 
     // insert initial attributes
-    yxmlelem_insert_attr(xml, txn, "attr1", "value1");
-    yxmlelem_insert_attr(xml, txn, "attr2", "value2");
+    YInput attr_value = yinput_string("value1");
+    yxmlelem_insert_attr(xml, txn, "attr1", &attr_value);
+    attr_value = yinput_string("value2");
+    yxmlelem_insert_attr(xml, txn, "attr2", &attr_value);
     ytransaction_commit(txn);
 
     REQUIRE(t->target != NULL);
@@ -1012,7 +1016,8 @@ TEST_CASE("YXmlElement observe") {
     // update attributes
     yxml_test_clean(t);
     txn = ydoc_write_transaction(doc, 0, NULL);
-    yxmlelem_insert_attr(xml, txn, "attr1", "value11");
+    attr_value = yinput_string("value11");
+    yxmlelem_insert_attr(xml, txn, "attr1", &attr_value);
     yxmlelem_remove_attr(xml, txn, "attr2");
     ytransaction_commit(txn);
 

--- a/yrs/src/json_path/iter_txn.rs
+++ b/yrs/src/json_path/iter_txn.rs
@@ -342,12 +342,8 @@ fn get_member<T: ReadTxn>(txn: &T, out: Option<&Out>, key: &str) -> Option<Out> 
         None => txn.get(key),
         Some(Out::YMap(map)) => map.get(txn, key),
         Some(Out::Any(Any::Map(map))) => map.get(key).map(|any| Out::Any(any.clone())),
-        Some(Out::YXmlElement(elem)) => elem
-            .get_attribute(txn, key)
-            .map(|attr| Out::Any(Any::String(attr.into()))),
-        Some(Out::YXmlText(elem)) => elem
-            .get_attribute(txn, key)
-            .map(|attr| Out::Any(Any::String(attr.into()))),
+        Some(Out::YXmlElement(elem)) => elem.get_attribute(txn, key),
+        Some(Out::YXmlText(elem)) => elem.get_attribute(txn, key),
         Some(Out::UndefinedRef(branch)) => {
             // we assume it's a YMap
             let map = crate::MapRef::from(*branch);

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -356,7 +356,10 @@ fn utf32_lib0_v2_decoding() {
         ("tagName", "div".to_string()),
         ("lineHeight", "".to_string()),
     ]);
-    let actual_attrs: HashMap<&str, String> = actual.attributes(&txn).collect();
+    let actual_attrs: HashMap<&str, String> = actual
+        .attributes(&txn)
+        .map(|(k, v)| (k, v.to_string(&txn)))
+        .collect();
     assert_eq!(actual_attrs, expected_attrs);
 
     let txt: XmlTextRef = actual.get(&txn, 0).unwrap().try_into().unwrap();


### PR DESCRIPTION
This PR is follow up to #569 . Since the complexity added is almost none, we can as well not limit ourselves to insert only primitive types (including non-string ones) as attributes to XmlElementRef/XmlTextRef, but we could use any type accepted into shared maps (i.e. attribute value as TextRef?).

Since this is going to add breaking changes to next release anyway, I'm also conflating `get_attribute`/`get_attribute_any` into single method: you can always obtain string the old way by calling `xml.get_attribute(txn, key).unwrap().to_string(txn)`.