### PR TITLE
refactor(ywasm): replace gloo-utils with serde-wasm-bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,19 +388,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,6 +842,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,10 +1293,9 @@ version = "0.25.0"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",
- "gloo-utils",
  "js-sys",
  "serde",
- "serde_json",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wee_alloc",

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -20,8 +20,7 @@ default = ["console_error_panic_hook"]
 yrs = { path = "../yrs", version = "0.25.0", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_json = "1.0"
-gloo-utils = { version = "0.2", features = ["serde"] }
+serde-wasm-bindgen = "0.6"
 base64_light = "0.1"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/ywasm/src/array.rs
+++ b/ywasm/src/array.rs
@@ -3,7 +3,6 @@ use crate::js::{Callback, Js, ValueRef, YRange};
 use crate::transaction::{ImplicitTransaction, YTransaction};
 use crate::weak::YWeakLink;
 use crate::Result;
-use gloo_utils::format::JsValueSerdeExt;
 use std::iter::FromIterator;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
@@ -102,7 +101,7 @@ impl YArray {
             }
             SharedCollection::Integrated(c) => c.readonly(txn, |c, txn| {
                 let any = c.to_json(txn);
-                JsValue::from_serde(&any).map_err(|e| JsValue::from_str(&e.to_string()))
+                crate::js::to_js(&any).map_err(|e| JsValue::from_str(&e.to_string()))
             }),
         }
     }

--- a/ywasm/src/awareness.rs
+++ b/ywasm/src/awareness.rs
@@ -1,4 +1,3 @@
-use gloo_utils::format::JsValueSerdeExt;
 use js_sys::Uint8Array;
 use serde::Serialize;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -42,7 +41,7 @@ impl Awareness {
                 clock: state.clock,
                 last_updated: state.last_updated,
             };
-            let info = JsValue::from_serde(&info).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            let info = crate::js::to_js(&info).map_err(|e| JsValue::from_str(&e.to_string()))?;
             result.set(&JsValue::from_f64(client_id as f64), &info);
         }
         Ok(result)
