### PR TITLE
disable clock only for unknown target

### DIFF
--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -44,7 +44,7 @@ impl Awareness {
     /// Creates a new instance of [Awareness] struct, which operates over a given document.
     /// Awareness instance has full ownership of that document. If necessary it can be accessed
     /// using either [Awareness::doc] or [Awareness::doc_mut] methods.
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
     pub fn new(doc: Doc) -> Self {
         Self::with_clock(doc, crate::sync::time::SystemClock)
     }
@@ -479,7 +479,7 @@ impl Awareness {
     }
 }
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 impl Default for Awareness {
     fn default() -> Self {
         Awareness::new(Doc::new())

--- a/yrs/src/sync/time.rs
+++ b/yrs/src/sync/time.rs
@@ -17,11 +17,11 @@ where
 }
 
 /// A clock which uses standard (non-monotonic) OS date time.
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 #[derive(Debug, Copy, Clone, Default)]
 pub struct SystemClock;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
 impl Clock for SystemClock {
     fn now(&self) -> Timestamp {
         std::time::SystemTime::now()


### PR DESCRIPTION
while std::time::SystemTime::now() will crash on wasm32-unknown-unknown (nowadays standard web-sys) it is fine on wasm32-unknown-emscripten which has a POSIX emulation layer, and albeit not tested, but I highly expect it to work on wasm32-wasi too (which may get more traction in future)

This is no biggy, i can just copy/paste the clock code into my code and use that to instance an awareness, but IMO it would make things a bit easier to use in some cases. 