### PR TITLE
sticky_index doesn't need mut

### DIFF
--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -961,9 +961,9 @@ impl Decode for Assoc {
 pub trait IndexedSequence: AsRef<Branch> {
     /// Returns a [StickyIndex] equivalent to a human-readable `index`.
     /// Returns `None` if `index` is beyond the length of current sequence.
-    fn sticky_index(
+    fn sticky_index<T: ReadTxn>(
         &self,
-        txn: &mut TransactionMut,
+        txn: &T,
         index: u32,
         assoc: Assoc,
     ) -> Option<StickyIndex> {


### PR DESCRIPTION
I don't think sticky_index() necessarily needs a muting transaction.
At least the tests pass fine if it allows a Transaction or a TransactionMut.