### PR TITLE
DecoderV1: read clientIDs as u64 (fixes silent truncation above 2^32)

### DIFF
--- a/yrs/src/tests/decoder_v1_clientid_above_u32.rs
+++ b/yrs/src/tests/decoder_v1_clientid_above_u32.rs
@@ -1,0 +1,138 @@
+//! Regression gates for issue #609 — `DecoderV1::read_client` and
+//! `read_id` silently truncated clientIDs > 2^32 to u32 via
+//! `read_var_u32`'s `wrapping_shl`. The encoder side and the wire
+//! format both supported the full `ClientID = u64` range; only the V1
+//! decoder dropped the upper bits. `DecoderV2` was always correct.
+//!
+//! These tests fail on the pre-fix DecoderV1 (clientID `0x19266f5beab768`
+//! decodes as `0x5bfbb768` — lower 32 bits XOR-rotated) and pass on
+//! the fixed DecoderV1.
+
+use crate::updates::decoder::Decode;
+use crate::{Doc, GetString, Options, ReadTxn, StateVector, Text, Transact, Update};
+
+/// `DecoderV1::read_client` site — the per-client header in the v1
+/// update binary.
+#[test]
+fn decoderv1_read_client_round_trips_clientids_above_u32() {
+    // 0x19266f5beab768 ≈ 7×10^15 — fits in 53 bits (the JS-yjs safe range)
+    // but well above 2^32 so the bug truncates it.
+    let cid: u64 = 7_079_134_143_100_776;
+    assert!(cid > u64::from(u32::MAX));
+
+    let doc = Doc::with_options(Options {
+        client_id: cid,
+        skip_gc: false,
+        ..Default::default()
+    });
+    let text = doc.get_or_insert_text("content");
+    {
+        let mut txn = doc.transact_mut();
+        text.insert(&mut txn, 0, "x");
+    }
+    let bytes = doc
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+
+    let update = Update::decode_v1(&bytes).expect("decode_v1 must succeed on self-encoded update");
+    let decoded: Vec<u64> = update.state_vector().iter().map(|(c, _)| *c).collect();
+    assert_eq!(
+        decoded,
+        vec![cid],
+        "DecoderV1::read_client must round-trip clientIDs > 2^32 losslessly. \
+         Encoded {cid:#x}, decoded {decoded:?}.",
+    );
+}
+
+/// `DecoderV1::read_id` site — block-origin (`left_id` / `right_id`)
+/// references. More dangerous than `read_client`: corrupts CRDT
+/// ordering, not just attribution metadata. Construct a multi-writer
+/// merge update where the second writer's op has a left-origin
+/// pointing at the first writer's > 2^32 clientID; assert the post-
+/// apply doc's state_vector contains BOTH original clientIDs un-
+/// truncated.
+#[test]
+fn decoderv1_read_id_round_trips_block_origin_clientids_above_u32() {
+    let cid_a: u64 = 7_079_134_143_100_776; // 0x19266f5beab768
+    let cid_b: u64 = 6_332_093_782_882_047; // 0x167f01789cf6ff (distinct, > u32::MAX)
+    assert!(cid_a > u64::from(u32::MAX) && cid_b > u64::from(u32::MAX));
+    assert_ne!(cid_a, cid_b);
+
+    // Step 1: doc_a inserts "a".
+    let doc_a = Doc::with_options(Options {
+        client_id: cid_a,
+        skip_gc: false,
+        ..Default::default()
+    });
+    let text_a = doc_a.get_or_insert_text("content");
+    {
+        let mut txn = doc_a.transact_mut();
+        text_a.insert(&mut txn, 0, "a");
+    }
+    let doc_a_state = doc_a
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+
+    // Step 2: doc_b applies doc_a's state, then inserts "b" at offset 1
+    // (left-origin = "a"'s ID, which carries cid_a).
+    let doc_b = Doc::with_options(Options {
+        client_id: cid_b,
+        skip_gc: false,
+        ..Default::default()
+    });
+    let text_b = doc_b.get_or_insert_text("content");
+    {
+        let mut txn = doc_b.transact_mut();
+        let update_a = Update::decode_v1(&doc_a_state).expect("decode doc_a state");
+        txn.apply_update(update_a).expect("apply doc_a state in doc_b");
+    }
+    {
+        let mut txn = doc_b.transact_mut();
+        text_b.insert(&mut txn, 1, "b");
+    }
+    let doc_b_state = doc_b
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+
+    // Step 3: doc_c (fresh, distinct < u32 clientID) applies doc_b's state.
+    let doc_c = Doc::with_options(Options {
+        client_id: 0x0011_0011, // < u32::MAX, sentinel
+        skip_gc: false,
+        ..Default::default()
+    });
+    let _text_c = doc_c.get_or_insert_text("content");
+    {
+        let mut txn = doc_c.transact_mut();
+        let update_b = Update::decode_v1(&doc_b_state).expect("decode doc_b state");
+        txn.apply_update(update_b).expect("apply doc_b state in doc_c");
+    }
+
+    // Both writer clientIDs (cid_a, cid_b) MUST appear un-truncated
+    // in doc_c's post-apply state_vector. Drop the local mirror
+    // clientID (artifact of get_or_insert_text local write).
+    let txn_c = doc_c.transact();
+    let sv = txn_c.state_vector();
+    let mut clients: std::collections::BTreeSet<u64> = sv
+        .iter()
+        .map(|(c, _)| *c)
+        .collect::<std::collections::BTreeSet<u64>>();
+    clients.remove(&0x0011_0011);
+
+    let expected: std::collections::BTreeSet<u64> =
+        std::array::IntoIter::new([cid_a, cid_b]).collect();
+    assert_eq!(
+        clients, expected,
+        "DecoderV1::read_id must round-trip block-origin clientIDs > 2^32 losslessly. \
+         Expected {{cid_a={cid_a:#x}, cid_b={cid_b:#x}}}, got {clients:?}.",
+    );
+
+    // Sanity: the merge actually happened (both characters present).
+    let text_c = txn_c
+        .get_text("content")
+        .expect("doc_c content text root must exist post-apply")
+        .get_string(&txn_c);
+    assert!(
+        text_c.contains('a') && text_c.contains('b') && text_c.len() == 2,
+        "merged text malformed: {text_c:?}",
+    );
+}

