### PR TITLE
UndoManager: make undo/redo stacks serializable

### DIFF
--- a/ywasm/src/undo.rs
+++ b/ywasm/src/undo.rs
@@ -45,6 +45,8 @@ impl YUndoManager {
             tracked_origins: HashSet::new(),
             capture_transaction: None,
             timestamp: Arc::new(crate::awareness::JsClock),
+            init_undo_stack: Vec::new(),
+            init_redo_stack: Vec::new(),
         };
         if options.is_object() {
             if let Ok(js) = Reflect::get(&options, &JsValue::from_str("captureTimeout")) {


### PR DESCRIPTION
Related #586

1. This PR implements serde traits over `IdSet` and UndoManager's `StackItems`. They can be serialized into pretty much any serde-compatible serialiser but given the fact that IdSet serialisation always produces a binary representation, you probably want to use binary format (CBOR, MsgPack) over usual serde_json, which is bad when it comes to serialising byte arrays.
2. Another part of the PR allows to recreate UndoManager with predefined undo/redo stacks. These two can be combined to serialise UndoManager and then recreate it later from serialized stacks data.
3. Final element is `StackItem::merge` method, which enables combining different stack items together into one.