### PR TITLE
Move release profile to workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,10 @@ members = [
   "ywasm",
   "yffi"
 ]
+
+[profile.release]
+# optimization over all codebase ( better optimization, slower build )
+codegen-units = 1
+opt-level = 3 
+lto = true
+panic = 'abort'

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -40,9 +40,3 @@ js-sys = "0.3"
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-[profile.release]
-# optimization over all codebase ( better optimization, slower build )
-codegen-units = 1
-opt-level = 3 # use "z" for size optimization, however it doesn't seem to have any effect
-lto = true
-panic = 'abort'


### PR DESCRIPTION
Reason: member crate profiles are ignored in a workspace, so optimizations weren't applied.

ywasm_bg.wasm size dropped from 707K to 669K (about 38K reduction).