@@ -96,7 +95,7 @@ impl Awareness {
         let abi = callback.subscription_key();
         match event {
             "update" => self.inner.on_update_with(abi, move |_, e, origin| {
-                let json = JsValue::from_serde(e.summary()).unwrap();
+                let json = crate::js::to_js(e.summary()).unwrap();
                 let origin = match origin {
                     None => JsValue::UNDEFINED,
                     Some(origin) => Js::from(origin).into(),
@@ -104,7 +103,7 @@ impl Awareness {
                 callback.call2(&JsValue::NULL, &json, &origin).unwrap();
             }),
             "change" => self.inner.on_change_with(abi, move |_, e, origin| {
-                let json = JsValue::from_serde(e.summary()).unwrap();
+                let json = crate::js::to_js(e.summary()).unwrap();
                 let origin = match origin {
                     None => JsValue::UNDEFINED,
                     Some(origin) => Js::from(origin).into(),
@@ -141,7 +140,7 @@ pub fn encode_update(awareness: &Awareness, clients: JsValue) -> crate::Result<U
         awareness.inner.update()
     } else {
         let client_ids: Vec<u64> =
-            JsValue::into_serde(&clients).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            serde_wasm_bindgen::from_value(clients).map_err(|e| JsValue::from_str(&e.to_string()))?;
         awareness.inner.update_with_clients(client_ids)
     };
 

--- a/ywasm/src/collection.rs
+++ b/ywasm/src/collection.rs
@@ -1,6 +1,5 @@
 use crate::transaction::{ImplicitTransaction, YTransaction};
 use crate::Result;
-use gloo_utils::format::JsValueSerdeExt;
 use std::ops::Deref;
 use wasm_bindgen::JsValue;
 use yrs::{BranchID, Doc, Hook, ReadTxn, SharedRef, Transact, Transaction, TransactionMut};
@@ -28,7 +27,7 @@ impl<P, S: SharedRef + 'static> SharedCollection<P, S> {
             }
             SharedCollection::Integrated(c) => {
                 let branch_id = c.hook.id();
-                JsValue::from_serde(branch_id).map_err(|e| JsValue::from_str(&e.to_string()))
+                crate::js::to_js(branch_id).map_err(|e| JsValue::from_str(&e.to_string()))
             }
         }
     }

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -65,9 +65,7 @@ impl YDoc {
     /// be assigned a randomly generated number.
     #[wasm_bindgen(constructor)]
     pub fn new(options: &JsValue) -> Result<YDoc> {
-        use gloo_utils::format::JsValueSerdeExt;
-        let js_options = options
-            .into_serde::<Option<DocOptions>>()
+        let js_options = serde_wasm_bindgen::from_value::<Option<DocOptions>>(options.clone())
             .map_err(|_| JsValue::from_str("invalid document options"))?;
         let mut options = Options::default();
         options.offset_kind = OffsetKind::Utf16;

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -9,6 +9,13 @@ use crate::xml_frag::YXmlFragment;
 use crate::xml_text::YXmlText;
 use crate::Result;
 use js_sys::Uint8Array;
+use serde::Serialize;
+
+/// Serialize a value to JsValue using JSON-compatible settings.
+/// This ensures maps are serialized as plain JS objects (not ES2015 Map).
+pub fn to_js<T: Serialize + ?Sized>(value: &T) -> std::result::Result<JsValue, serde_wasm_bindgen::Error> {
+    value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+}
 use std::collections::{Bound, HashMap};
 use std::convert::TryInto;
 use std::ops::{Deref, RangeBounds};
@@ -546,6 +553,7 @@ pub trait Callback: AsRef<JsValue> {
 impl Callback for js_sys::Function {}
 
 pub(crate) mod convert {
+    use super::to_js;
     use crate::array::YArrayEvent;
     use crate::js::errors::INVALID_DELTA;
     use crate::js::Js;
@@ -555,7 +563,6 @@ pub(crate) mod convert {
     use crate::xml_frag::YXmlEvent;
     use crate::xml_text::YXmlTextEvent;
     use crate::Text;
-    use gloo_utils::format::JsValueSerdeExt;
     use std::iter::FromIterator;
     use wasm_bindgen::convert::RefMutFromWasmAbi;
     use wasm_bindgen::JsValue;
@@ -654,7 +661,7 @@ pub(crate) mod convert {
                 )?;
 
                 if let Some(attrs) = attrs {
-                    let attrs = JsValue::from_serde(attrs)
+                    let attrs = to_js(attrs)
                         .map_err(|e| JsValue::from_str(&e.to_string()))?;
                     js_sys::Reflect::set(&result, &JsValue::from("attributes"), &attrs)?;
                 }
@@ -664,7 +671,7 @@ pub(crate) mod convert {
                 js_sys::Reflect::set(&result, &JsValue::from("retain"), &value)?;
 
                 if let Some(attrs) = attrs {
-                    let attrs = JsValue::from_serde(&attrs)
+                    let attrs = to_js(&attrs)
                         .map_err(|e| JsValue::from_str(&e.to_string()))?;
                     js_sys::Reflect::set(&result, &JsValue::from("attributes"), &attrs)?;
                 }
@@ -760,7 +767,7 @@ pub(crate) mod convert {
         };
         let result = if let Some(func) = compute_ychange {
             let id =
-                JsValue::from_serde(&change.id).map_err(|e| JsValue::from_str(&e.to_string()))?;
+                to_js(&change.id).map_err(|e| JsValue::from_str(&e.to_string()))?;
             func.call2(&JsValue::UNDEFINED, &kind, &id).unwrap()
         } else {
             let js: JsValue = js_sys::Object::new().into();

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -1,5 +1,4 @@
 use base64_light::base64_decode;
-use gloo_utils::format::JsValueSerdeExt;
 use js_sys::Uint8Array;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -360,13 +359,13 @@ impl Serialize for Snapshot {
 #[wasm_bindgen(js_name = snapshot)]
 pub fn snapshot(doc: &Doc) -> crate::Result<JsValue> {
     let snapshot = doc.0.transact().snapshot();
-    JsValue::from_serde(&Snapshot(snapshot)).map_err(|e| JsValue::from_str(&e.to_string()))
+    crate::js::to_js(&Snapshot(snapshot)).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 #[wasm_bindgen(js_name = equalSnapshots)]
 pub fn equal_snapshots(snap1: &JsValue, snap2: &JsValue) -> bool {
-    let s1: Snapshot = snap1.into_serde().unwrap();
-    let s2: Snapshot = snap2.into_serde().unwrap();
+    let s1: Snapshot = serde_wasm_bindgen::from_value(snap1.clone()).unwrap();
+    let s2: Snapshot = serde_wasm_bindgen::from_value(snap2.clone()).unwrap();
     s1.0 == s2.0
 }
 
@@ -377,7 +376,7 @@ pub fn encode_snapshot_v1(snapshot: &JsValue) -> Vec<u8> {
 
 #[wasm_bindgen(js_name = encodeSnapshotV2)]
 pub fn encode_snapshot_v2(snapshot: &JsValue) -> Vec<u8> {
-    let s: Snapshot = snapshot.into_serde().unwrap();
+    let s: Snapshot = serde_wasm_bindgen::from_value(snapshot.clone()).unwrap();
     s.0.encode_v2()
 }
 
@@ -385,7 +384,7 @@ pub fn encode_snapshot_v2(snapshot: &JsValue) -> Vec<u8> {
 pub fn decode_snapshot_v2(snapshot: &[u8]) -> Result<JsValue> {
     let s = yrs::Snapshot::decode_v2(snapshot)
         .map_err(|_| JsValue::from("failed to deserialize snapshot using lib0 v2 decoding"))?;
-    JsValue::from_serde(&Snapshot(s)).map_err(|e| JsValue::from_str(&e.to_string()))
+    crate::js::to_js(&Snapshot(s)).map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
 #[wasm_bindgen(js_name = decodeSnapshotV1)]
@@ -397,8 +396,7 @@ pub fn decode_snapshot_v1(snapshot: &[u8]) -> Result<JsValue> {
 
 #[wasm_bindgen(js_name = encodeStateFromSnapshotV1)]
 pub fn encode_state_from_snapshot_v1(doc: &Doc, snapshot: JsValue) -> Result<Vec<u8>> {
-    let snapshot: Snapshot = snapshot
-        .into_serde()
+    let snapshot: Snapshot = serde_wasm_bindgen::from_value(snapshot)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
     let mut encoder = yrs::updates::encoder::EncoderV1::new();
     match doc
@@ -413,8 +411,7 @@ pub fn encode_state_from_snapshot_v1(doc: &Doc, snapshot: JsValue) -> Result<Vec
 
 #[wasm_bindgen(js_name = encodeStateFromSnapshotV2)]
 pub fn encode_state_from_snapshot_v2(doc: &Doc, snapshot: JsValue) -> Result<Vec<u8>> {
-    let snapshot: Snapshot = snapshot
-        .into_serde()
+    let snapshot: Snapshot = serde_wasm_bindgen::from_value(snapshot)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
     let mut encoder = yrs::updates::encoder::EncoderV2::new();
     match doc
@@ -467,7 +464,7 @@ pub fn create_sticky_index_from_type(
                 StickyIndex::at(&txn, ptr, index, assoc)
             }
         };
-        JsValue::from_serde(&index).map_err(|e| JsValue::from_str(&e.to_string()))
+        crate::js::to_js(&index).map_err(|e| JsValue::from_str(&e.to_string()))
     } else {
         Err(JsValue::from_str(crate::js::errors::NOT_WASM_OBJ))
     }
@@ -478,7 +475,7 @@ pub fn create_sticky_index_from_type(
 #[wasm_bindgen(js_name=createAbsolutePositionFromRelativePosition)]
 pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &Doc) -> Result<JsValue> {
     let pos: StickyIndex =
-        JsValue::into_serde(rpos).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        serde_wasm_bindgen::from_value(rpos.clone()).map_err(|e| JsValue::from_str(&e.to_string()))?;
     let txn = doc.0.transact();
     if let Some(abs) = pos.get_offset(&txn) {
         #[derive(Serialize)]
@@ -490,7 +487,7 @@ pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &Doc) -> Result<JsVa
             index: abs.index,
             assoc: abs.assoc,
         };
-        JsValue::from_serde(&abs).map_err(|e| JsValue::from_str(&e.to_string()))
+        crate::js::to_js(&abs).map_err(|e| JsValue::from_str(&e.to_string()))
     } else {
         Ok(JsValue::NULL)
     }
@@ -501,7 +498,7 @@ pub fn create_offset_from_sticky_index(rpos: &JsValue, doc: &Doc) -> Result<JsVa
 #[wasm_bindgen(js_name=encodeRelativePosition)]
 pub fn encode_sticky_index(rpos: &JsValue) -> Result<Uint8Array> {
     let pos: StickyIndex =
-        JsValue::into_serde(rpos).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        serde_wasm_bindgen::from_value(rpos.clone()).map_err(|e| JsValue::from_str(&e.to_string()))?;
     let bytes = Uint8Array::from(pos.encode_v1().as_slice());
     Ok(bytes)
 }
@@ -511,14 +508,14 @@ pub fn encode_sticky_index(rpos: &JsValue) -> Result<Uint8Array> {
 pub fn decode_sticky_index(bin: Uint8Array) -> Result<JsValue> {
     let data: Vec<u8> = bin.to_vec();
     match StickyIndex::decode_v1(&data) {
-        Ok(index) => JsValue::from_serde(&index).map_err(|e| JsValue::from_str(&e.to_string())),
+        Ok(index) => crate::js::to_js(&index).map_err(|e| JsValue::from_str(&e.to_string())),
         Err(err) => Err(JsValue::from_str(&err.to_string())),
     }
 }
 
 #[wasm_bindgen(js_name=compareRelativePositions)]
 pub fn sticky_index_cmp(a: JsValue, b: JsValue) -> bool {
-    let a: Option<StickyIndex> = a.into_serde().unwrap();
-    let b: Option<StickyIndex> = b.into_serde().unwrap();
+    let a: Option<StickyIndex> = serde_wasm_bindgen::from_value(a).unwrap();
+    let b: Option<StickyIndex> = serde_wasm_bindgen::from_value(b).unwrap();
     a == b
 }

--- a/ywasm/src/map.rs
+++ b/ywasm/src/map.rs
@@ -3,7 +3,6 @@ use crate::js::{Callback, Js};
 use crate::transaction::YTransaction;
 use crate::weak::YWeakLink;
 use crate::{js, ImplicitTransaction};
-use gloo_utils::format::JsValueSerdeExt;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
@@ -102,7 +101,7 @@ impl YMap {
             }
             SharedCollection::Integrated(c) => c.readonly(txn, |c, txn| {
                 let any = c.to_json(txn);
-                JsValue::from_serde(&any).map_err(|e| JsValue::from_str(&e.to_string()))
+                crate::js::to_js(&any).map_err(|e| JsValue::from_str(&e.to_string()))
             }),
         }
     }

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -3,7 +3,6 @@ use crate::js::{Callback, Js, ValueRef, YRange};
 use crate::transaction::YTransaction;
 use crate::weak::YWeakLink;
 use crate::{ImplicitTransaction, Snapshot};
-use gloo_utils::format::JsValueSerdeExt;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::text::TextEvent;
@@ -312,11 +311,9 @@ impl YText {
             }
             SharedCollection::Integrated(c) => c.mutably(txn, |c, txn| {
                 let doc = txn.doc().clone();
-                let hi: Option<Snapshot> = snapshot
-                    .into_serde()
+                let hi: Option<Snapshot> = serde_wasm_bindgen::from_value(snapshot.clone())
                     .map_err(|e| JsValue::from_str(&e.to_string()))?;
-                let lo: Option<Snapshot> = prev_snapshot
-                    .into_serde()
+                let lo: Option<Snapshot> = serde_wasm_bindgen::from_value(prev_snapshot.clone())
                     .map_err(|e| JsValue::from_str(&e.to_string()))?;
                 let array = js_sys::Array::new();
                 let delta = c.diff_range(txn, hi.as_deref(), lo.as_deref(), |change| {

--- a/ywasm/src/transaction.rs
+++ b/ywasm/src/transaction.rs
@@ -9,7 +9,6 @@ use crate::xml_elem::YXmlElement;
 use crate::xml_frag::YXmlFragment;
 use crate::xml_text::YXmlText;
 use crate::Result;
-use gloo_utils::format::JsValueSerdeExt;
 use js_sys::Uint8Array;
 use std::ops::Deref;
 use wasm_bindgen::__rt::{RcRef, RcRefMut};
@@ -189,7 +188,7 @@ impl YTransaction {
     #[wasm_bindgen(js_name = get)]
     pub fn get(&self, id: JsValue) -> crate::Result<JsValue> {
         let branch_id: BranchID =
-            JsValue::into_serde(&id).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            serde_wasm_bindgen::from_value(id).map_err(|e| JsValue::from_str(&e.to_string()))?;
         let txn = self.as_ref();
         let doc = txn.doc().clone();
         Ok(match branch_id.get_branch(txn) {

--- a/ywasm/src/xml_text.rs
+++ b/ywasm/src/xml_text.rs
@@ -6,7 +6,6 @@ use crate::weak::YWeakLink;
 use crate::xml::XmlAttrs;
 use crate::xml_elem::YXmlElement;
 use crate::{ImplicitTransaction, Snapshot};
-use gloo_utils::format::JsValueSerdeExt;
 use std::collections::HashMap;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
@@ -193,11 +192,9 @@ impl YXmlText {
             }
             SharedCollection::Integrated(c) => c.mutably(txn, |c, txn| {
                 let doc = txn.doc().clone();
-                let hi: Option<Snapshot> = snapshot
-                    .into_serde()
+                let hi: Option<Snapshot> = serde_wasm_bindgen::from_value(snapshot.clone())
                     .map_err(|e| JsValue::from_str(&e.to_string()))?;
-                let lo: Option<Snapshot> = prev_snapshot
-                    .into_serde()
+                let lo: Option<Snapshot> = serde_wasm_bindgen::from_value(prev_snapshot.clone())
                     .map_err(|e| JsValue::from_str(&e.to_string()))?;
                 let array = js_sys::Array::new();
                 let delta = c.diff_range(txn, hi.as_deref(), lo.as_deref(), |change| {


### PR DESCRIPTION
Replace gloo-utils (which uses serde_json internally) with serde-wasm-bindgen for more efficient JS<->Rust serialization without JSON intermediate format.

Key changes:
- Replace gloo-utils dependency with serde-wasm-bindgen
- Add to_js() helper using Serializer::json_compatible() to ensure maps serialize as plain JS objects (not ES2015 Map)
- Update all JsValue::from_serde/into_serde calls to use the new APIs

This reduces the optimized WASM binary size by ~78KB (~9% reduction):
- Before: 837KB (with wasm-opt + strip)
- After:  759KB (with wasm-opt + strip)

All 89 tests pass.