### PR TITLE
fix delete set application after collected history

### DIFF
--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -620,7 +620,18 @@ impl<'doc> TransactionMut<'doc> {
                         }
                         // We can ignore the case of GC and Delete structs, because we are going to skip them
                         if let Some(mut index) = blocks.find_pivot(clock) {
-                            // We can ignore the case of GC and Delete structs, because we are going to skip them
+                            // The delete range may start in collected history.
+                            // Advance to the next materialized item so the remainder of the range
+                            // is still applied to any later live items.
+                            while index < blocks.len() && blocks[index].as_item().is_none() {
+                                index += 1;
+                            }
+
+                            if index == blocks.len() {
+                                continue;
+                            }
+
+                            // We can ignore the case of Delete structs, because we are going to skip them
                             let ptr = &mut blocks[index];
                             if let Some(item) = ptr.as_item() {
                                 // split the first item if necessary


### PR DESCRIPTION
Fixes #605, the fix results can be seen in the [fix branch](https://github.com/mslxl/yrs-xml-syncstep2-repro/tree/fix)([CI Result](https://github.com/mslxl/yrs-xml-syncstep2-repro/actions/runs/24029662293/job/70075547946)) of the minimal reproduction repo.

This change fixes `DeleteSet` application when the start of a delete range falls inside collected history and the next live item still needs to be processed.

I am not very familiar with Yrs/Yjs, so while this change fixes the reproduced cases, I am not sure if any break changes exist. But all unit tests are passed. Please review carefully, thanks.