--- a/yrs/src/tests/mod.rs
+++ b/yrs/src/tests/mod.rs
@@ -1,3 +1,4 @@
 mod compatibility_tests;
+mod decoder_v1_clientid_above_u32;
 mod edit_traces;
 mod edit_traces_tests;

--- a/yrs/src/updates/decoder.rs
+++ b/yrs/src/updates/decoder.rs
@@ -83,9 +83,16 @@ impl<'a> DecoderV1<'a> {
     }
 
     fn read_id(&mut self) -> Result<ID, Error> {
-        let client: u32 = self.read_var()?;
-        let clock = self.read_var()?;
-        Ok(ID::new(client as ClientID, clock))
+        // Read client as `u64` (was `u32`). `read_var<u32>` uses
+        // `u32::wrapping_shl` per byte, silently truncating clientIDs
+        // > 2^32 by XOR-rotating their upper bits into the lower 32 —
+        // breaking Rust ⇄ JS interop and breaking Rust-only deployments
+        // that use the full `ClientID = u64` range. `clock` stays `u32`
+        // because the clock space IS u32 by design (`StateVector`
+        // values are `u32`).
+        let client: u64 = self.read_var()?;
+        let clock: u32 = self.read_var()?;
+        Ok(ID::new(client, clock))
     }
 }
 
@@ -139,10 +146,12 @@ impl<'a> Decoder for DecoderV1<'a> {
         self.read_id()
     }
 
+    /// Read client as `u64`. See sibling [`DecoderV1::read_id`] patch
+    /// comment for the full rationale (DecoderV2 already reads u64
+    /// — only V1 carried the legacy u32 cast).
     #[inline]
     fn read_client(&mut self) -> Result<ClientID, Error> {
-        let client: u32 = self.cursor.read_var()?;
-        Ok(client as ClientID)
+        self.cursor.read_var::<u64>()
     }
 
     #[inline]


### PR DESCRIPTION
Closes #609.

### What

Two-line change in `src/updates/decoder.rs`:

- `DecoderV1::read_client` (per-client header, line 143): read as `u64`.
- `DecoderV1::read_id` (block origin / `left_id` / `right_id`, lines 85-88): read `client` as `u64`. `clock` stays `u32` (yrs's clock space is `u32` by design; `StateVector` values are `u32`; `ID::new(client: ClientID, clock: u32)` already takes `u32` for clock).

```diff
@@ DecoderV1::read_id @@
     fn read_id(&mut self) -> Result<ID, Error> {
-        let client: u32 = self.read_var()?;
-        let clock = self.read_var()?;
-        Ok(ID::new(client as ClientID, clock))
+        let client: u64 = self.read_var()?;
+        let clock: u32 = self.read_var()?;
+        Ok(ID::new(client, clock))
     }

@@ Decoder for DecoderV1 :: read_client @@
     #[inline]
     fn read_client(&mut self) -> Result<ClientID, Error> {
-        let client: u32 = self.cursor.read_var()?;
-        Ok(client as ClientID)
+        self.cursor.read_var::<u64>()
     }
```

`DecoderV2` is unchanged — it already reads as `u64`.

### Why

Issue #609 describes the bug: client IDs in `[u32::MAX + 1, u64::MAX]` round-trip losslessly through `lib0.readVarUint` (JS) and through the `yrs` encoder, but `DecoderV1` silently truncates them to the lower 32 bits XOR-rotated (because `read_var<u32>` uses `u32::wrapping_shl` per byte). This breaks Rust ⇄ JS interop and breaks Rust-only deployments that use the full `ClientID = u64` range.

### Behavioural change

For client IDs in `[0, u32::MAX]` the patch is a strict no-op (the previous `read_var<u32>` cast was correct in this range, and `read_var<u64>` returns the same bits). For client IDs in `(u32::MAX, u64::MAX]` the patch unbreaks the round-trip — the value the encoder wrote is now the value the decoder reads.

### Tests

- Adds `tests/clientid_above_u32_round_trips_v1.rs` with two regression gates (one per fixed site): per-client-header round-trip, and a multi-writer merge update where the second writer's op has a left-origin pointing at the first writer's `> 2^32` client ID. Both fail under stock `yrs` and pass under this patch.
- Existing test suite is unaffected (no test in the existing suite happened to exercise client IDs > 2^32, which is why the bug went undetected).

### Compatibility

- Wire format: unchanged. `write_var<u64>` and `read_var<u64>` produce / consume the same byte stream that `lib0` already produces / consumes.
- `Update::blocks.clients` HashMap key type: unchanged (`ClientID = u64`).
- `StateVector::iter()` value semantics: unchanged.
- `yjs` JS peer compatibility: improved (now matches `lib0.readVarUint`'s 53-bit range).

### Discovered via

Working on a Rust ⇄ JS interop test for a project we are working on. We use a per-device BLAKE3-derived `u64 & ((1<<53) - 1)` client ID; values ≥ 2^32 are overwhelmingly common. Our local workaround was a `[patch.crates-io]` vendored fork carrying this exact diff; we'd rather upstream the fix.

