### PR TITLE
Idset refactor

### DIFF
--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -24,9 +24,9 @@ use yrs::undo::EventKind;
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use yrs::{
-    uuid_v4, Any, Array, ArrayRef, Assoc, BranchID, DeleteSet, GetString, JsonPath, JsonPathEval,
-    Map, MapRef, Observable, OffsetKind, Options, Origin, Out, Quotable, ReadTxn, Snapshot,
-    StateVector, StickyIndex, Store, SubdocsEvent, SubdocsEventIter, Text, TextRef, Transact,
+    uuid_v4, Any, Array, ArrayRef, Assoc, BranchID, GetString, IdSet, JsonPath, JsonPathEval, Map,
+    MapRef, Observable, OffsetKind, Options, Origin, Out, Quotable, ReadTxn, Snapshot, StateVector,
+    StickyIndex, Store, SubdocsEvent, SubdocsEventIter, Text, TextRef, Transact,
     TransactionCleanupEvent, Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragmentRef,
     XmlTextPrelim, XmlTextRef, ID,
 };
@@ -4013,7 +4013,7 @@ pub struct YDeleteSet {
 }
 
 impl YDeleteSet {
-    unsafe fn new(ds: &DeleteSet) -> Self {
+    unsafe fn new(ds: &IdSet) -> Self {
         let len = ds.len();
         let mut client_ids = Vec::with_capacity(len);
         let mut ranges = Vec::with_capacity(len);

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -41,6 +41,10 @@ uuid = "1.16.0"
 name = "benches"
 harness = false
 
+[[bench]]
+name = "id_set"
+harness = false
+
 [lib]
 doctest = true
 bench = true

--- a/yrs/benches/id_set.rs
+++ b/yrs/benches/id_set.rs
@@ -1,0 +1,147 @@
+// Microbenchmarks for IdSet/DeleteSet insert + squash + merge.
+//
+// Used to compare the current "batch insert + explicit squash()" pipeline
+// against an upcoming refactor that maintains the squashed invariant
+// inside insert/merge directly. The benches use only the public DeleteSet
+// API so they remain runnable across the refactor (post-refactor: drop the
+// .squash() calls — they become a no-op or are removed).
+
+use criterion::*;
+use yrs::{DeleteSet, ID};
+
+const CLIENT_A: u64 = 1;
+const CLIENT_B: u64 = 2;
+
+// Base set: 10 ranges for one client, spaced with gaps.
+// Pattern: [0..5), [10..15), [20..25), ..., [90..95).
+fn build_base_10() -> DeleteSet {
+    let mut ds = DeleteSet::new();
+    for i in 0..10u32 {
+        ds.insert(ID::new(CLIENT_A, i * 10), 5);
+    }
+    ds
+}
+
+// Scenario 1: starting from a 10-range set, insert one new range that
+// overlaps the middle, then squash to canonical form.
+fn bench_insert_one_then_squash(c: &mut Criterion) {
+    c.bench_function("id_set/insert_1_then_squash", |b| {
+        b.iter_batched(
+            build_base_10,
+            |mut ds| {
+                // [47..53) overlaps [40..45) tail and [50..55) head — bridges them.
+                ds.insert(ID::new(CLIENT_A, 47), 6);
+                ds.squash();
+                ds
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+// Scenario 2: starting from a 10-range set, insert five new ranges
+// (mix of disjoint, adjacent, overlapping, and extending past the tail),
+// then squash.
+fn bench_insert_five_then_squash(c: &mut Criterion) {
+    c.bench_function("id_set/insert_5_then_squash", |b| {
+        b.iter_batched(
+            build_base_10,
+            |mut ds| {
+                // [7..11)   — bridges [0..5) and [10..15) via the gap (no overlap, but adjacent merge after squash).
+                // [23..27)  — overlaps [20..25).
+                // [47..53)  — bridges [40..45) and [50..55).
+                // [75..83)  — overlaps [70..75) and [80..85).
+                // [100..110)— extends past the tail.
+                ds.insert(ID::new(CLIENT_A, 7), 4);
+                ds.insert(ID::new(CLIENT_A, 23), 4);
+                ds.insert(ID::new(CLIENT_A, 47), 6);
+                ds.insert(ID::new(CLIENT_A, 75), 8);
+                ds.insert(ID::new(CLIENT_A, 100), 10);
+                ds.squash();
+                ds
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+// Scenario 3: merge two DeleteSets in three flavours.
+//
+// disjoint_same_client: same client id; ranges in B sit far past the
+// ranges in A — same per-client list to walk, but no overlap.
+//
+// unique_clients: A and B carry different client ids — merge degenerates
+// to a HashMap union with no per-IdRange merging.
+//
+// overlapping: same client id; every range in B overlaps a range in A,
+// forcing a real merge per range.
+fn bench_merge(c: &mut Criterion) {
+    let build_b_disjoint = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            ds.insert(ID::new(CLIENT_A, 200 + i * 10), 5);
+        }
+        ds
+    };
+
+    let build_b_unique = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            ds.insert(ID::new(CLIENT_B, i * 10), 5);
+        }
+        ds
+    };
+
+    let build_b_overlapping = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            // A has [i*10 .. i*10 + 5); B has [i*10 + 3 .. i*10 + 8).
+            ds.insert(ID::new(CLIENT_A, i * 10 + 3), 5);
+        }
+        ds
+    };
+
+    let mut g = c.benchmark_group("id_set/merge");
+
+    g.bench_function("disjoint_same_client", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_disjoint()),
+            |(mut a, b)| {
+                a.merge(b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("unique_clients", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_unique()),
+            |(mut a, b)| {
+                a.merge(b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("overlapping", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_overlapping()),
+            |(mut a, b)| {
+                a.merge(b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.finish();
+}
+
+criterion_group! {
+    name = id_set_benches;
+    config = Criterion::default();
+    targets = bench_insert_one_then_squash, bench_insert_five_then_squash, bench_merge,
+}
+criterion_main!(id_set_benches);

--- a/yrs/benches/id_set.rs
+++ b/yrs/benches/id_set.rs
@@ -1,11 +1,3 @@
-// Microbenchmarks for IdSet/DeleteSet insert + squash + merge.
-//
-// Used to compare the current "batch insert + explicit squash()" pipeline
-// against an upcoming refactor that maintains the squashed invariant
-// inside insert/merge directly. The benches use only the public DeleteSet
-// API so they remain runnable across the refactor (post-refactor: drop the
-// .squash() calls — they become a no-op or are removed).
-
 use criterion::*;
 use yrs::{DeleteSet, ID};
 
@@ -22,8 +14,7 @@ fn build_base_10() -> DeleteSet {
     ds
 }
 
-// Scenario 1: starting from a 10-range set, insert one new range that
-// overlaps the middle, then squash to canonical form.
+// Scenario 1: starting from a 10-range set, insert one new range that overlaps the middle
 fn bench_insert_one_then_squash(c: &mut Criterion) {
     c.bench_function("id_set/insert_1_then_squash", |b| {
         b.iter_batched(
@@ -31,7 +22,6 @@ fn bench_insert_one_then_squash(c: &mut Criterion) {
             |mut ds| {
                 // [47..53) overlaps [40..45) tail and [50..55) head — bridges them.
                 ds.insert(ID::new(CLIENT_A, 47), 6);
-                ds.squash();
                 ds
             },
             BatchSize::SmallInput,
@@ -40,14 +30,13 @@ fn bench_insert_one_then_squash(c: &mut Criterion) {
 }
 
 // Scenario 2: starting from a 10-range set, insert five new ranges
-// (mix of disjoint, adjacent, overlapping, and extending past the tail),
-// then squash.
+// (mix of disjoint, adjacent, overlapping, and extending past the tail).
 fn bench_insert_five_then_squash(c: &mut Criterion) {
     c.bench_function("id_set/insert_5_then_squash", |b| {
         b.iter_batched(
             build_base_10,
             |mut ds| {
-                // [7..11)   — bridges [0..5) and [10..15) via the gap (no overlap, but adjacent merge after squash).
+                // [7..11)   — bridges [0..5) and [10..15) via the gap.
                 // [23..27)  — overlaps [20..25).
                 // [47..53)  — bridges [40..45) and [50..55).
                 // [75..83)  — overlaps [70..75) and [80..85).
@@ -57,7 +46,6 @@ fn bench_insert_five_then_squash(c: &mut Criterion) {
                 ds.insert(ID::new(CLIENT_A, 47), 6);
                 ds.insert(ID::new(CLIENT_A, 75), 8);
                 ds.insert(ID::new(CLIENT_A, 100), 10);
-                ds.squash();
                 ds
             },
             BatchSize::SmallInput,

--- a/yrs/benches/id_set.rs
+++ b/yrs/benches/id_set.rs
@@ -127,9 +127,139 @@ fn bench_merge(c: &mut Criterion) {
     g.finish();
 }
 
+// Scenario 4: exclude one DeleteSet from another in three flavours, mirroring `bench_merge`.
+fn bench_exclude(c: &mut Criterion) {
+    let build_b_disjoint = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            ds.insert(ID::new(CLIENT_A, 200 + i * 10), 5);
+        }
+        ds
+    };
+
+    let build_b_unique = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            ds.insert(ID::new(CLIENT_B, i * 10), 5);
+        }
+        ds
+    };
+
+    let build_b_overlapping = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            // A has [i*10 .. i*10 + 5); B has [i*10 + 3 .. i*10 + 8) — carves the right edge of every range in A.
+            ds.insert(ID::new(CLIENT_A, i * 10 + 3), 5);
+        }
+        ds
+    };
+
+    let mut g = c.benchmark_group("id_set/exclude");
+
+    g.bench_function("disjoint_same_client", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_disjoint()),
+            |(mut a, b)| {
+                a.exclude(&b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("unique_clients", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_unique()),
+            |(mut a, b)| {
+                a.exclude(&b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("overlapping", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_overlapping()),
+            |(mut a, b)| {
+                a.exclude(&b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.finish();
+}
+
+// Scenario 5: intersect two DeleteSets in three flavours.
+fn bench_intersect(c: &mut Criterion) {
+    let build_b_disjoint = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            ds.insert(ID::new(CLIENT_A, 200 + i * 10), 5);
+        }
+        ds
+    };
+
+    let build_b_unique = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            ds.insert(ID::new(CLIENT_B, i * 10), 5);
+        }
+        ds
+    };
+
+    let build_b_overlapping = || {
+        let mut ds = DeleteSet::new();
+        for i in 0..10u32 {
+            // B's [i*10 + 3 .. i*10 + 8) overlaps the right portion of every range in A.
+            ds.insert(ID::new(CLIENT_A, i * 10 + 3), 5);
+        }
+        ds
+    };
+
+    let mut g = c.benchmark_group("id_set/intersect");
+
+    g.bench_function("disjoint_same_client", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_disjoint()),
+            |(mut a, b)| {
+                a.intersect(&b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("unique_clients", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_unique()),
+            |(mut a, b)| {
+                a.intersect(&b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.bench_function("overlapping", |b| {
+        b.iter_batched(
+            || (build_base_10(), build_b_overlapping()),
+            |(mut a, b)| {
+                a.intersect(&b);
+                a
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    g.finish();
+}
+
 criterion_group! {
     name = id_set_benches;
     config = Criterion::default();
-    targets = bench_insert_one_then_squash, bench_insert_five_then_squash, bench_merge,
+    targets = bench_insert_one_then_squash, bench_insert_five_then_squash, bench_merge, bench_exclude, bench_intersect,
 }
 criterion_main!(id_set_benches);

--- a/yrs/benches/id_set.rs
+++ b/yrs/benches/id_set.rs
@@ -1,13 +1,13 @@
 use criterion::*;
-use yrs::{DeleteSet, ID};
+use yrs::{IdSet, ID};
 
 const CLIENT_A: u64 = 1;
 const CLIENT_B: u64 = 2;
 
 // Base set: 10 ranges for one client, spaced with gaps.
 // Pattern: [0..5), [10..15), [20..25), ..., [90..95).
-fn build_base_10() -> DeleteSet {
-    let mut ds = DeleteSet::new();
+fn build_base_10() -> IdSet {
+    let mut ds = IdSet::new();
     for i in 0..10u32 {
         ds.insert(ID::new(CLIENT_A, i * 10), 5);
     }
@@ -65,7 +65,7 @@ fn bench_insert_five_then_squash(c: &mut Criterion) {
 // forcing a real merge per range.
 fn bench_merge(c: &mut Criterion) {
     let build_b_disjoint = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             ds.insert(ID::new(CLIENT_A, 200 + i * 10), 5);
         }
@@ -73,7 +73,7 @@ fn bench_merge(c: &mut Criterion) {
     };
 
     let build_b_unique = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             ds.insert(ID::new(CLIENT_B, i * 10), 5);
         }
@@ -81,7 +81,7 @@ fn bench_merge(c: &mut Criterion) {
     };
 
     let build_b_overlapping = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             // A has [i*10 .. i*10 + 5); B has [i*10 + 3 .. i*10 + 8).
             ds.insert(ID::new(CLIENT_A, i * 10 + 3), 5);
@@ -127,10 +127,10 @@ fn bench_merge(c: &mut Criterion) {
     g.finish();
 }
 
-// Scenario 4: exclude one DeleteSet from another in three flavours, mirroring `bench_merge`.
+// Scenario 4: exclude one IdSet from another in three flavours, mirroring `bench_merge`.
 fn bench_exclude(c: &mut Criterion) {
     let build_b_disjoint = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             ds.insert(ID::new(CLIENT_A, 200 + i * 10), 5);
         }
@@ -138,7 +138,7 @@ fn bench_exclude(c: &mut Criterion) {
     };
 
     let build_b_unique = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             ds.insert(ID::new(CLIENT_B, i * 10), 5);
         }
@@ -146,7 +146,7 @@ fn bench_exclude(c: &mut Criterion) {
     };
 
     let build_b_overlapping = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             // A has [i*10 .. i*10 + 5); B has [i*10 + 3 .. i*10 + 8) — carves the right edge of every range in A.
             ds.insert(ID::new(CLIENT_A, i * 10 + 3), 5);
@@ -195,7 +195,7 @@ fn bench_exclude(c: &mut Criterion) {
 // Scenario 5: intersect two DeleteSets in three flavours.
 fn bench_intersect(c: &mut Criterion) {
     let build_b_disjoint = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             ds.insert(ID::new(CLIENT_A, 200 + i * 10), 5);
         }
@@ -203,7 +203,7 @@ fn bench_intersect(c: &mut Criterion) {
     };
 
     let build_b_unique = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             ds.insert(ID::new(CLIENT_B, i * 10), 5);
         }
@@ -211,7 +211,7 @@ fn bench_intersect(c: &mut Criterion) {
     };
 
     let build_b_overlapping = || {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         for i in 0..10u32 {
             // B's [i*10 + 3 .. i*10 + 8) overlaps the right portion of every range in A.
             ds.insert(ID::new(CLIENT_A, i * 10 + 3), 5);

--- a/yrs/benches/id_set.rs
+++ b/yrs/benches/id_set.rs
@@ -95,7 +95,7 @@ fn bench_merge(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_disjoint()),
             |(mut a, b)| {
-                a.merge(b);
+                a.merge_with(b);
                 a
             },
             BatchSize::SmallInput,
@@ -106,7 +106,7 @@ fn bench_merge(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_unique()),
             |(mut a, b)| {
-                a.merge(b);
+                a.merge_with(b);
                 a
             },
             BatchSize::SmallInput,
@@ -117,7 +117,7 @@ fn bench_merge(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_overlapping()),
             |(mut a, b)| {
-                a.merge(b);
+                a.merge_with(b);
                 a
             },
             BatchSize::SmallInput,
@@ -160,7 +160,7 @@ fn bench_exclude(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_disjoint()),
             |(mut a, b)| {
-                a.exclude(&b);
+                a.diff_with(&b);
                 a
             },
             BatchSize::SmallInput,
@@ -171,7 +171,7 @@ fn bench_exclude(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_unique()),
             |(mut a, b)| {
-                a.exclude(&b);
+                a.diff_with(&b);
                 a
             },
             BatchSize::SmallInput,
@@ -182,7 +182,7 @@ fn bench_exclude(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_overlapping()),
             |(mut a, b)| {
-                a.exclude(&b);
+                a.diff_with(&b);
                 a
             },
             BatchSize::SmallInput,
@@ -225,7 +225,7 @@ fn bench_intersect(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_disjoint()),
             |(mut a, b)| {
-                a.intersect(&b);
+                a.intersect_with(&b);
                 a
             },
             BatchSize::SmallInput,
@@ -236,7 +236,7 @@ fn bench_intersect(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_unique()),
             |(mut a, b)| {
-                a.intersect(&b);
+                a.intersect_with(&b);
                 a
             },
             BatchSize::SmallInput,
@@ -247,7 +247,7 @@ fn bench_intersect(c: &mut Criterion) {
         b.iter_batched(
             || (build_base_10(), build_b_overlapping()),
             |(mut a, b)| {
-                a.intersect(&b);
+                a.intersect_with(&b);
                 a
             },
             BatchSize::SmallInput,

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -13,7 +13,7 @@ use crate::undo::UndoStack;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::OptionExt;
-use crate::{Any, DeleteSet, Doc, Options, Out, Transact};
+use crate::{Any, Doc, IdSet, Options, Out, Transact};
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;
 use std::collections::HashSet;
@@ -240,7 +240,7 @@ impl ItemPtr {
         &mut self,
         txn: &mut TransactionMut,
         redo_items: &HashSet<ItemPtr>,
-        items_to_delete: &DeleteSet,
+        items_to_delete: &IdSet,
         s1: &UndoStack<M>,
         s2: &UndoStack<M>,
     ) -> Option<ItemPtr> {
@@ -297,7 +297,7 @@ impl ItemPtr {
                     if let Some(left_right) = left_item.right {
                         let id = left_right.id();
                         if left_right.redone.is_some()
-                            || items_to_delete.is_deleted(id)
+                            || items_to_delete.contains(id)
                             || s1.is_deleted(id)
                             || s2.is_deleted(id)
                         {

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1043,7 +1043,7 @@ mod test {
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{
-        any, uuid_v4, Any, Array, ArrayPrelim, ArrayRef, DeleteSet, Doc, GetString, Map, MapRef,
+        any, uuid_v4, Any, Array, ArrayPrelim, ArrayRef, Doc, GetString, IdSet, Map, MapRef,
         OffsetKind, Options, Snapshot, StateVector, Subscription, Text, TextPrelim, TextRef,
         Transact, Uuid, WriteTxn, XmlElementPrelim, XmlFragment, XmlFragmentRef, XmlTextPrelim,
         XmlTextRef, ID,
@@ -2376,7 +2376,7 @@ mod test {
             Some(Arc::new((
                 StateVector::default(),
                 StateVector::from_iter([(1, 11)]),
-                DeleteSet::default()
+                IdSet::default()
             )))
         );
 
@@ -2388,7 +2388,7 @@ mod test {
                 StateVector::from_iter([(1, 11)]),
                 StateVector::from_iter([(1, 11)]),
                 {
-                    let mut ds = DeleteSet::new();
+                    let mut ds = IdSet::new();
                     ds.insert(ID::new(1, 2), 7);
                     ds
                 }

--- a/yrs/src/event.rs
+++ b/yrs/src/event.rs
@@ -1,6 +1,6 @@
 use crate::doc::DocAddr;
 use crate::transaction::Subdocs;
-use crate::{DeleteSet, Doc, StateVector, TransactionMut};
+use crate::{Doc, IdSet, StateVector, TransactionMut};
 use std::collections::HashMap;
 
 /// An update event passed to a callback subscribed with [Doc::observe_update_v1]/[Doc::observe_update_v2].
@@ -28,7 +28,7 @@ impl UpdateEvent {
 pub struct TransactionCleanupEvent {
     pub before_state: StateVector,
     pub after_state: StateVector,
-    pub delete_set: DeleteSet,
+    pub delete_set: IdSet,
 }
 
 impl TransactionCleanupEvent {

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -1,5 +1,5 @@
 use crate::block::{BlockCell, ClientID, GC};
-use crate::{DeleteSet, Store, TransactionMut, ID};
+use crate::{IdSet, Store, TransactionMut, ID};
 use std::collections::HashMap;
 
 #[derive(Default)]
@@ -16,7 +16,7 @@ impl GCCollector {
     }
 
     /// Garbage collect all deleted blocks from current transaction's document store.
-    pub fn collect_all(txn: &mut TransactionMut, delete_set: Option<&DeleteSet>) {
+    pub fn collect_all(txn: &mut TransactionMut, delete_set: Option<&IdSet>) {
         let mut gc = Self::default();
         match delete_set {
             None => gc.mark_all(txn),
@@ -30,7 +30,7 @@ impl GCCollector {
         &mut self,
         store: &mut Store,
         mut merge_blocks: Option<&mut Vec<ID>>,
-        delete_set: &DeleteSet,
+        delete_set: &IdSet,
     ) {
         for (client, range) in delete_set.iter() {
             if let Some(blocks) = store.blocks.get_client_mut(client) {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -239,34 +239,44 @@ impl IdRange {
     /// Excludes `other` from the current [IdRange]: every clock covered by `other` is removed
     /// from `self`, leaving the parts of `self` that lie outside `other`.
     pub fn exclude(&mut self, other: &Self) {
+        if other.0.is_empty() || self.0.is_empty() {
+            return;
+        }
+
         let mut result = SmallVec::new();
+        let other = other.0.as_slice();
+        let mut i = 0usize;
 
         for range in self.0.iter() {
-            let mut current_ranges: SmallVec<[Range<u32>; 2]> = smallvec![range.clone()];
+            let mut start = range.start;
+            let end = range.end;
 
-            for other_range in other.0.iter() {
-                let mut new_ranges = SmallVec::new();
-                for r in current_ranges {
-                    if Self::disjoint(&r, other_range) {
-                        // No overlap, keep the range as is
-                        new_ranges.push(r);
-                    } else {
-                        // There's overlap, subtract the overlapping part
-                        if r.start < other_range.start {
-                            // Keep the part before other_range
-                            new_ranges.push(r.start..other_range.start);
-                        }
-                        if r.end > other_range.end {
-                            // Keep the part after other_range
-                            new_ranges.push(other_range.end..r.end);
-                        }
-                        // The overlapping part is discarded
-                    }
-                }
-                current_ranges = new_ranges;
+            // Drop other-ranges entirely to the left of [s..e). Monotone across iterations.
+            while i < other.len() && other[i].end <= start {
+                i += 1;
             }
 
-            result.extend(current_ranges);
+            // Cut the other range from [s..e)
+            let mut j = i;
+            while start < end && j < other.len() {
+                let other_range = &other[j];
+                if other_range.start >= end {
+                    break; // remaining other-ranges lie past this self-range
+                }
+                if other_range.start > start {
+                    result.push(start..other_range.start);
+                }
+                start = start.max(other_range.end);
+                if other_range.end < end {
+                    j += 1; // consumed other range; move on
+                } else {
+                    break; // other range extends over the current one — keep it for the next self-range
+                }
+            }
+            if start < end {
+                result.push(start..end);
+            }
+            i = j;
         }
 
         *self = IdRange(result);
@@ -275,21 +285,38 @@ impl IdRange {
     /// Computes the intersection of the current [IdRange] with `other`, modifying the current
     /// range to contain only elements present in both ranges.
     pub fn intersect(&mut self, other: &Self) {
-        let mut result = SmallVec::new();
+        if self.0.is_empty() || other.0.is_empty() {
+            *self = IdRange::default();
+            return;
+        }
 
-        for self_range in self.0.iter() {
-            for other_range in other.0.iter() {
-                if !Self::disjoint(self_range, other_range) {
-                    // Ranges overlap, compute the intersection.
-                    let start = self_range.start.max(other_range.start);
-                    let end = self_range.end.min(other_range.end);
-                    // `disjoint()` uses closed-interval semantics, so `start == end` can slip
-                    // through for half-open ranges that abut at a single clock — drop those.
-                    if start < end {
-                        result.push(start..end);
-                    }
+        let mut result = SmallVec::new();
+        let other = other.0.as_slice();
+        let mut i = 0usize;
+
+        for range in self.0.iter() {
+            while i < other.len() && other[i].end <= range.start {
+                i += 1;
+            }
+
+            let mut j = i;
+            while j < other.len() {
+                let other_range = &other[j];
+                if other_range.start >= range.end {
+                    break;
+                }
+                let lo = range.start.max(other_range.start);
+                let hi = range.end.min(other_range.end);
+                if lo < hi {
+                    result.push(lo..hi);
+                }
+                if other_range.end < range.end {
+                    j += 1;
+                } else {
+                    break;
                 }
             }
+            i = j;
         }
 
         *self = IdRange(result);
@@ -300,11 +327,6 @@ impl IdRange {
         for range in self.0.iter() {
             range.encode(encoder);
         }
-    }
-
-    #[inline]
-    fn disjoint(a: &Range<u32>, b: &Range<u32>) -> bool {
-        a.start > b.end || b.start > a.end
     }
 }
 
@@ -635,6 +657,18 @@ impl DeleteSet {
     /// clock ranges.
     pub fn merge(&mut self, other: Self) {
         self.0.merge(other.0)
+    }
+
+    /// Removes from `self` every clock range covered by `other`. Clients whose ranges become
+    /// empty are dropped.
+    pub fn exclude(&mut self, other: &Self) {
+        self.0.exclude(&other.0)
+    }
+
+    /// Restricts `self` to the per-client intersection with `other`. Clients absent from
+    /// `other` (or whose intersection is empty) are dropped.
+    pub fn intersect(&mut self, other: &Self) {
+        self.0.intersect(&other.0)
     }
 
     pub fn range(&self, client_id: &ClientID) -> Option<&IdRange> {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -36,187 +36,162 @@ impl Decode for Range<u32> {
 
 /// [IdRange] describes a set of elements, represented as ranges of `u32` clock values, created by
 /// specific client, included in a corresponding [IdSet].
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub enum IdRange {
-    /// [IdRange] variant that can be represented as a single range of clock values. It's an
-    /// optimization that can be used to avoid allocations, when the corresponding set describes
-    /// a single continuous range.
-    Continuous(Range<u32>),
-    /// A multiple ranges containing clock values, separated from each other by other clock ranges
-    /// not included in this [IdRange].
-    Fragmented(Vec<Range<u32>>),
+///
+/// Internally backed by a [SmallVec] inlining a single [Range], so the common case of one
+/// continuous range incurs no heap allocation. Read-only slice access is exposed via [Deref] —
+/// callers can use `range.iter()`, `range.len()`, `range[i]`, etc. directly.
+#[repr(transparent)]
+#[derive(Clone, PartialEq, Eq, Hash, Default)]
+pub struct IdRange(SmallVec<[Range<u32>; 1]>);
+
+impl std::ops::Deref for IdRange {
+    type Target = [Range<u32>];
+    #[inline]
+    fn deref(&self) -> &[Range<u32>] {
+        &self.0
+    }
+}
+
+impl<'a> IntoIterator for &'a IdRange {
+    type Item = &'a Range<u32>;
+    type IntoIter = std::slice::Iter<'a, Range<u32>>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
 }
 
 impl IdRange {
     pub fn with_capacity(capacity: usize) -> Self {
-        IdRange::Fragmented(Vec::with_capacity(capacity))
-    }
-
-    /// Check if range is empty (doesn't cover any clock space).
-    pub fn is_empty(&self) -> bool {
-        match self {
-            IdRange::Continuous(r) => r.start == r.end,
-            IdRange::Fragmented(rs) => rs.is_empty(),
-        }
+        IdRange(SmallVec::with_capacity(capacity))
     }
 
     /// Inverts current [IdRange], returning another [IdRange] that contains all
     /// "holes" (ranges not included in current range). If current range is a continuous space
     /// starting from the initial clock (eg. [0..5)), then returned range will be empty.
     pub fn invert(&self) -> IdRange {
-        match self {
-            IdRange::Continuous(range) => IdRange::Continuous(0..range.start),
-            IdRange::Fragmented(ranges) => {
-                let mut inv = Vec::new();
-                let mut start = 0;
-                for range in ranges.iter() {
-                    if range.start > start {
-                        inv.push(start..range.start);
-                    }
-                    start = range.end;
-                }
-                match inv.len() {
-                    0 => IdRange::Continuous(0..0),
-                    1 => IdRange::Continuous(inv[0].clone()),
-                    _ => IdRange::Fragmented(inv),
-                }
+        let mut inv = SmallVec::new();
+        let mut start = 0;
+        for range in self.0.iter() {
+            if range.start > start {
+                inv.push(start..range.start);
             }
+            start = range.end;
         }
+        IdRange(inv)
     }
 
     /// Check if given clock exists within current [IdRange].
-    pub fn contains(&self, clock: u32) -> bool {
-        match self {
-            IdRange::Continuous(range) => range.contains(&clock),
-            IdRange::Fragmented(ranges) => ranges.iter().any(|r| r.contains(&clock)),
-        }
-    }
-
-    /// Iterate over ranges described by current [IdRange].
-    pub fn iter(&self) -> IdRangeIter<'_> {
-        let (range, inner) = match self {
-            IdRange::Continuous(range) => (Some(range), None),
-            IdRange::Fragmented(ranges) => (None, Some(ranges.iter())),
-        };
-        IdRangeIter { range, inner }
+    pub fn contains_clock(&self, clock: u32) -> bool {
+        self.0.iter().any(|r| r.contains(&clock))
     }
 
     fn push(&mut self, range: Range<u32>) {
-        match self {
-            IdRange::Continuous(r) => {
+        match self.0.len() {
+            0 => self.0.push(range),
+            1 => {
+                let r = &mut self.0[0];
                 if r.end >= range.start {
                     if r.start > range.end {
-                        *self = IdRange::Fragmented(vec![range, r.clone()])
+                        // `range` lies entirely before `r` — produce [range, r].
+                        let r_clone = r.clone();
+                        *r = range;
+                        self.0.push(r_clone);
                     } else {
-                        // two ranges overlap - merge them
+                        // overlap or adjacency — merge in place.
                         r.end = range.end.max(r.end);
                         r.start = range.start.min(r.start);
                     }
                 } else {
-                    *self = IdRange::Fragmented(vec![r.clone(), range])
+                    // `range` lies entirely after `r` — produce [r, range].
+                    self.0.push(range);
                 }
             }
-            IdRange::Fragmented(ranges) => {
-                if ranges.is_empty() {
-                    *self = IdRange::Continuous(range);
-                } else {
-                    let last_idx = ranges.len() - 1;
-                    let last = &mut ranges[last_idx];
-                    if !Self::try_join(last, &range) {
-                        ranges.push(range);
-                    }
+            _ => {
+                let last = self.0.last_mut().unwrap();
+                if !Self::try_join(last, &range) {
+                    self.0.push(range);
                 }
             }
         }
     }
 
-    /// Alters current [IdRange] by compacting its internal implementation (in fragmented case).
+    /// Alters current [IdRange] by compacting its internal implementation.
     /// Example: fragmented space of [0,3), [3,5), [6,7) will be compacted into [0,5), [6,7).
     fn squash(&mut self) {
-        if let IdRange::Fragmented(ranges) = self {
-            if !ranges.is_empty() {
-                ranges.sort_by(|a, b| a.start.cmp(&b.start));
-                let mut new_len = 1;
+        let ranges = &mut self.0;
+        if ranges.len() < 2 {
+            return;
+        }
+        ranges.sort_by(|a, b| a.start.cmp(&b.start));
+        let mut new_len = 1;
 
-                let len = ranges.len() as isize;
-                let head = ranges.as_mut_ptr();
-                let mut current = unsafe { head.as_mut().unwrap() };
-                let mut i = 1;
-                while i < len {
-                    let next = unsafe { head.offset(i).as_ref().unwrap() };
-                    if !Self::try_join(current, next) {
-                        // current and next are disjoined eg. [0,5) & [6,9)
+        let len = ranges.len() as isize;
+        let head = ranges.as_mut_ptr();
+        let mut current = unsafe { head.as_mut().unwrap() };
+        let mut i = 1;
+        while i < len {
+            let next = unsafe { head.offset(i).as_ref().unwrap() };
+            if !Self::try_join(current, next) {
+                // current and next are disjoined eg. [0,5) & [6,9)
 
-                        // move current pointer one index to the left: by using new_len we
-                        // squash ranges possibly already merged to current
-                        current = unsafe { head.offset(new_len).as_mut().unwrap() };
+                // move current pointer one index to the left: by using new_len we
+                // squash ranges possibly already merged to current
+                current = unsafe { head.offset(new_len).as_mut().unwrap() };
 
-                        // make next a new current
-                        current.start = next.start;
-                        current.end = next.end;
-                        new_len += 1;
-                    }
-
-                    i += 1;
-                }
-
-                if new_len == 1 {
-                    *self = IdRange::Continuous(ranges[0].clone())
-                } else if ranges.len() != new_len as usize {
-                    ranges.truncate(new_len as usize);
-                }
+                // make next a new current
+                current.start = next.start;
+                current.end = next.end;
+                new_len += 1;
             }
+
+            i += 1;
+        }
+
+        if ranges.len() != new_len as usize {
+            ranges.truncate(new_len as usize);
         }
     }
 
     fn is_squashed(&self) -> bool {
-        match self {
-            IdRange::Continuous(_) => true,
-            IdRange::Fragmented(ranges) => {
-                let mut i = ranges.iter();
-                if let Some(r) = i.next() {
-                    let mut prev_end = r.end;
-                    while let Some(r) = i.next() {
-                        if r.start < prev_end {
-                            return false;
-                        }
-                        prev_end = r.end;
-                    }
-                    true
-                } else {
-                    true
+        let mut i = self.0.iter();
+        if let Some(r) = i.next() {
+            let mut prev_end = r.end;
+            while let Some(r) = i.next() {
+                if r.start < prev_end {
+                    return false;
                 }
+                prev_end = r.end;
             }
         }
+        true
     }
 
     /// Merge `other` ID range into current one.
     pub fn merge(&mut self, other: IdRange) {
-        let raw = std::mem::take(self);
-        *self = match (raw, other) {
-            (IdRange::Continuous(mut a), IdRange::Continuous(b)) => {
-                if Self::disjoint(&a, &b) {
-                    IdRange::Fragmented(vec![a, b])
+        match (self.0.len(), other.0.len()) {
+            (0, _) => self.0 = other.0,
+            (_, 0) => {}
+            (1, 1) => {
+                let b = other.0.into_iter().next().unwrap();
+                if Self::disjoint(&self.0[0], &b) {
+                    self.0.push(b);
                 } else {
+                    let a = &mut self.0[0];
                     a.start = a.start.min(b.start);
                     a.end = a.end.max(b.end);
-                    IdRange::Continuous(a)
                 }
             }
-            (IdRange::Fragmented(mut a), IdRange::Continuous(b)) => {
-                a.push(b);
-                IdRange::Fragmented(a)
+            (1, _) => {
+                // (Continuous, Fragmented) — old behaviour appended self to other's vec.
+                let a = self.0[0].clone();
+                self.0 = other.0;
+                self.0.push(a);
             }
-            (IdRange::Continuous(a), IdRange::Fragmented(b)) => {
-                let mut v = b;
-                v.push(a);
-                IdRange::Fragmented(v)
+            _ => {
+                self.0.extend(other.0);
             }
-            (IdRange::Fragmented(mut a), IdRange::Fragmented(mut b)) => {
-                a.append(&mut b);
-                IdRange::Fragmented(a)
-            }
-        };
+        }
     }
 
     /// Check if current [IdRange] is a subset of `other`. This means that all the elements
@@ -265,12 +240,12 @@ impl IdRange {
     /// Subtracts `other` from the current [IdRange], producing a new [IdRange] that contains
     /// all elements from the current range that are not present in `other`.
     pub fn subtract(&mut self, other: Self) {
-        let mut result = Vec::new();
+        let mut result = SmallVec::new();
 
-        for range in self.iter() {
+        for range in self.0.iter() {
             let mut current_ranges: SmallVec<[Range<u32>; 2]> = smallvec![range.clone()];
 
-            for other_range in other.iter() {
+            for other_range in other.0.iter() {
                 let mut new_ranges = SmallVec::new();
                 for r in current_ranges {
                     if Self::disjoint(&r, other_range) {
@@ -295,20 +270,16 @@ impl IdRange {
             result.extend(current_ranges);
         }
 
-        *self = match result.len() {
-            0 => IdRange::Continuous(0..0),
-            1 => IdRange::Continuous(result[0].clone()),
-            _ => IdRange::Fragmented(result),
-        };
+        *self = IdRange(result);
     }
 
     /// Computes the intersection of the current [IdRange] with `other`, modifying the current
     /// range to contain only elements present in both ranges.
     pub fn intersect(&mut self, other: Self) {
-        let mut result = Vec::new();
+        let mut result = SmallVec::new();
 
-        for self_range in self.iter() {
-            for other_range in other.iter() {
+        for self_range in self.0.iter() {
+            for other_range in other.0.iter() {
                 if !Self::disjoint(self_range, other_range) {
                     // Ranges overlap, compute the intersection
                     let start = self_range.start.max(other_range.start);
@@ -318,25 +289,13 @@ impl IdRange {
             }
         }
 
-        *self = match result.len() {
-            0 => IdRange::Continuous(0..0),
-            1 => IdRange::Continuous(result[0].clone()),
-            _ => IdRange::Fragmented(result),
-        };
+        *self = IdRange(result);
     }
 
     fn encode_raw<E: Encoder>(&self, encoder: &mut E) {
-        match self {
-            IdRange::Continuous(range) => {
-                encoder.write_var(1u32);
-                range.encode(encoder)
-            }
-            IdRange::Fragmented(ranges) => {
-                encoder.write_var(ranges.len() as u32);
-                for range in ranges.iter() {
-                    range.encode(encoder);
-                }
-            }
+        encoder.write_var(self.0.len() as u32);
+        for range in self.0.iter() {
+            range.encode(encoder);
         }
     }
 
@@ -357,12 +316,6 @@ impl IdRange {
     }
 }
 
-impl Default for IdRange {
-    fn default() -> Self {
-        IdRange::Continuous(0..0)
-    }
-}
-
 impl Encode for IdRange {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         if self.is_squashed() {
@@ -377,49 +330,12 @@ impl Encode for IdRange {
 
 impl Decode for IdRange {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
-        match decoder.read_var::<u32>()? {
-            1 => {
-                let range = Range::decode(decoder)?;
-                Ok(IdRange::Continuous(range))
-            }
-            len => {
-                let mut ranges = Vec::with_capacity(len as usize);
-                let mut i = 0;
-                while i < len {
-                    ranges.push(Range::decode(decoder)?);
-                    i += 1;
-                }
-                Ok(IdRange::Fragmented(ranges))
-            }
+        let len: u32 = decoder.read_var()?;
+        let mut ranges = SmallVec::with_capacity(len as usize);
+        for _ in 0..len {
+            ranges.push(Range::decode(decoder)?);
         }
-    }
-}
-
-pub struct IdRangeIter<'a> {
-    inner: Option<std::slice::Iter<'a, Range<u32>>>,
-    range: Option<&'a Range<u32>>,
-}
-
-impl<'a> Iterator for IdRangeIter<'a> {
-    type Item = &'a Range<u32>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(inner) = &mut self.inner {
-            inner.next()
-        } else {
-            self.range.take()
-        }
-    }
-}
-
-/// Implement this to efficiently let IdRange iterator work in descending order
-impl<'a> DoubleEndedIterator for IdRangeIter<'a> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if let Some(inner) = &mut self.inner {
-            inner.next_back()
-        } else {
-            self.range.take()
-        }
+        Ok(IdRange(ranges))
     }
 }
 
@@ -455,7 +371,7 @@ impl IdSet {
     /// Check if current [IdSet] contains given `id`.
     pub fn contains(&self, id: &ID) -> bool {
         if let Some(ranges) = self.0.get(&id.client) {
-            ranges.contains(id.clock)
+            ranges.contains_clock(id.clock)
         } else {
             false
         }
@@ -474,15 +390,10 @@ impl IdSet {
     }
 
     pub fn insert(&mut self, id: ID, len: u32) {
-        let range = id.clock..(id.clock + len);
-        match self.0.entry(id.client) {
-            Entry::Occupied(r) => {
-                r.into_mut().push(range);
-            }
-            Entry::Vacant(e) => {
-                e.insert(IdRange::Continuous(range));
-            }
-        }
+        self.0
+            .entry(id.client)
+            .or_default()
+            .push(id.clock..(id.clock + len));
     }
 
     /// Inserts a new ID `range` corresponding with a given `client`.
@@ -596,7 +507,7 @@ impl<'de> Deserialize<'de> for IdSet {
 /// [DeleteSet] contains information about all blocks (described by clock ranges) that have been
 /// subjected to delete process.
 #[repr(transparent)]
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
 pub struct DeleteSet(IdSet);
 
 impl From<IdSet> for DeleteSet {
@@ -624,12 +535,6 @@ impl<'a> From<&'a BlockStore> for DeleteSet {
             }
         }
         set
-    }
-}
-
-impl Default for DeleteSet {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -666,16 +571,15 @@ impl std::fmt::Debug for IdRange {
 }
 impl std::fmt::Display for IdRange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            IdRange::Continuous(r) => write!(f, "[{}..{})", r.start, r.end),
-            IdRange::Fragmented(r) => {
-                write!(f, "[")?;
-                for r in r.iter() {
-                    write!(f, " [{}..{})", r.start, r.end)?;
-                }
-                write!(f, " ]")
-            }
+        let mut i = self.iter();
+        write!(f, "[")?;
+        if let Some(r) = i.next() {
+            write!(f, "[{}..{})", r.start, r.end)?;
         }
+        while let Some(r) = i.next() {
+            write!(f, ", [{}..{})", r.start, r.end)?;
+        }
+        write!(f, "]")
     }
 }
 
@@ -776,7 +680,7 @@ pub(crate) struct DeletedBlocks<'ds> {
     ds_iter: Iter<'ds>,
     current_range: Option<&'ds Range<u32>>,
     current_client_id: Option<ClientID>,
-    range_iter: Option<IdRangeIter<'ds>>,
+    range_iter: Option<std::slice::Iter<'ds, Range<u32>>>,
     current_index: Option<usize>,
 }
 
@@ -895,207 +799,198 @@ mod test {
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{DeleteSet, Doc, Options, ReadTxn, Text, Transact, ID};
+    use smallvec::smallvec;
     use std::collections::HashSet;
     use std::fmt::Debug;
 
     #[test]
     fn id_range_merge_continous() {
         // `b` entirely within `a`
-        let mut a = IdRange::Continuous(0..5);
-        a.merge(IdRange::Continuous(2..4));
-        assert_eq!(a, IdRange::Continuous(0..5));
+        let mut a = IdRange(smallvec![0..5]);
+        a.merge(IdRange(smallvec![2..4]));
+        assert_eq!(a, IdRange(smallvec![0..5]));
 
         // the tail of `a` crosses the head of `b`
-        let mut a = IdRange::Continuous(0..5);
-        a.merge(IdRange::Continuous(4..9));
-        assert_eq!(a, IdRange::Continuous(0..9));
+        let mut a = IdRange(smallvec![0..5]);
+        a.merge(IdRange(smallvec![4..9]));
+        assert_eq!(a, IdRange(smallvec![0..9]));
 
         // `b` is immediately adjacent to the end of `a`
-        let mut a = IdRange::Continuous(0..5);
-        a.merge(IdRange::Continuous(5..9));
-        assert_eq!(a, IdRange::Continuous(0..9));
+        let mut a = IdRange(smallvec![0..5]);
+        a.merge(IdRange(smallvec![5..9]));
+        assert_eq!(a, IdRange(smallvec![0..9]));
 
         // `a` does not intersect with `b`
-        let mut a = IdRange::Continuous(0..4);
-        a.merge(IdRange::Continuous(6..9));
-        assert_eq!(a, IdRange::Fragmented(vec![0..4, 6..9]));
+        let mut a = IdRange(smallvec![0..4]);
+        a.merge(IdRange(smallvec![6..9]));
+        assert_eq!(a, IdRange(smallvec![0..4, 6..9]));
     }
 
     #[test]
     fn id_range_compact() {
-        let mut r = IdRange::Fragmented(vec![(0..3), (3..5), (6..7)]);
+        let mut r = IdRange(smallvec![(0..3), (3..5), (6..7)]);
         r.squash();
-        assert_eq!(r, IdRange::Fragmented(vec![(0..5), (6..7)]));
+        assert_eq!(r, IdRange(smallvec![(0..5), (6..7)]));
     }
 
     #[test]
     fn id_range_invert() {
-        assert!(IdRange::Continuous(0..3).invert().is_empty());
+        assert!(IdRange(smallvec![0..3]).invert().is_empty());
+
+        assert_eq!(IdRange(smallvec![3..5]).invert(), IdRange(smallvec![0..3]));
 
         assert_eq!(
-            IdRange::Continuous(3..5).invert(),
-            IdRange::Continuous(0..3)
+            IdRange(smallvec![0..3, 4..5]).invert(),
+            IdRange(smallvec![3..4])
         );
 
         assert_eq!(
-            IdRange::Fragmented(vec![0..3, 4..5]).invert(),
-            IdRange::Continuous(3..4)
-        );
-
-        assert_eq!(
-            IdRange::Fragmented(vec![3..4, 7..9]).invert(),
-            IdRange::Fragmented(vec![0..3, 4..7])
+            IdRange(smallvec![3..4, 7..9]).invert(),
+            IdRange(smallvec![0..3, 4..7])
         );
     }
 
     #[test]
     fn id_range_contains() {
-        assert!(!IdRange::Continuous(1..3).contains(0));
-        assert!(IdRange::Continuous(1..3).contains(1));
-        assert!(IdRange::Continuous(1..3).contains(2));
-        assert!(!IdRange::Continuous(1..3).contains(3));
+        assert!(!IdRange(smallvec![1..3]).contains_clock(0));
+        assert!(IdRange(smallvec![1..3]).contains_clock(1));
+        assert!(IdRange(smallvec![1..3]).contains_clock(2));
+        assert!(!IdRange(smallvec![1..3]).contains_clock(3));
 
-        assert!(!IdRange::Fragmented(vec![1..3, 4..5]).contains(0));
-        assert!(IdRange::Fragmented(vec![1..3, 4..5]).contains(1));
-        assert!(IdRange::Fragmented(vec![1..3, 4..5]).contains(2));
-        assert!(!IdRange::Fragmented(vec![1..3, 4..5]).contains(3));
-        assert!(IdRange::Fragmented(vec![1..3, 4..5]).contains(4));
-        assert!(!IdRange::Fragmented(vec![1..3, 4..5]).contains(5));
-        assert!(!IdRange::Fragmented(vec![1..3, 4..5]).contains(6));
+        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(0));
+        assert!(IdRange(smallvec![1..3, 4..5]).contains_clock(1));
+        assert!(IdRange(smallvec![1..3, 4..5]).contains_clock(2));
+        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(3));
+        assert!(IdRange(smallvec![1..3, 4..5]).contains_clock(4));
+        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(5));
+        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(6));
     }
 
     #[test]
     fn id_range_push() {
-        let mut range = IdRange::Continuous(0..0);
+        let mut range = IdRange(smallvec![]);
 
         range.push(0..4);
-        assert_eq!(range, IdRange::Continuous(0..4));
+        assert_eq!(range, IdRange(smallvec![0..4]));
 
         range.push(4..6);
-        assert_eq!(range, IdRange::Continuous(0..6));
+        assert_eq!(range, IdRange(smallvec![0..6]));
 
         range.push(7..9);
-        assert_eq!(range, IdRange::Fragmented(vec![0..6, 7..9]));
+        assert_eq!(range, IdRange(smallvec![0..6, 7..9]));
     }
 
     #[test]
     fn id_range_subset_of() {
-        assert!(IdRange::Continuous(1..2).subset_of(&IdRange::Continuous(1..2)));
-        assert!(IdRange::Continuous(1..2).subset_of(&IdRange::Continuous(0..2)));
-        assert!(IdRange::Continuous(1..2).subset_of(&IdRange::Continuous(1..3)));
+        assert!(IdRange(smallvec![1..2]).subset_of(&IdRange(smallvec![1..2])));
+        assert!(IdRange(smallvec![1..2]).subset_of(&IdRange(smallvec![0..2])));
+        assert!(IdRange(smallvec![1..2]).subset_of(&IdRange(smallvec![1..3])));
 
-        assert!(IdRange::Fragmented(vec![1..2, 3..4]).subset_of(&IdRange::Continuous(1..4)));
-        assert!(IdRange::Fragmented(vec![1..2, 3..4, 5..6])
-            .subset_of(&IdRange::Fragmented(vec![1..2, 3..6])));
-        assert!(
-            IdRange::Fragmented(vec![3..4, 5..6]).subset_of(&IdRange::Fragmented(vec![0..1, 3..6]))
-        );
-        assert!(
-            IdRange::Fragmented(vec![3..4, 5..6]).subset_of(&IdRange::Fragmented(vec![3..4, 5..6]))
-        );
+        assert!(IdRange(smallvec![1..2, 3..4]).subset_of(&IdRange(smallvec![1..4])));
+        assert!(IdRange(smallvec![1..2, 3..4, 5..6]).subset_of(&IdRange(smallvec![1..2, 3..6])));
+        assert!(IdRange(smallvec![3..4, 5..6]).subset_of(&IdRange(smallvec![0..1, 3..6])));
+        assert!(IdRange(smallvec![3..4, 5..6]).subset_of(&IdRange(smallvec![3..4, 5..6])));
 
-        assert!(!IdRange::Continuous(1..3).subset_of(&IdRange::Continuous(0..2)));
-        assert!(!IdRange::Continuous(1..3).subset_of(&IdRange::Continuous(1..2)));
-        assert!(!IdRange::Continuous(1..3).subset_of(&IdRange::Continuous(2..3)));
-        assert!(!IdRange::Continuous(1..3).subset_of(&IdRange::Continuous(2..4)));
+        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![0..2])));
+        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![1..2])));
+        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![2..3])));
+        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![2..4])));
 
-        assert!(!IdRange::Fragmented(vec![1..2, 3..4]).subset_of(&IdRange::Continuous(1..3)));
-        assert!(!IdRange::Fragmented(vec![1..2, 3..6])
-            .subset_of(&IdRange::Fragmented(vec![1..2, 3..5])));
-        assert!(!IdRange::Fragmented(vec![1..2, 3..6])
-            .subset_of(&IdRange::Fragmented(vec![1..2, 4..7])));
+        assert!(!IdRange(smallvec![1..2, 3..4]).subset_of(&IdRange(smallvec![1..3])));
+        assert!(!IdRange(smallvec![1..2, 3..6]).subset_of(&IdRange(smallvec![1..2, 3..5])));
+        assert!(!IdRange(smallvec![1..2, 3..6]).subset_of(&IdRange(smallvec![1..2, 4..7])));
     }
 
     #[test]
     fn id_range_subtract() {
         // subtract from the left side
-        let mut a = IdRange::Continuous(0..4);
-        a.subtract(IdRange::Continuous(0..2));
-        assert_eq!(a, IdRange::Continuous(2..4));
+        let mut a = IdRange(smallvec![0..4]);
+        a.subtract(IdRange(smallvec![0..2]));
+        assert_eq!(a, IdRange(smallvec![2..4]));
 
         // subtract from the right side
-        let mut a = IdRange::Continuous(0..4);
-        a.subtract(IdRange::Continuous(2..4));
-        assert_eq!(a, IdRange::Continuous(0..2));
+        let mut a = IdRange(smallvec![0..4]);
+        a.subtract(IdRange(smallvec![2..4]));
+        assert_eq!(a, IdRange(smallvec![0..2]));
 
         // subtract in the middle - splitting the continuous block in two
-        let mut a = IdRange::Continuous(0..4);
-        a.subtract(IdRange::Continuous(1..3));
-        assert_eq!(a, IdRange::Fragmented(vec![0..1, 3..4]));
+        let mut a = IdRange(smallvec![0..4]);
+        a.subtract(IdRange(smallvec![1..3]));
+        assert_eq!(a, IdRange(smallvec![0..1, 3..4]));
 
         // subtract with fragmented block - splitting single range into >2 ranges
-        let mut a = IdRange::Continuous(0..10);
-        a.subtract(IdRange::Fragmented(vec![1..3, 4..5]));
-        assert_eq!(a, IdRange::Fragmented(vec![0..1, 3..4, 5..10]));
+        let mut a = IdRange(smallvec![0..10]);
+        a.subtract(IdRange(smallvec![1..3, 4..5]));
+        assert_eq!(a, IdRange(smallvec![0..1, 3..4, 5..10]));
 
         // subtract continuous range overlapping with more than one range
-        let mut a = IdRange::Fragmented(vec![0..4, 5..6, 7..10]);
-        a.subtract(IdRange::Continuous(3..8));
-        assert_eq!(a, IdRange::Fragmented(vec![0..3, 8..10]));
+        let mut a = IdRange(smallvec![0..4, 5..6, 7..10]);
+        a.subtract(IdRange(smallvec![3..8]));
+        assert_eq!(a, IdRange(smallvec![0..3, 8..10]));
 
         // subtract two fragmented ranges with partially overlapping boundaries
-        let mut a = IdRange::Fragmented(vec![0..4, 7..10]);
-        a.subtract(IdRange::Fragmented(vec![3..5, 6..9]));
-        assert_eq!(a, IdRange::Fragmented(vec![0..3, 9..10]));
+        let mut a = IdRange(smallvec![0..4, 7..10]);
+        a.subtract(IdRange(smallvec![3..5, 6..9]));
+        assert_eq!(a, IdRange(smallvec![0..3, 9..10]));
 
         // subtract fragmented ranges, when one gets split into 2+, and another overlaps at the end
-        let mut a = IdRange::Fragmented(vec![0..4, 7..10]);
-        a.subtract(IdRange::Fragmented(vec![2..3, 5..6, 9..10]));
-        assert_eq!(a, IdRange::Fragmented(vec![0..2, 3..4, 7..9]));
+        let mut a = IdRange(smallvec![0..4, 7..10]);
+        a.subtract(IdRange(smallvec![2..3, 5..6, 9..10]));
+        assert_eq!(a, IdRange(smallvec![0..2, 3..4, 7..9]));
     }
 
     #[test]
     fn id_range_intersect() {
         // Basic continuous range intersection
-        let mut a = IdRange::Continuous(0..10);
-        a.intersect(IdRange::Continuous(5..15));
-        assert_eq!(a, IdRange::Continuous(5..10));
+        let mut a = IdRange(smallvec![0..10]);
+        a.intersect(IdRange(smallvec![5..15]));
+        assert_eq!(a, IdRange(smallvec![5..10]));
 
         // Fragmented intersecting with continuous
-        let mut a = IdRange::Fragmented(vec![0..5, 10..15]);
-        a.intersect(IdRange::Continuous(3..12));
-        assert_eq!(a, IdRange::Fragmented(vec![3..5, 10..12]));
+        let mut a = IdRange(smallvec![0..5, 10..15]);
+        a.intersect(IdRange(smallvec![3..12]));
+        assert_eq!(a, IdRange(smallvec![3..5, 10..12]));
 
         // No overlap - empty result
-        let mut a = IdRange::Continuous(0..5);
-        a.intersect(IdRange::Continuous(10..15));
-        assert_eq!(a, IdRange::Continuous(0..0));
+        let mut a = IdRange(smallvec![0..5]);
+        a.intersect(IdRange(smallvec![10..15]));
+        assert_eq!(a, IdRange::default());
 
         // Multiple ranges with multiple intersections
-        let mut a = IdRange::Fragmented(vec![1..4, 6..9]);
-        a.intersect(IdRange::Continuous(2..7));
-        assert_eq!(a, IdRange::Fragmented(vec![2..4, 6..7]));
+        let mut a = IdRange(smallvec![1..4, 6..9]);
+        a.intersect(IdRange(smallvec![2..7]));
+        assert_eq!(a, IdRange(smallvec![2..4, 6..7]));
 
         // Complete overlap
-        let mut a = IdRange::Continuous(2..8);
-        a.intersect(IdRange::Continuous(0..10));
-        assert_eq!(a, IdRange::Continuous(2..8));
+        let mut a = IdRange(smallvec![2..8]);
+        a.intersect(IdRange(smallvec![0..10]));
+        assert_eq!(a, IdRange(smallvec![2..8]));
 
         // Partial overlap on both sides
-        let mut a = IdRange::Continuous(5..15);
-        a.intersect(IdRange::Continuous(0..10));
-        assert_eq!(a, IdRange::Continuous(5..10));
+        let mut a = IdRange(smallvec![5..15]);
+        a.intersect(IdRange(smallvec![0..10]));
+        assert_eq!(a, IdRange(smallvec![5..10]));
 
         // Fragmented with fragmented
-        let mut a = IdRange::Fragmented(vec![0..5, 10..15, 20..25]);
-        a.intersect(IdRange::Fragmented(vec![3..12, 22..30]));
-        assert_eq!(a, IdRange::Fragmented(vec![3..5, 10..12, 22..25]));
+        let mut a = IdRange(smallvec![0..5, 10..15, 20..25]);
+        a.intersect(IdRange(smallvec![3..12, 22..30]));
+        assert_eq!(a, IdRange(smallvec![3..5, 10..12, 22..25]));
 
         // Exact match
-        let mut a = IdRange::Continuous(5..10);
-        a.intersect(IdRange::Continuous(5..10));
-        assert_eq!(a, IdRange::Continuous(5..10));
+        let mut a = IdRange(smallvec![5..10]);
+        a.intersect(IdRange(smallvec![5..10]));
+        assert_eq!(a, IdRange(smallvec![5..10]));
 
         // Single element overlap
-        let mut a = IdRange::Continuous(0..5);
-        a.intersect(IdRange::Continuous(4..10));
-        assert_eq!(a, IdRange::Continuous(4..5));
+        let mut a = IdRange(smallvec![0..5]);
+        a.intersect(IdRange(smallvec![4..10]));
+        assert_eq!(a, IdRange(smallvec![4..5]));
     }
 
     #[test]
     fn id_range_encode_decode() {
-        roundtrip(&IdRange::Continuous(0..4));
-        roundtrip(&IdRange::Fragmented(vec![1..4, 5..8]));
+        roundtrip(&IdRange(smallvec![0..4]));
+        roundtrip(&IdRange(smallvec![1..4, 5..8]));
     }
 
     #[test]

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -12,7 +12,7 @@ use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::ops::Range;
@@ -393,19 +393,24 @@ impl Decode for IdRange {
     }
 }
 
-/// DeleteSet is a temporary object that is created when needed.
-/// - When created in a transaction, it must only be accessed after sorting and merging.
-///   - This DeleteSet is sent to other clients.
-/// - We do not create a DeleteSet when we send a sync message. The DeleteSet message is created
-///   directly from StructStore.
-/// - We read a DeleteSet as a apart of sync/update message. In this case the DeleteSet is already
-///   sorted and merged.
+/// IdSet is a set describing ranges of blocks stored within the document.
+///
+/// Each block can be expressed as a `client_id, [start_clock..end_clock)` pair, where `client_id`
+/// is a unique identifier of client which created given block, while `[start_clock..endclock)`
+/// describe a clocks of the elements inserted into Yjs document. With that in mind, the [IdSet]
+/// expresses a group of blocks in a very compact manner.
+///
+/// The most common use cases for [IdSet]s are:
+/// - [IdSet] which is generated as part of the updates send between documents. It describes all
+///   blocks deleted as part of an update.
+/// - [crate::UndoManager] uses notion of stack items as a units of work, which can be undone/redone
+///   together. Such stack item is a pair of (inserts, deletes), both of which are [IdSet]s.
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct IdSet(HashMap<ClientID, IdRange, BuildHasherDefault<ClientHasher>>);
 
-pub(crate) type Iter<'a> = std::collections::hash_map::Iter<'a, ClientID, IdRange>;
+pub type Iter<'a> = std::collections::hash_map::Iter<'a, ClientID, IdRange>;
 
-//TODO: I'd say we should split IdSet and DeleteSet into two structures. While DeleteSet can be
+//TODO: I'd say we should split IdSet and IdSet into two structures. While IdSet can be
 // implemented in terms of IdSet, it has more specific methods (related to deletion process), while
 // IdSet could contain wider area of use cases.
 impl IdSet {
@@ -431,7 +436,7 @@ impl IdSet {
         self.0.len()
     }
 
-    pub(crate) fn iter(&self) -> Iter<'_> {
+    pub fn iter(&self) -> Iter<'_> {
         self.0.iter()
     }
 
@@ -599,51 +604,6 @@ impl<'de> Deserialize<'de> for IdSet {
     }
 }
 
-/// [DeleteSet] contains information about all blocks (described by clock ranges) that have been
-/// subjected to delete process.
-#[repr(transparent)]
-#[derive(Clone, Eq, PartialEq, Hash, Default, Serialize, Deserialize)]
-pub struct DeleteSet(IdSet);
-
-impl From<IdSet> for DeleteSet {
-    fn from(id_set: IdSet) -> Self {
-        DeleteSet(id_set)
-    }
-}
-
-impl<'a> From<&'a BlockStore> for DeleteSet {
-    /// Creates a [DeleteSet] by reading all deleted blocks and including their clock ranges into
-    /// the delete set itself.
-    fn from(store: &'a BlockStore) -> Self {
-        let mut set = DeleteSet(IdSet::new());
-        for (&client, blocks) in store.iter() {
-            let mut deletes = IdRange::with_capacity(blocks.len());
-            for block in blocks.iter() {
-                if block.is_deleted() {
-                    let (start, end) = block.clock_range();
-                    deletes.insert(start..(end + 1));
-                }
-            }
-
-            if !deletes.is_empty() {
-                set.0.insert_range(client, deletes);
-            }
-        }
-        set
-    }
-}
-
-impl std::fmt::Debug for DeleteSet {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
-    }
-}
-impl std::fmt::Display for DeleteSet {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
-    }
-}
-
 impl std::fmt::Debug for IdSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)
@@ -678,67 +638,37 @@ impl std::fmt::Display for IdRange {
     }
 }
 
-impl DeleteSet {
-    /// Creates a new empty delete set instance.
-    pub fn new() -> Self {
-        DeleteSet(IdSet::new())
+/// An extension over [IdSet] that defines methods specific to work with block store deletions.
+pub(crate) trait DeleteSet {
+    /// Creates a [IdSet] by reading all deleted blocks and including their clock ranges into
+    /// the delete set itself.
+    fn from_store(store: &BlockStore) -> Self;
+
+    fn try_squash_with(&mut self, store: &mut Store);
+
+    fn blocks(&self) -> Blocks;
+}
+
+impl DeleteSet for IdSet {
+    fn from_store(store: &BlockStore) -> Self {
+        let mut set = IdSet::new();
+        for (&client, blocks) in store.iter() {
+            let mut deletes = IdRange::with_capacity(blocks.len());
+            for block in blocks.iter() {
+                if block.is_deleted() {
+                    let (start, end) = block.clock_range();
+                    deletes.insert(start..(end + 1));
+                }
+            }
+
+            if !deletes.is_empty() {
+                set.0.insert(client, deletes);
+            }
+        }
+        set
     }
 
-    /// Inserts an information about delete block (identified by `id` and having a specified length)
-    /// inside of a current delete set.
-    pub fn insert(&mut self, id: ID, len: u32) {
-        self.0.insert(id, len)
-    }
-
-    /// Removes a single delete entry described by `range` from the set. If the client's
-    /// [IdRange] becomes empty, the client entry is dropped from the set.
-    pub fn remove(&mut self, range: &BlockRange) {
-        self.0.remove_range(range)
-    }
-
-    /// Returns number of clients stored;
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Checks if delete set contains any clock ranges.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Checks if given block `id` is considered deleted from the perspective of current delete set.
-    pub fn is_deleted(&self, id: &ID) -> bool {
-        self.0.contains(id)
-    }
-
-    /// Returns an iterator over all client-range pairs registered in this delete set.
-    pub fn iter(&self) -> Iter<'_> {
-        self.0.iter()
-    }
-
-    /// Merges another delete set into a current one, combining their information about deleted
-    /// clock ranges.
-    pub fn merge_with(&mut self, other: Self) {
-        self.0.merge_with(other.0)
-    }
-
-    /// Removes from `self` every clock range covered by `other`. Clients whose ranges become
-    /// empty are dropped.
-    pub fn diff_with(&mut self, other: &Self) {
-        self.0.diff_with(&other.0)
-    }
-
-    /// Restricts `self` to the per-client intersection with `other`. Clients absent from
-    /// `other` (or whose intersection is empty) are dropped.
-    pub fn intersect_with(&mut self, other: &Self) {
-        self.0.intersect_with(&other.0)
-    }
-
-    pub fn range(&self, client_id: &ClientID) -> Option<&IdRange> {
-        self.0.get(client_id)
-    }
-
-    pub(crate) fn try_squash_with(&mut self, store: &mut Store) {
+    fn try_squash_with(&mut self, store: &mut Store) {
         // try to merge deleted / gc'd items
         for (&client, range) in self.iter() {
             let blocks = store.blocks.get_client_blocks_mut(client);
@@ -764,25 +694,12 @@ impl DeleteSet {
         }
     }
 
-    pub(crate) fn deleted_blocks(&self) -> DeletedBlocks {
-        DeletedBlocks::new(self)
+    fn blocks(&self) -> Blocks {
+        Blocks::new(self)
     }
 }
 
-impl Decode for DeleteSet {
-    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
-        Ok(DeleteSet(IdSet::decode(decoder)?))
-    }
-}
-
-impl Encode for DeleteSet {
-    #[inline]
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
-        self.0.encode(encoder)
-    }
-}
-
-pub(crate) struct DeletedBlocks<'ds> {
+pub(crate) struct Blocks<'ds> {
     ds_iter: Iter<'ds>,
     current_range: Option<&'ds Range<u32>>,
     current_client_id: Option<ClientID>,
@@ -790,10 +707,10 @@ pub(crate) struct DeletedBlocks<'ds> {
     current_index: Option<usize>,
 }
 
-impl<'ds> DeletedBlocks<'ds> {
-    pub(crate) fn new(ds: &'ds DeleteSet) -> Self {
+impl<'ds> Blocks<'ds> {
+    pub(crate) fn new(ds: &'ds IdSet) -> Self {
         let ds_iter = ds.iter();
-        DeletedBlocks {
+        Blocks {
             ds_iter,
             current_client_id: None,
             current_range: None,
@@ -803,7 +720,7 @@ impl<'ds> DeletedBlocks<'ds> {
     }
 }
 
-impl<'ds> TxnIterator for DeletedBlocks<'ds> {
+impl<'ds> TxnIterator for Blocks<'ds> {
     type Item = BlockSlice;
 
     fn next<T: ReadTxn>(&mut self, txn: &T) -> Option<Self::Item> {
@@ -897,18 +814,17 @@ impl<'ds> TxnIterator for DeletedBlocks<'ds> {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockRange, ClientID, ItemContent};
-    use crate::id_set::{IdRange, IdSet};
+    use crate::block::{BlockRange, ItemContent};
+    use crate::id_set::{DeleteSet, IdRange, IdSet};
     use crate::iter::TxnIterator;
     use crate::slice::BlockSlice;
     use crate::test_utils::exchange_updates;
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
-    use crate::{DeleteSet, Doc, Options, ReadTxn, Text, Transact, ID};
-    use smallvec::{smallvec, SmallVec};
+    use crate::{Doc, Options, ReadTxn, Text, Transact, ID};
+    use smallvec::smallvec;
     use std::collections::HashSet;
     use std::fmt::Debug;
-    use std::ops::Range;
 
     #[test]
     fn id_range_merge_continous() {
@@ -1404,7 +1320,7 @@ mod test {
             let mut blocks = HashSet::new();
 
             let mut i = 0;
-            let mut deleted = s.delete_set.deleted_blocks();
+            let mut deleted = s.delete_set.blocks();
             while let Some(BlockSlice::Item(b)) = deleted.next(&txn) {
                 let item = txn.store.materialize(b);
                 if let ItemContent::String(str) = &item.content {
@@ -1436,13 +1352,13 @@ mod test {
 
     #[test]
     fn deleted_blocks2() {
-        let mut ds = DeleteSet::new();
+        let mut ds = IdSet::new();
         let doc = Doc::with_client_id(1);
         let txt = doc.get_or_insert_text("test");
         txt.push(&mut doc.transact_mut(), "testab");
         ds.insert(ID::new(1, 5), 1);
         let txn = doc.transact_mut();
-        let mut i = ds.deleted_blocks();
+        let mut i = ds.blocks();
         let ptr = i.next(&txn).unwrap();
         let start = ptr.clock_start();
         let end = ptr.clock_end();

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -12,7 +12,7 @@ use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::ops::Range;
@@ -464,7 +464,7 @@ impl IdSet {
     /// Merges another ID set into a current one, combining their information about observed ID
     /// ranges. Per-client [IdRange] merge maintains the canonical invariant on its own, so no
     /// trailing squash is needed.
-    pub fn merge(&mut self, other: Self) {
+    pub fn merge_with(&mut self, other: Self) {
         other.0.into_iter().for_each(|(client, range)| {
             if let Some(r) = self.0.get_mut(&client) {
                 r.merge(range)
@@ -476,7 +476,7 @@ impl IdSet {
 
     /// Removes from `self` every clock range covered by `other`. Per-client [IdRange]s are
     /// excluded individually; clients absent from `other` are left untouched.
-    pub fn exclude(&mut self, other: &Self) {
+    pub fn diff_with(&mut self, other: &Self) {
         self.0.retain(|client, ranges| {
             if let Some(other_ranges) = other.0.get(client) {
                 ranges.exclude(other_ranges);
@@ -487,7 +487,7 @@ impl IdSet {
 
     /// Replaces `self` with the per-client intersection against `other`. Clients present only
     /// in `self` (or only in `other`) are dropped.
-    pub fn intersect(&mut self, other: &Self) {
+    pub fn intersect_with(&mut self, other: &Self) {
         self.0.retain(|client, ranges| match other.0.get(client) {
             Some(other_ranges) => {
                 ranges.intersect(other_ranges);
@@ -499,7 +499,7 @@ impl IdSet {
 
     /// Remove a given range of elements from the current [IdSet]. If the client's [IdRange]
     /// becomes empty as a result, the client entry is dropped from the set entirely.
-    pub fn remove(&mut self, range: &BlockRange) {
+    pub fn remove_range(&mut self, range: &BlockRange) {
         if let Entry::Occupied(mut e) = self.0.entry(range.id.client) {
             let id_range = e.get_mut();
             id_range.remove(range.id.clock..(range.id.clock + range.len));
@@ -693,7 +693,7 @@ impl DeleteSet {
     /// Removes a single delete entry described by `range` from the set. If the client's
     /// [IdRange] becomes empty, the client entry is dropped from the set.
     pub fn remove(&mut self, range: &BlockRange) {
-        self.0.remove(range)
+        self.0.remove_range(range)
     }
 
     /// Returns number of clients stored;
@@ -718,20 +718,20 @@ impl DeleteSet {
 
     /// Merges another delete set into a current one, combining their information about deleted
     /// clock ranges.
-    pub fn merge(&mut self, other: Self) {
-        self.0.merge(other.0)
+    pub fn merge_with(&mut self, other: Self) {
+        self.0.merge_with(other.0)
     }
 
     /// Removes from `self` every clock range covered by `other`. Clients whose ranges become
     /// empty are dropped.
-    pub fn exclude(&mut self, other: &Self) {
-        self.0.exclude(&other.0)
+    pub fn diff_with(&mut self, other: &Self) {
+        self.0.diff_with(&other.0)
     }
 
     /// Restricts `self` to the per-client intersection with `other`. Clients absent from
     /// `other` (or whose intersection is empty) are dropped.
-    pub fn intersect(&mut self, other: &Self) {
-        self.0.intersect(&other.0)
+    pub fn intersect_with(&mut self, other: &Self) {
+        self.0.intersect_with(&other.0)
     }
 
     pub fn range(&self, client_id: &ClientID) -> Option<&IdRange> {
@@ -1136,22 +1136,22 @@ mod test {
     fn id_set_remove() {
         // Removing from a client absent from the set is a no-op.
         let mut set = IdSet::from_iter([(1, [0..10])]);
-        set.remove(&BlockRange::new(ID::new(2, 0), 5));
+        set.remove_range(&BlockRange::new(ID::new(2, 0), 5));
         assert_eq!(set, IdSet::from_iter([(1, [0..10])]));
 
         // Partial removal — split.
         let mut set = IdSet::from_iter([(1, [0..10])]);
-        set.remove(&BlockRange::new(ID::new(1, 3), 4));
+        set.remove_range(&BlockRange::new(ID::new(1, 3), 4));
         assert_eq!(set, IdSet::from_iter([(1, [0..3, 7..10])]));
 
         // Removing the entire IdRange drops the client.
         let mut set = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
-        set.remove(&BlockRange::new(ID::new(1, 0), 10));
+        set.remove_range(&BlockRange::new(ID::new(1, 0), 10));
         assert_eq!(set, IdSet::from_iter([(2, [0..5])]));
 
         // Empty len is a no-op.
         let mut set = IdSet::from_iter([(1, [0..10])]);
-        set.remove(&BlockRange::new(ID::new(1, 5), 0));
+        set.remove_range(&BlockRange::new(ID::new(1, 5), 0));
         assert_eq!(set, IdSet::from_iter([(1, [0..10])]));
     }
 
@@ -1300,24 +1300,24 @@ mod test {
         // Clients only in `self` are untouched; clients only in `other` are ignored.
         let mut a = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
         let b = IdSet::from_iter([(2, [0..3]), (3, [0..100])]);
-        a.exclude(&b);
+        a.diff_with(&b);
         assert_eq!(a, IdSet::from_iter([(1, [0..10]), (2, [3..5])]));
 
         // Per-client exclude carves the right shape (split into two).
         let mut a = IdSet::from_iter([(1, [0..10])]);
         let b = IdSet::from_iter([(1, [3..7])]);
-        a.exclude(&b);
+        a.diff_with(&b);
         assert_eq!(a, IdSet::from_iter([(1, [0..3, 7..10])]));
 
         // Clients whose ranges become empty are dropped entirely.
         let mut a = IdSet::from_iter([(1, [0..5]), (2, [0..5])]);
         let b = IdSet::from_iter([(1, [0..5])]);
-        a.exclude(&b);
+        a.diff_with(&b);
         assert_eq!(a, IdSet::from_iter([(2, [0..5])]));
 
         // Excluding an empty other is a no-op.
         let mut a = IdSet::from_iter([(1, [0..10])]);
-        a.exclude(&IdSet::new());
+        a.diff_with(&IdSet::new());
         assert_eq!(a, IdSet::from_iter([(1, [0..10])]));
     }
 
@@ -1326,24 +1326,24 @@ mod test {
         // Clients present only in `self` are dropped.
         let mut a = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
         let b = IdSet::from_iter([(1, [5..15])]);
-        a.intersect(&b);
+        a.intersect_with(&b);
         assert_eq!(a, IdSet::from_iter([(1, [5..10])]));
 
         // Clients present only in `other` are ignored.
         let mut a = IdSet::from_iter([(1, [0..10])]);
         let b = IdSet::from_iter([(1, [3..7]), (2, [0..100])]);
-        a.intersect(&b);
+        a.intersect_with(&b);
         assert_eq!(a, IdSet::from_iter([(1, [3..7])]));
 
         // Clients whose intersection is empty (disjoint ranges) are dropped.
         let mut a = IdSet::from_iter([(1, [0..5]), (2, [0..5])]);
         let b = IdSet::from_iter([(1, [10..20]), (2, [1..4])]);
-        a.intersect(&b);
+        a.intersect_with(&b);
         assert_eq!(a, IdSet::from_iter([(2, [1..4])]));
 
         // Intersecting with an empty other yields empty.
         let mut a = IdSet::from_iter([(1, [0..10])]);
-        a.intersect(&IdSet::new());
+        a.intersect_with(&IdSet::new());
         assert!(a.is_empty());
     }
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -1,4 +1,4 @@
-use crate::block::{ClientID, ID};
+use crate::block::{BlockRange, ClientID, ID};
 use crate::block_store::BlockStore;
 use crate::encoding::read::Error;
 use crate::iter::TxnIterator;
@@ -10,7 +10,8 @@ use crate::utils::client_hasher::ClientHasher;
 use crate::ReadTxn;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use smallvec::{smallvec, SmallVec};
+use smallvec::SmallVec;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
@@ -87,7 +88,7 @@ impl IdRange {
         self.0.iter().any(|r| r.contains(&clock))
     }
 
-    fn push(&mut self, range: Range<u32>) {
+    pub fn insert(&mut self, range: Range<u32>) {
         if range.start >= range.end {
             return;
         }
@@ -134,6 +135,49 @@ impl IdRange {
         }
     }
 
+    /// Removes a single clock `range` from the current [IdRange].
+    pub fn remove(&mut self, range: Range<u32>) {
+        if range.start >= range.end || self.0.is_empty() {
+            return;
+        }
+
+        // First index whose entry overlaps or follows `range` (i.e. r.end > range.start).
+        let mut i = self.0.partition_point(|r| r.end <= range.start);
+        if i >= self.0.len() {
+            return; // `range` lies past every entry — no-op.
+        }
+
+        // Special case: a single existing entry strictly contains `range` — split it.
+        if self.0[i].start < range.start && self.0[i].end > range.end {
+            let right = range.end..self.0[i].end;
+            self.0[i].end = range.start;
+            self.0.insert(i + 1, right);
+            return;
+        }
+
+        // Trim the leftmost entry if it straddles `range.start` — keep [r.start..range.start).
+        if self.0[i].start < range.start {
+            self.0[i].end = range.start;
+            i += 1;
+        }
+
+        // Find the slice of entries fully covered by `range`.
+        let mut j = i;
+        while j < self.0.len() && self.0[j].end <= range.end {
+            j += 1;
+        }
+
+        // Trim the trailing entry if it straddles `range.end` — keep [range.end..r.end).
+        if j < self.0.len() && self.0[j].start < range.end {
+            self.0[j].start = range.end;
+        }
+
+        // Drop the fully-covered middle.
+        if j > i {
+            self.0.drain(i..j);
+        }
+    }
+
     /// Merge `other` ID range into current one. Both inputs are assumed to be in canonical
     /// form (sorted, non-overlapping, non-adjacent); the result is too. Adjacent and
     /// overlapping ranges across the two inputs coalesce.
@@ -148,17 +192,17 @@ impl IdRange {
 
         // Fast path: `other` lies entirely after `self`. Common when accumulating updates
         // in clock order — avoids the general two-way merge alloc.
-        let self_last_idx = self.0.len() - 1;
-        let self_last_end = self.0[self_last_idx].end;
+        let last_idx = self.0.len() - 1;
+        let last_end = self.0[last_idx].end;
         let other_first_start = other.0[0].start;
-        if self_last_end < other_first_start {
+        if last_end < other_first_start {
             self.0.extend(other.0);
             return;
         }
-        if self_last_end == other_first_start {
+        if last_end == other_first_start {
             // Adjacent at the boundary — merge first of `other` into last of `self`,
             // then append the rest.
-            self.0[self_last_idx].end = self_last_end.max(other.0[0].end);
+            self.0[last_idx].end = last_end.max(other.0[0].end);
             let mut it = other.0.into_iter();
             it.next();
             self.0.extend(it);
@@ -166,7 +210,8 @@ impl IdRange {
         }
 
         // General two-way merge.
-        let mut out = SmallVec::with_capacity(self.0.len() + other.0.len());
+        let mut result: SmallVec<[Range<u32>; 2]> =
+            SmallVec::with_capacity(self.0.len() + other.0.len());
         let mut a = std::mem::take(&mut self.0).into_iter().peekable();
         let mut b = other.0.into_iter().peekable();
 
@@ -182,15 +227,15 @@ impl IdRange {
             } else {
                 b.next().unwrap()
             };
-            match out.last_mut() {
+            match result.last_mut() {
                 Some(last) if last.end >= next.start => {
                     last.end = last.end.max(next.end);
                 }
-                _ => out.push(next),
+                _ => result.push(next),
             }
         }
 
-        self.0 = out;
+        self.0 = result;
     }
 
     /// Check if current [IdRange] is a subset of `other`. This means that all the elements
@@ -408,7 +453,7 @@ impl IdSet {
         self.0
             .entry(id.client)
             .or_default()
-            .push(id.clock..(id.clock + len));
+            .insert(id.clock..(id.clock + len));
     }
 
     /// Inserts a new ID `range` corresponding with a given `client`.
@@ -450,6 +495,18 @@ impl IdSet {
             }
             None => false,
         });
+    }
+
+    /// Remove a given range of elements from the current [IdSet]. If the client's [IdRange]
+    /// becomes empty as a result, the client entry is dropped from the set entirely.
+    pub fn remove(&mut self, range: &BlockRange) {
+        if let Entry::Occupied(mut e) = self.0.entry(range.id.client) {
+            let id_range = e.get_mut();
+            id_range.remove(range.id.clock..(range.id.clock + range.len));
+            if id_range.is_empty() {
+                e.remove();
+            }
+        }
     }
 
     pub fn get(&self, client_id: &ClientID) -> Option<&IdRange> {
@@ -564,7 +621,7 @@ impl<'a> From<&'a BlockStore> for DeleteSet {
             for block in blocks.iter() {
                 if block.is_deleted() {
                     let (start, end) = block.clock_range();
-                    deletes.push(start..(end + 1));
+                    deletes.insert(start..(end + 1));
                 }
             }
 
@@ -631,6 +688,12 @@ impl DeleteSet {
     /// inside of a current delete set.
     pub fn insert(&mut self, id: ID, len: u32) {
         self.0.insert(id, len)
+    }
+
+    /// Removes a single delete entry described by `range` from the set. If the client's
+    /// [IdRange] becomes empty, the client entry is dropped from the set.
+    pub fn remove(&mut self, range: &BlockRange) {
+        self.0.remove(range)
     }
 
     /// Returns number of clients stored;
@@ -834,7 +897,7 @@ impl<'ds> TxnIterator for DeletedBlocks<'ds> {
 
 #[cfg(test)]
 mod test {
-    use crate::block::ItemContent;
+    use crate::block::{BlockRange, ClientID, ItemContent};
     use crate::id_set::{IdRange, IdSet};
     use crate::iter::TxnIterator;
     use crate::slice::BlockSlice;
@@ -842,9 +905,10 @@ mod test {
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{DeleteSet, Doc, Options, ReadTxn, Text, Transact, ID};
-    use smallvec::smallvec;
+    use smallvec::{smallvec, SmallVec};
     use std::collections::HashSet;
     use std::fmt::Debug;
+    use std::ops::Range;
 
     #[test]
     fn id_range_merge_continous() {
@@ -908,9 +972,9 @@ mod test {
         // Same canonical end-state as the old squash-based test, now produced incrementally
         // by merge-on-insert: adjacent [0..3) + [3..5) collapses, [6..7) stays separate.
         let mut r = IdRange::default();
-        r.push(0..3);
-        r.push(3..5);
-        r.push(6..7);
+        r.insert(0..3);
+        r.insert(3..5);
+        r.insert(6..7);
         assert_eq!(r, IdRange(smallvec![0..5, 6..7]));
     }
 
@@ -951,22 +1015,22 @@ mod test {
     fn id_range_push() {
         let mut range = IdRange(smallvec![]);
 
-        range.push(0..4);
+        range.insert(0..4);
         assert_eq!(range, IdRange(smallvec![0..4]));
 
-        range.push(4..6);
+        range.insert(4..6);
         assert_eq!(range, IdRange(smallvec![0..6]));
 
-        range.push(7..9);
+        range.insert(7..9);
         assert_eq!(range, IdRange(smallvec![0..6, 7..9]));
     }
 
     #[test]
     fn id_range_push_out_of_order() {
         let mut range = IdRange::default();
-        range.push(5..7);
-        range.push(1..3);
-        range.push(3..5);
+        range.insert(5..7);
+        range.insert(1..3);
+        range.insert(3..5);
         // Adjacency-chain: [3..5) bridges [1..3) and [5..7) into a single [1..7).
         assert_eq!(range, IdRange(smallvec![1..7]));
     }
@@ -974,20 +1038,20 @@ mod test {
     #[test]
     fn id_range_push_skips_empty() {
         let mut range = IdRange::default();
-        range.push(5..5);
+        range.insert(5..5);
         assert_eq!(range, IdRange::default());
-        range.push(0..3);
-        range.push(7..7);
+        range.insert(0..3);
+        range.insert(7..7);
         assert_eq!(range, IdRange(smallvec![0..3]));
     }
 
     #[test]
     fn id_range_push_chain_absorb() {
         let mut range = IdRange::default();
-        range.push(0..2);
-        range.push(4..6);
-        range.push(8..10);
-        range.push(1..9);
+        range.insert(0..2);
+        range.insert(4..6);
+        range.insert(8..10);
+        range.insert(1..9);
         // The single push spans three existing ranges — all collapse into one.
         assert_eq!(range, IdRange(smallvec![0..10]));
     }
@@ -995,8 +1059,8 @@ mod test {
     #[test]
     fn id_range_push_adjacency_merge() {
         let mut range = IdRange::default();
-        range.push(0..3);
-        range.push(3..5);
+        range.insert(0..3);
+        range.insert(3..5);
         // Adjacent (touching at 3) — must merge, not stay split.
         assert_eq!(range, IdRange(smallvec![0..5]));
     }
@@ -1004,10 +1068,91 @@ mod test {
     #[test]
     fn id_range_push_front() {
         let mut range = IdRange::default();
-        range.push(5..7);
-        range.push(1..3);
+        range.insert(5..7);
+        range.insert(1..3);
         // Front insert preserves order; no adjacency to merge.
         assert_eq!(range, IdRange(smallvec![1..3, 5..7]));
+    }
+
+    #[test]
+    fn id_range_remove() {
+        // No-op: empty input range.
+        let mut r = IdRange(smallvec![0..10]);
+        r.remove(5..5);
+        assert_eq!(r, IdRange(smallvec![0..10]));
+
+        // No-op: range starts past every entry.
+        let mut r = IdRange(smallvec![0..5]);
+        r.remove(10..15);
+        assert_eq!(r, IdRange(smallvec![0..5]));
+
+        // No-op: range falls entirely in a gap.
+        let mut r = IdRange(smallvec![0..5, 10..15]);
+        r.remove(5..10);
+        assert_eq!(r, IdRange(smallvec![0..5, 10..15]));
+
+        // Split: range strictly inside a single entry.
+        let mut r = IdRange(smallvec![0..10]);
+        r.remove(3..7);
+        assert_eq!(r, IdRange(smallvec![0..3, 7..10]));
+
+        // Trim left edge: removal hits the head of a single entry.
+        let mut r = IdRange(smallvec![0..10]);
+        r.remove(0..3);
+        assert_eq!(r, IdRange(smallvec![3..10]));
+
+        // Trim right edge: removal hits the tail of a single entry.
+        let mut r = IdRange(smallvec![0..10]);
+        r.remove(7..10);
+        assert_eq!(r, IdRange(smallvec![0..7]));
+
+        // Exact match: drop the only entry.
+        let mut r = IdRange(smallvec![0..10]);
+        r.remove(0..10);
+        assert_eq!(r, IdRange::default());
+
+        // Spans multiple entries — left trim, drop middle, right trim.
+        let mut r = IdRange(smallvec![0..3, 6..10, 12..15]);
+        r.remove(2..13);
+        assert_eq!(r, IdRange(smallvec![0..2, 13..15]));
+
+        // Spans multiple entries — drop two adjacent entries entirely.
+        let mut r = IdRange(smallvec![0..3, 6..10, 12..15]);
+        r.remove(0..15);
+        assert_eq!(r, IdRange::default());
+
+        // Removal that exceeds the rightmost entry on its right side.
+        let mut r = IdRange(smallvec![0..5, 10..15]);
+        r.remove(12..100);
+        assert_eq!(r, IdRange(smallvec![0..5, 10..12]));
+
+        // Removal beginning before the first entry.
+        let mut r = IdRange(smallvec![5..10]);
+        r.remove(0..7);
+        assert_eq!(r, IdRange(smallvec![7..10]));
+    }
+
+    #[test]
+    fn id_set_remove() {
+        // Removing from a client absent from the set is a no-op.
+        let mut set = IdSet::from_iter([(1, [0..10])]);
+        set.remove(&BlockRange::new(ID::new(2, 0), 5));
+        assert_eq!(set, IdSet::from_iter([(1, [0..10])]));
+
+        // Partial removal — split.
+        let mut set = IdSet::from_iter([(1, [0..10])]);
+        set.remove(&BlockRange::new(ID::new(1, 3), 4));
+        assert_eq!(set, IdSet::from_iter([(1, [0..3, 7..10])]));
+
+        // Removing the entire IdRange drops the client.
+        let mut set = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
+        set.remove(&BlockRange::new(ID::new(1, 0), 10));
+        assert_eq!(set, IdSet::from_iter([(2, [0..5])]));
+
+        // Empty len is a no-op.
+        let mut set = IdSet::from_iter([(1, [0..10])]);
+        set.remove(&BlockRange::new(ID::new(1, 5), 0));
+        assert_eq!(set, IdSet::from_iter([(1, [0..10])]));
     }
 
     #[test]
@@ -1015,20 +1160,20 @@ mod test {
         // Tail-fast path must not shrink the last range when the new range is a
         // subset of it (range.start >= last.start AND range.end <= last.end).
         let mut range = IdRange::default();
-        range.push(0..10);
-        range.push(5..7);
+        range.insert(0..10);
+        range.insert(5..7);
         assert_eq!(range, IdRange(smallvec![0..10]));
 
         // Boundary: range.end == last.end — also a subset, must be a no-op.
         let mut range = IdRange::default();
-        range.push(0..10);
-        range.push(3..10);
+        range.insert(0..10);
+        range.insert(3..10);
         assert_eq!(range, IdRange(smallvec![0..10]));
 
         // Boundary: identical to last.
         let mut range = IdRange::default();
-        range.push(0..10);
-        range.push(0..10);
+        range.insert(0..10);
+        range.insert(0..10);
         assert_eq!(range, IdRange(smallvec![0..10]));
     }
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -44,7 +44,7 @@ impl Decode for Range<u32> {
 /// ranges are merged together on insert.
 #[repr(transparent)]
 #[derive(Clone, PartialEq, Eq, Hash, Default)]
-pub struct IdRange(SmallVec<[Range<u32>; 1]>);
+pub struct IdRange(SmallVec<[Range<u32>; 2]>);
 
 impl std::ops::Deref for IdRange {
     type Target = [Range<u32>];
@@ -167,7 +167,7 @@ impl IdRange {
         }
 
         // General two-way merge.
-        let mut out: SmallVec<[Range<u32>; 1]> =
+        let mut out =
             SmallVec::with_capacity(self.0.len() + other.0.len());
         let mut a = std::mem::take(&mut self.0).into_iter().peekable();
         let mut b = other.0.into_iter().peekable();

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -39,7 +39,7 @@ impl Decode for Range<u32> {
 ///
 /// Internally backed by a [SmallVec] inlining a single [Range], so the common case of one
 /// continuous range incurs no heap allocation.
-/// 
+///
 /// Within the `IdRange` all ranges are values sorted by `start` of the range, overlapping or adjacent
 /// ranges are merged together on insert.
 #[repr(transparent)]
@@ -91,6 +91,18 @@ impl IdRange {
     fn push(&mut self, range: Range<u32>) {
         if range.start >= range.end {
             return;
+        }
+
+        // tail-fast push - if inserted range >= last element, we don't need binary search
+        if let Some(last) = self.0.last_mut() {
+            if range.start >= last.start {
+                if range.start > last.end {
+                    self.0.push(range);
+                } else {
+                    last.end = last.end.max(range.end); // inserted range is overlapping -> merge to the end
+                }
+                return;
+            }
         }
 
         let mut start = range.start;
@@ -924,6 +936,28 @@ mod test {
         range.push(1..3);
         // Front insert preserves order; no adjacency to merge.
         assert_eq!(range, IdRange(smallvec![1..3, 5..7]));
+    }
+
+    #[test]
+    fn id_range_push_subset_of_last() {
+        // Tail-fast path must not shrink the last range when the new range is a
+        // subset of it (range.start >= last.start AND range.end <= last.end).
+        let mut range = IdRange::default();
+        range.push(0..10);
+        range.push(5..7);
+        assert_eq!(range, IdRange(smallvec![0..10]));
+
+        // Boundary: range.end == last.end — also a subset, must be a no-op.
+        let mut range = IdRange::default();
+        range.push(0..10);
+        range.push(3..10);
+        assert_eq!(range, IdRange(smallvec![0..10]));
+
+        // Boundary: identical to last.
+        let mut range = IdRange::default();
+        range.push(0..10);
+        range.push(0..10);
+        assert_eq!(range, IdRange(smallvec![0..10]));
     }
 
     #[test]

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -38,8 +38,10 @@ impl Decode for Range<u32> {
 /// specific client, included in a corresponding [IdSet].
 ///
 /// Internally backed by a [SmallVec] inlining a single [Range], so the common case of one
-/// continuous range incurs no heap allocation. Read-only slice access is exposed via [Deref] —
-/// callers can use `range.iter()`, `range.len()`, `range[i]`, etc. directly.
+/// continuous range incurs no heap allocation.
+/// 
+/// Within the `IdRange` all ranges are values sorted by `start` of the range, overlapping or adjacent
+/// ranges are merged together on insert.
 #[repr(transparent)]
 #[derive(Clone, PartialEq, Eq, Hash, Default)]
 pub struct IdRange(SmallVec<[Range<u32>; 1]>);
@@ -87,111 +89,98 @@ impl IdRange {
     }
 
     fn push(&mut self, range: Range<u32>) {
-        match self.0.len() {
-            0 => self.0.push(range),
-            1 => {
-                let r = &mut self.0[0];
-                if r.end >= range.start {
-                    if r.start > range.end {
-                        // `range` lies entirely before `r` — produce [range, r].
-                        let r_clone = r.clone();
-                        *r = range;
-                        self.0.push(r_clone);
-                    } else {
-                        // overlap or adjacency — merge in place.
-                        r.end = range.end.max(r.end);
-                        r.start = range.start.min(r.start);
-                    }
-                } else {
-                    // `range` lies entirely after `r` — produce [r, range].
-                    self.0.push(range);
-                }
-            }
-            _ => {
-                let last = self.0.last_mut().unwrap();
-                if !Self::try_join(last, &range) {
-                    self.0.push(range);
-                }
-            }
-        }
-    }
-
-    /// Alters current [IdRange] by compacting its internal implementation.
-    /// Example: fragmented space of [0,3), [3,5), [6,7) will be compacted into [0,5), [6,7).
-    fn squash(&mut self) {
-        let ranges = &mut self.0;
-        if ranges.len() < 2 {
+        if range.start >= range.end {
             return;
         }
-        ranges.sort_by(|a, b| a.start.cmp(&b.start));
-        let mut new_len = 1;
 
-        let len = ranges.len() as isize;
-        let head = ranges.as_mut_ptr();
-        let mut current = unsafe { head.as_mut().unwrap() };
-        let mut i = 1;
-        while i < len {
-            let next = unsafe { head.offset(i).as_ref().unwrap() };
-            if !Self::try_join(current, next) {
-                // current and next are disjoined eg. [0,5) & [6,9)
+        let mut start = range.start;
+        let mut end = range.end;
+        let mut lo = self.0.partition_point(|r| r.start < range.start);
 
-                // move current pointer one index to the left: by using new_len we
-                // squash ranges possibly already merged to current
-                current = unsafe { head.offset(new_len).as_mut().unwrap() };
-
-                // make next a new current
-                current.start = next.start;
-                current.end = next.end;
-                new_len += 1;
-            }
-
-            i += 1;
+        // Absorb the left neighbour if it touches or overlaps the new range.
+        // `>= start` (not `> start`) so adjacents like [0..3) + [3..5) merge into [0..5).
+        if lo > 0 && self.0[lo - 1].end >= start {
+            lo -= 1;
+            start = self.0[lo].start;
+            end = end.max(self.0[lo].end);
         }
 
-        if ranges.len() != new_len as usize {
-            ranges.truncate(new_len as usize);
+        // Walk forward absorbing every right neighbour that touches or overlaps.
+        let mut hi = lo;
+        while hi < self.0.len() && self.0[hi].start <= end {
+            end = end.max(self.0[hi].end);
+            hi += 1;
+        }
+
+        // Splice [lo..hi] with the single merged range.
+        if lo == hi {
+            self.0.insert(lo, start..end);
+        } else {
+            self.0[lo] = start..end;
+            if hi - lo > 1 {
+                self.0.drain(lo + 1..hi);
+            }
         }
     }
 
-    fn is_squashed(&self) -> bool {
-        let mut i = self.0.iter();
-        if let Some(r) = i.next() {
-            let mut prev_end = r.end;
-            while let Some(r) = i.next() {
-                if r.start < prev_end {
-                    return false;
-                }
-                prev_end = r.end;
-            }
-        }
-        true
-    }
-
-    /// Merge `other` ID range into current one.
+    /// Merge `other` ID range into current one. Both inputs are assumed to be in canonical
+    /// form (sorted, non-overlapping, non-adjacent); the result is too. Adjacent and
+    /// overlapping ranges across the two inputs coalesce.
     pub fn merge(&mut self, other: IdRange) {
-        match (self.0.len(), other.0.len()) {
-            (0, _) => self.0 = other.0,
-            (_, 0) => {}
-            (1, 1) => {
-                let b = other.0.into_iter().next().unwrap();
-                if Self::disjoint(&self.0[0], &b) {
-                    self.0.push(b);
-                } else {
-                    let a = &mut self.0[0];
-                    a.start = a.start.min(b.start);
-                    a.end = a.end.max(b.end);
+        if other.0.is_empty() {
+            return;
+        }
+        if self.0.is_empty() {
+            self.0 = other.0;
+            return;
+        }
+
+        // Fast path: `other` lies entirely after `self`. Common when accumulating updates
+        // in clock order — avoids the general two-way merge alloc.
+        let self_last_idx = self.0.len() - 1;
+        let self_last_end = self.0[self_last_idx].end;
+        let other_first_start = other.0[0].start;
+        if self_last_end < other_first_start {
+            self.0.extend(other.0);
+            return;
+        }
+        if self_last_end == other_first_start {
+            // Adjacent at the boundary — merge first of `other` into last of `self`,
+            // then append the rest.
+            self.0[self_last_idx].end = self_last_end.max(other.0[0].end);
+            let mut it = other.0.into_iter();
+            it.next();
+            self.0.extend(it);
+            return;
+        }
+
+        // General two-way merge.
+        let mut out: SmallVec<[Range<u32>; 1]> =
+            SmallVec::with_capacity(self.0.len() + other.0.len());
+        let mut a = std::mem::take(&mut self.0).into_iter().peekable();
+        let mut b = other.0.into_iter().peekable();
+
+        loop {
+            let pick_a = match (a.peek(), b.peek()) {
+                (Some(ra), Some(rb)) => ra.start <= rb.start,
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (None, None) => break,
+            };
+            let next = if pick_a {
+                a.next().unwrap()
+            } else {
+                b.next().unwrap()
+            };
+            match out.last_mut() {
+                Some(last) if last.end >= next.start => {
+                    last.end = last.end.max(next.end);
                 }
-            }
-            (1, _) => {
-                // (Continuous, Fragmented) — old behaviour appended self to other's vec.
-                let a = self.0[0].clone();
-                self.0 = other.0;
-                self.0.push(a);
-            }
-            _ => {
-                self.0.extend(other.0);
+                _ => out.push(next),
             }
         }
+
+        self.0 = out;
     }
 
     /// Check if current [IdRange] is a subset of `other`. This means that all the elements
@@ -300,31 +289,15 @@ impl IdRange {
     }
 
     #[inline]
-    fn try_join(a: &mut Range<u32>, b: &Range<u32>) -> bool {
-        if Self::disjoint(a, b) {
-            false
-        } else {
-            a.start = a.start.min(b.start);
-            a.end = a.end.max(b.end);
-            true
-        }
-    }
-
-    #[inline]
     fn disjoint(a: &Range<u32>, b: &Range<u32>) -> bool {
         a.start > b.end || b.start > a.end
     }
 }
 
 impl Encode for IdRange {
+    #[inline]
     fn encode<E: Encoder>(&self, encoder: &mut E) {
-        if self.is_squashed() {
-            self.encode_raw(encoder)
-        } else {
-            let mut clone = self.clone();
-            clone.squash();
-            clone.encode_raw(encoder);
-        }
+        self.encode_raw(encoder)
     }
 }
 
@@ -382,13 +355,6 @@ impl IdSet {
         self.0.is_empty() || self.0.values().all(|r| r.is_empty())
     }
 
-    /// Compacts an internal ranges representation.
-    pub fn squash(&mut self) {
-        for block in self.0.values_mut() {
-            block.squash();
-        }
-    }
-
     pub fn insert(&mut self, id: ID, len: u32) {
         self.0
             .entry(id.client)
@@ -402,7 +368,8 @@ impl IdSet {
     }
 
     /// Merges another ID set into a current one, combining their information about observed ID
-    /// ranges and squashing them if necessary.
+    /// ranges. Per-client [IdRange] merge maintains the canonical invariant on its own, so no
+    /// trailing squash is needed.
     pub fn merge(&mut self, other: Self) {
         other.0.into_iter().for_each(|(client, range)| {
             if let Some(r) = self.0.get_mut(&client) {
@@ -411,7 +378,6 @@ impl IdSet {
                 self.0.insert(client, range);
             }
         });
-        self.squash()
     }
 
     pub fn get(&self, client_id: &ClientID) -> Option<&IdRange> {
@@ -621,13 +587,6 @@ impl DeleteSet {
         self.0.merge(other.0)
     }
 
-    /// Squashes the contents of a current delete set. This operation means, that in case when
-    /// delete set contains any overlapping ranges within, they will be squashed together to
-    /// optimize the space and make future encoding more compact.
-    pub fn squash(&mut self) {
-        self.0.squash()
-    }
-
     pub fn range(&self, client_id: &ClientID) -> Option<&IdRange> {
         self.0.get(client_id)
     }
@@ -827,10 +786,48 @@ mod test {
     }
 
     #[test]
+    fn id_range_merge_canonical() {
+        // Empty into non-empty — self unchanged.
+        let mut a = IdRange(smallvec![0..3]);
+        a.merge(IdRange::default());
+        assert_eq!(a, IdRange(smallvec![0..3]));
+
+        // Non-empty into empty — adopts other.
+        let mut a = IdRange::default();
+        a.merge(IdRange(smallvec![1..5]));
+        assert_eq!(a, IdRange(smallvec![1..5]));
+
+        // Other has lower start than self — sorted output.
+        let mut a = IdRange(smallvec![5..7]);
+        a.merge(IdRange(smallvec![1..3]));
+        assert_eq!(a, IdRange(smallvec![1..3, 5..7]));
+
+        // Two-way merge with overlapping middles.
+        let mut a = IdRange(smallvec![0..2, 4..6, 10..12]);
+        a.merge(IdRange(smallvec![1..5, 11..15]));
+        // [0..2] + [1..5] -> [0..5], absorbs [4..6] -> [0..6]; [10..12] + [11..15] -> [10..15]
+        assert_eq!(a, IdRange(smallvec![0..6, 10..15]));
+
+        // Cross-source adjacency must merge.
+        let mut a = IdRange(smallvec![0..3, 10..12]);
+        a.merge(IdRange(smallvec![3..5, 12..14]));
+        assert_eq!(a, IdRange(smallvec![0..5, 10..14]));
+
+        // Interleaved disjoint ranges stay disjoint and sorted.
+        let mut a = IdRange(smallvec![0..2, 6..8]);
+        a.merge(IdRange(smallvec![3..5, 9..11]));
+        assert_eq!(a, IdRange(smallvec![0..2, 3..5, 6..8, 9..11]));
+    }
+
+    #[test]
     fn id_range_compact() {
-        let mut r = IdRange(smallvec![(0..3), (3..5), (6..7)]);
-        r.squash();
-        assert_eq!(r, IdRange(smallvec![(0..5), (6..7)]));
+        // Same canonical end-state as the old squash-based test, now produced incrementally
+        // by merge-on-insert: adjacent [0..3) + [3..5) collapses, [6..7) stays separate.
+        let mut r = IdRange::default();
+        r.push(0..3);
+        r.push(3..5);
+        r.push(6..7);
+        assert_eq!(r, IdRange(smallvec![0..5, 6..7]));
     }
 
     #[test]
@@ -878,6 +875,55 @@ mod test {
 
         range.push(7..9);
         assert_eq!(range, IdRange(smallvec![0..6, 7..9]));
+    }
+
+    #[test]
+    fn id_range_push_out_of_order() {
+        let mut range = IdRange::default();
+        range.push(5..7);
+        range.push(1..3);
+        range.push(3..5);
+        // Adjacency-chain: [3..5) bridges [1..3) and [5..7) into a single [1..7).
+        assert_eq!(range, IdRange(smallvec![1..7]));
+    }
+
+    #[test]
+    fn id_range_push_skips_empty() {
+        let mut range = IdRange::default();
+        range.push(5..5);
+        assert_eq!(range, IdRange::default());
+        range.push(0..3);
+        range.push(7..7);
+        assert_eq!(range, IdRange(smallvec![0..3]));
+    }
+
+    #[test]
+    fn id_range_push_chain_absorb() {
+        let mut range = IdRange::default();
+        range.push(0..2);
+        range.push(4..6);
+        range.push(8..10);
+        range.push(1..9);
+        // The single push spans three existing ranges — all collapse into one.
+        assert_eq!(range, IdRange(smallvec![0..10]));
+    }
+
+    #[test]
+    fn id_range_push_adjacency_merge() {
+        let mut range = IdRange::default();
+        range.push(0..3);
+        range.push(3..5);
+        // Adjacent (touching at 3) — must merge, not stay split.
+        assert_eq!(range, IdRange(smallvec![0..5]));
+    }
+
+    #[test]
+    fn id_range_push_front() {
+        let mut range = IdRange::default();
+        range.push(5..7);
+        range.push(1..3);
+        // Front insert preserves order; no adjacency to merge.
+        assert_eq!(range, IdRange(smallvec![1..3, 5..7]));
     }
 
     #[test]

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -11,7 +11,6 @@ use crate::ReadTxn;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::{smallvec, SmallVec};
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
@@ -167,8 +166,7 @@ impl IdRange {
         }
 
         // General two-way merge.
-        let mut out =
-            SmallVec::with_capacity(self.0.len() + other.0.len());
+        let mut out = SmallVec::with_capacity(self.0.len() + other.0.len());
         let mut a = std::mem::take(&mut self.0).into_iter().peekable();
         let mut b = other.0.into_iter().peekable();
 
@@ -238,9 +236,9 @@ impl IdRange {
         current >= range.end
     }
 
-    /// Subtracts `other` from the current [IdRange], producing a new [IdRange] that contains
-    /// all elements from the current range that are not present in `other`.
-    pub fn subtract(&mut self, other: Self) {
+    /// Excludes `other` from the current [IdRange]: every clock covered by `other` is removed
+    /// from `self`, leaving the parts of `self` that lie outside `other`.
+    pub fn exclude(&mut self, other: &Self) {
         let mut result = SmallVec::new();
 
         for range in self.0.iter() {
@@ -276,16 +274,20 @@ impl IdRange {
 
     /// Computes the intersection of the current [IdRange] with `other`, modifying the current
     /// range to contain only elements present in both ranges.
-    pub fn intersect(&mut self, other: Self) {
+    pub fn intersect(&mut self, other: &Self) {
         let mut result = SmallVec::new();
 
         for self_range in self.0.iter() {
             for other_range in other.0.iter() {
                 if !Self::disjoint(self_range, other_range) {
-                    // Ranges overlap, compute the intersection
+                    // Ranges overlap, compute the intersection.
                     let start = self_range.start.max(other_range.start);
                     let end = self_range.end.min(other_range.end);
-                    result.push(start..end);
+                    // `disjoint()` uses closed-interval semantics, so `start == end` can slip
+                    // through for half-open ranges that abut at a single clock — drop those.
+                    if start < end {
+                        result.push(start..end);
+                    }
                 }
             }
         }
@@ -344,6 +346,19 @@ impl IdSet {
         Self::default()
     }
 
+    pub fn from_iter<I1, I2>(iter: I1) -> Self
+    where
+        I1: IntoIterator<Item = (ClientID, I2)>,
+        I2: IntoIterator<Item = Range<u32>>,
+    {
+        let mut set = Self::new();
+        for (client_id, range) in iter {
+            let range = IdRange(range.into_iter().collect());
+            set.0.insert(client_id, range);
+        }
+        set
+    }
+
     /// Returns number of clients stored;
     pub fn len(&self) -> usize {
         self.0.len()
@@ -389,6 +404,29 @@ impl IdSet {
             } else {
                 self.0.insert(client, range);
             }
+        });
+    }
+
+    /// Removes from `self` every clock range covered by `other`. Per-client [IdRange]s are
+    /// excluded individually; clients absent from `other` are left untouched.
+    pub fn exclude(&mut self, other: &Self) {
+        self.0.retain(|client, ranges| {
+            if let Some(other_ranges) = other.0.get(client) {
+                ranges.exclude(other_ranges);
+            }
+            !ranges.is_empty()
+        });
+    }
+
+    /// Replaces `self` with the per-client intersection against `other`. Clients present only
+    /// in `self` (or only in `other`) are dropped.
+    pub fn intersect(&mut self, other: &Self) {
+        self.0.retain(|client, ranges| match other.0.get(client) {
+            Some(other_ranges) => {
+                ranges.intersect(other_ranges);
+                !ranges.is_empty()
+            }
+            None => false,
         });
     }
 
@@ -982,40 +1020,40 @@ mod test {
     }
 
     #[test]
-    fn id_range_subtract() {
-        // subtract from the left side
+    fn id_range_exclude() {
+        // exclude from the left side
         let mut a = IdRange(smallvec![0..4]);
-        a.subtract(IdRange(smallvec![0..2]));
+        a.exclude(&IdRange(smallvec![0..2]));
         assert_eq!(a, IdRange(smallvec![2..4]));
 
-        // subtract from the right side
+        // exclude from the right side
         let mut a = IdRange(smallvec![0..4]);
-        a.subtract(IdRange(smallvec![2..4]));
+        a.exclude(&IdRange(smallvec![2..4]));
         assert_eq!(a, IdRange(smallvec![0..2]));
 
-        // subtract in the middle - splitting the continuous block in two
+        // exclude in the middle - splitting the continuous block in two
         let mut a = IdRange(smallvec![0..4]);
-        a.subtract(IdRange(smallvec![1..3]));
+        a.exclude(&IdRange(smallvec![1..3]));
         assert_eq!(a, IdRange(smallvec![0..1, 3..4]));
 
-        // subtract with fragmented block - splitting single range into >2 ranges
+        // exclude fragmented block - splitting single range into >2 ranges
         let mut a = IdRange(smallvec![0..10]);
-        a.subtract(IdRange(smallvec![1..3, 4..5]));
+        a.exclude(&IdRange(smallvec![1..3, 4..5]));
         assert_eq!(a, IdRange(smallvec![0..1, 3..4, 5..10]));
 
-        // subtract continuous range overlapping with more than one range
+        // exclude continuous range overlapping with more than one range
         let mut a = IdRange(smallvec![0..4, 5..6, 7..10]);
-        a.subtract(IdRange(smallvec![3..8]));
+        a.exclude(&IdRange(smallvec![3..8]));
         assert_eq!(a, IdRange(smallvec![0..3, 8..10]));
 
-        // subtract two fragmented ranges with partially overlapping boundaries
+        // exclude two fragmented ranges with partially overlapping boundaries
         let mut a = IdRange(smallvec![0..4, 7..10]);
-        a.subtract(IdRange(smallvec![3..5, 6..9]));
+        a.exclude(&IdRange(smallvec![3..5, 6..9]));
         assert_eq!(a, IdRange(smallvec![0..3, 9..10]));
 
-        // subtract fragmented ranges, when one gets split into 2+, and another overlaps at the end
+        // exclude fragmented ranges, when one gets split into 2+, and another overlaps at the end
         let mut a = IdRange(smallvec![0..4, 7..10]);
-        a.subtract(IdRange(smallvec![2..3, 5..6, 9..10]));
+        a.exclude(&IdRange(smallvec![2..3, 5..6, 9..10]));
         assert_eq!(a, IdRange(smallvec![0..2, 3..4, 7..9]));
     }
 
@@ -1023,54 +1061,111 @@ mod test {
     fn id_range_intersect() {
         // Basic continuous range intersection
         let mut a = IdRange(smallvec![0..10]);
-        a.intersect(IdRange(smallvec![5..15]));
+        a.intersect(&IdRange(smallvec![5..15]));
         assert_eq!(a, IdRange(smallvec![5..10]));
 
         // Fragmented intersecting with continuous
         let mut a = IdRange(smallvec![0..5, 10..15]);
-        a.intersect(IdRange(smallvec![3..12]));
+        a.intersect(&IdRange(smallvec![3..12]));
         assert_eq!(a, IdRange(smallvec![3..5, 10..12]));
 
         // No overlap - empty result
         let mut a = IdRange(smallvec![0..5]);
-        a.intersect(IdRange(smallvec![10..15]));
+        a.intersect(&IdRange(smallvec![10..15]));
         assert_eq!(a, IdRange::default());
 
         // Multiple ranges with multiple intersections
         let mut a = IdRange(smallvec![1..4, 6..9]);
-        a.intersect(IdRange(smallvec![2..7]));
+        a.intersect(&IdRange(smallvec![2..7]));
         assert_eq!(a, IdRange(smallvec![2..4, 6..7]));
 
         // Complete overlap
         let mut a = IdRange(smallvec![2..8]);
-        a.intersect(IdRange(smallvec![0..10]));
+        a.intersect(&IdRange(smallvec![0..10]));
         assert_eq!(a, IdRange(smallvec![2..8]));
 
         // Partial overlap on both sides
         let mut a = IdRange(smallvec![5..15]);
-        a.intersect(IdRange(smallvec![0..10]));
+        a.intersect(&IdRange(smallvec![0..10]));
         assert_eq!(a, IdRange(smallvec![5..10]));
 
         // Fragmented with fragmented
         let mut a = IdRange(smallvec![0..5, 10..15, 20..25]);
-        a.intersect(IdRange(smallvec![3..12, 22..30]));
+        a.intersect(&IdRange(smallvec![3..12, 22..30]));
         assert_eq!(a, IdRange(smallvec![3..5, 10..12, 22..25]));
 
         // Exact match
         let mut a = IdRange(smallvec![5..10]);
-        a.intersect(IdRange(smallvec![5..10]));
+        a.intersect(&IdRange(smallvec![5..10]));
         assert_eq!(a, IdRange(smallvec![5..10]));
 
         // Single element overlap
         let mut a = IdRange(smallvec![0..5]);
-        a.intersect(IdRange(smallvec![4..10]));
+        a.intersect(&IdRange(smallvec![4..10]));
         assert_eq!(a, IdRange(smallvec![4..5]));
+
+        // Half-open boundary touch — must not yield an empty range.
+        let mut a = IdRange(smallvec![0..5]);
+        a.intersect(&IdRange(smallvec![5..10]));
+        assert_eq!(a, IdRange::default());
     }
 
     #[test]
     fn id_range_encode_decode() {
         roundtrip(&IdRange(smallvec![0..4]));
         roundtrip(&IdRange(smallvec![1..4, 5..8]));
+    }
+
+    #[test]
+    fn id_set_exclude() {
+        // Clients only in `self` are untouched; clients only in `other` are ignored.
+        let mut a = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
+        let b = IdSet::from_iter([(2, [0..3]), (3, [0..100])]);
+        a.exclude(&b);
+        assert_eq!(a, IdSet::from_iter([(1, [0..10]), (2, [3..5])]));
+
+        // Per-client exclude carves the right shape (split into two).
+        let mut a = IdSet::from_iter([(1, [0..10])]);
+        let b = IdSet::from_iter([(1, [3..7])]);
+        a.exclude(&b);
+        assert_eq!(a, IdSet::from_iter([(1, [0..3, 7..10])]));
+
+        // Clients whose ranges become empty are dropped entirely.
+        let mut a = IdSet::from_iter([(1, [0..5]), (2, [0..5])]);
+        let b = IdSet::from_iter([(1, [0..5])]);
+        a.exclude(&b);
+        assert_eq!(a, IdSet::from_iter([(2, [0..5])]));
+
+        // Excluding an empty other is a no-op.
+        let mut a = IdSet::from_iter([(1, [0..10])]);
+        a.exclude(&IdSet::new());
+        assert_eq!(a, IdSet::from_iter([(1, [0..10])]));
+    }
+
+    #[test]
+    fn id_set_intersect() {
+        // Clients present only in `self` are dropped.
+        let mut a = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
+        let b = IdSet::from_iter([(1, [5..15])]);
+        a.intersect(&b);
+        assert_eq!(a, IdSet::from_iter([(1, [5..10])]));
+
+        // Clients present only in `other` are ignored.
+        let mut a = IdSet::from_iter([(1, [0..10])]);
+        let b = IdSet::from_iter([(1, [3..7]), (2, [0..100])]);
+        a.intersect(&b);
+        assert_eq!(a, IdSet::from_iter([(1, [3..7])]));
+
+        // Clients whose intersection is empty (disjoint ranges) are dropped.
+        let mut a = IdSet::from_iter([(1, [0..5]), (2, [0..5])]);
+        let b = IdSet::from_iter([(1, [10..20]), (2, [1..4])]);
+        a.intersect(&b);
+        assert_eq!(a, IdSet::from_iter([(2, [1..4])]));
+
+        // Intersecting with an empty other yields empty.
+        let mut a = IdSet::from_iter([(1, [0..10])]);
+        a.intersect(&IdSet::new());
+        assert!(a.is_empty());
     }
 
     #[test]

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -652,7 +652,7 @@ pub use crate::doc::Doc;
 pub use crate::doc::OffsetKind;
 pub use crate::doc::Options;
 pub use crate::event::{SubdocsEvent, SubdocsEventIter, TransactionCleanupEvent, UpdateEvent};
-pub use crate::id_set::DeleteSet;
+pub use crate::id_set::IdSet;
 pub use crate::input::In;
 pub use crate::json_path::{JsonPath, JsonPathEval};
 pub use crate::moving::Assoc;

--- a/yrs/src/state_vector.rs
+++ b/yrs/src/state_vector.rs
@@ -3,7 +3,7 @@ use crate::encoding::read::Error;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::client_hasher::ClientHasher;
-use crate::{DeleteSet, ID};
+use crate::{IdSet, ID};
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -169,17 +169,17 @@ impl PartialOrd for StateVector {
 
 /// Snapshot describes a state of a document store at a given point in (logical) time. In practice
 /// it's a combination of [StateVector] (a summary of all observed insert/update operations)
-/// and a [DeleteSet] (a summary of all observed deletions).
+/// and a [IdSet] (a summary of all observed deletions).
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Snapshot {
     /// Compressed information about all deleted blocks at current snapshot time.
-    pub delete_set: DeleteSet,
+    pub delete_set: IdSet,
     /// Logical clock describing a current snapshot time.
     pub state_map: StateVector,
 }
 
 impl Snapshot {
-    pub fn new(state_map: StateVector, delete_set: DeleteSet) -> Self {
+    pub fn new(state_map: StateVector, delete_set: IdSet) -> Self {
         Snapshot {
             state_map,
             delete_set,
@@ -187,7 +187,7 @@ impl Snapshot {
     }
 
     pub(crate) fn is_visible(&self, id: &ID) -> bool {
-        self.state_map.get(&id.client) > id.clock && !self.delete_set.is_deleted(id)
+        self.state_map.get(&id.client) > id.clock && !self.delete_set.contains(id)
     }
 }
 
@@ -200,7 +200,7 @@ impl Encode for Snapshot {
 
 impl Decode for Snapshot {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
-        let ds = DeleteSet::decode(decoder)?;
+        let ds = IdSet::decode(decoder)?;
         let sm = StateVector::decode(decoder)?;
         Ok(Snapshot::new(sm, ds))
     }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -9,11 +9,11 @@ use crate::slice::ItemSlice;
 use crate::types::{Path, PathSegment, TypeRef};
 use crate::update::PendingUpdate;
 use crate::updates::encoder::{Encode, Encoder};
-use crate::StateVector;
 use crate::{
     Doc, Observer, OffsetKind, Snapshot, TransactionCleanupEvent, TransactionMut, UpdateEvent,
     Uuid, ID,
 };
+use crate::{IdSet, StateVector};
 use arc_swap::{ArcSwap, DefaultStrategy, Guard};
 use async_lock::futures::{Read, Write};
 use async_lock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -48,7 +48,7 @@ pub struct Store {
     /// A pending delete set. Just like `pending`, it contains deleted ranges of blocks that have
     /// not been yet applied due to missing blocks that prevent `pending` update to be integrated
     /// into `blocks`.
-    pub(crate) pending_ds: Option<DeleteSet>,
+    pub(crate) pending_ds: Option<IdSet>,
 
     pub(crate) subdocs: HashMap<DocAddr, Doc>,
 
@@ -93,12 +93,12 @@ impl Store {
 
     /// If there are some delete updates waiting for missing updates to arrive in order to be
     /// applied, this method will return them.
-    pub fn pending_ds(&self) -> Option<&DeleteSet> {
+    pub fn pending_ds(&self) -> Option<&IdSet> {
         self.pending_ds.as_ref()
     }
 
     /// Returns a mutable reference to the pending delete set if it exists.
-    pub fn pending_ds_mut(&mut self) -> Option<&mut DeleteSet> {
+    pub fn pending_ds_mut(&mut self) -> Option<&mut IdSet> {
         self.pending_ds.as_mut()
     }
 
@@ -208,7 +208,7 @@ impl Store {
         // 2. make Diff implement Encode trait and encode it
         // this way we can add some extra utility method on top of Diff (like introspection) without need of decoding it.
         self.write_blocks_from(sv, encoder);
-        let delete_set = DeleteSet::from(&self.blocks);
+        let delete_set = IdSet::from_store(&self.blocks);
         delete_set.encode(encoder);
     }
 

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -107,7 +107,7 @@ fn text_insert_delete() {
         let mut ds = IdSet::new();
         ds.insert(ID::new(CLIENT_ID, 0), 3);
         ds.insert(ID::new(CLIENT_ID, 5), 2);
-        DeleteSet::from(ds)
+        ds
     };
     let visited = Arc::new(AtomicBool::new(false));
     let setter = visited.clone();

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -967,8 +967,8 @@ impl<'doc> TransactionMut<'doc> {
         }
         self.committed = true;
 
-        // 1. sort and merge delete set
-        self.delete_set.squash();
+        // 1. delete set is already canonical — every IdRange::push / IdRange::merge
+        //    maintains sorted, non-overlapping, non-adjacent invariant on the fly.
         self.after_state = self.store.blocks.get_state_vector();
         // 2. emit 'beforeObserverCalls'
         // 3. for each change observed by the transaction call 'afterTransaction'

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -836,7 +836,7 @@ impl<'doc> TransactionMut<'doc> {
             let ds2 = self.apply_delete(&pending);
             let ds = match (remaining_ds, ds2) {
                 (Some(mut a), Some(b)) => {
-                    a.delete_set.merge(b);
+                    a.delete_set.merge_with(b);
                     Some(a.delete_set)
                 }
                 (Some(x), _) => Some(x.delete_set),

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -13,7 +13,7 @@ use crate::update::Update;
 use crate::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use crate::utils::OptionExt;
 use crate::{
-    merge_updates_v1, merge_updates_v2, ArrayRef, BranchID, Doc, MapRef, Out, Snapshot,
+    merge_updates_v1, merge_updates_v2, ArrayRef, BranchID, Doc, IdSet, MapRef, Out, Snapshot,
     StateVector, TextRef, Transact, XmlElementRef, XmlFragmentRef, XmlTextRef,
 };
 use async_lock::{RwLockReadGuard, RwLockWriteGuard};
@@ -41,7 +41,7 @@ pub trait ReadTxn: Sized {
         let store = self.store();
         let blocks = &store.blocks;
         let sv = blocks.get_state_vector();
-        let ds = DeleteSet::from(blocks);
+        let ds = IdSet::from_store(blocks);
         Snapshot::new(sv, ds)
     }
 
@@ -119,7 +119,7 @@ pub trait ReadTxn: Sized {
     fn encode_state_as_update<E: Encoder>(&self, sv: &StateVector, encoder: &mut E) {
         let store = self.store();
         store.write_blocks_from(sv, encoder);
-        let ds = DeleteSet::from(&store.blocks);
+        let ds = IdSet::from_store(&store.blocks);
         ds.encode(encoder);
     }
 
@@ -450,7 +450,7 @@ pub struct TransactionMut<'doc> {
     /// ID's of the blocks to be merged.
     pub(crate) merge_blocks: Vec<ID>,
     /// Describes the set of deleted items by ids.
-    pub(crate) delete_set: DeleteSet,
+    pub(crate) delete_set: IdSet,
     /// We store the reference that last moved an item. This is needed to compute the delta
     /// when multiple ContentMove move the same item.
     pub(crate) prev_moved: HashMap<ItemPtr, ItemPtr>,
@@ -501,7 +501,7 @@ impl<'doc> TransactionMut<'doc> {
             origin,
             before_state: begin_timestamp,
             merge_blocks: Vec::default(),
-            delete_set: DeleteSet::new(),
+            delete_set: IdSet::new(),
             after_state: StateVector::default(),
             changed: HashMap::default(),
             changed_parent_types: Vec::default(),
@@ -534,7 +534,7 @@ impl<'doc> TransactionMut<'doc> {
     }
 
     /// Data about deletions performed in the scope of current transaction.
-    pub fn delete_set(&self) -> &DeleteSet {
+    pub fn delete_set(&self) -> &IdSet {
         &self.delete_set
     }
 
@@ -604,8 +604,8 @@ impl<'doc> TransactionMut<'doc> {
 
     /// Applies given `id_set` onto current transaction to run multi-range deletion.
     /// Returns a remaining of original ID set, that couldn't be applied.
-    pub(crate) fn apply_delete(&mut self, ds: &DeleteSet) -> Option<DeleteSet> {
-        let mut unapplied = DeleteSet::new();
+    pub(crate) fn apply_delete(&mut self, ds: &IdSet) -> Option<IdSet> {
+        let mut unapplied = IdSet::new();
         for (client, ranges) in ds.iter() {
             if let Some(mut blocks) = self.store.blocks.get_client_mut(client) {
                 let state = blocks.clock();
@@ -1103,7 +1103,7 @@ impl<'doc> TransactionMut<'doc> {
     /// If `delete_set` is provided, it will be used to limit the scope of garbage collection
     /// to only those blocks that are present in the delete set. If `delete_set` is `None`, all
     /// deleted blocks will be considered for garbage collection.
-    pub fn gc(&mut self, delete_set: Option<&DeleteSet>) {
+    pub fn gc(&mut self, delete_set: Option<&IdSet>) {
         GCCollector::collect_all(self, delete_set);
     }
 
@@ -1126,7 +1126,7 @@ impl<'doc> TransactionMut<'doc> {
 
     /// Checks if item with a given `id` has been deleted within this transaction.
     pub(crate) fn has_deleted(&self, id: &ID) -> bool {
-        self.delete_set.is_deleted(id)
+        self.delete_set.contains(id)
     }
 
     pub(crate) fn split_by_snapshot(&mut self, snapshot: &Snapshot) {
@@ -1150,7 +1150,7 @@ impl<'doc> TransactionMut<'doc> {
         }
 
         self.merge_blocks.append(&mut merge_blocks);
-        let mut deleted = snapshot.delete_set.deleted_blocks();
+        let mut deleted = snapshot.delete_set.blocks();
         while let Some(slice) = deleted.next(self) {
             if let BlockSlice::Item(slice) = slice {
                 //TODO: we technically don't need to physically split underlying item in two

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -202,8 +202,8 @@ where
             // append change to last stack op
             if let Some(last_op) = stack.last_mut() {
                 // always true - we checked if stack is empty above
-                last_op.deletions.merge(txn.delete_set.clone());
-                last_op.insertions.merge(insertions);
+                last_op.deletions.merge_with(txn.delete_set.clone());
+                last_op.insertions.merge_with(insertions);
             }
         } else {
             // create a new stack op
@@ -956,8 +956,8 @@ impl<M> StackItem<M> {
     where
         F: FnOnce(&mut M, M),
     {
-        self.insertions.merge(other.insertions);
-        self.deletions.merge(other.deletions);
+        self.insertions.merge_with(other.insertions);
+        self.deletions.merge_with(other.deletions);
         merge_meta(&mut self.meta, other.meta);
     }
 }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -1,11 +1,11 @@
 use crate::block::ItemPtr;
 use crate::branch::{Branch, BranchPtr};
+use crate::id_set::DeleteSet;
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::sync::Clock;
 use crate::transaction::Origin;
-use crate::updates::encoder::Encode;
-use crate::{DeleteSet, Doc, Observer, ReadTxn, Transact, TransactionAcqError, TransactionMut, ID};
+use crate::{Doc, IdSet, Observer, ReadTxn, Transact, TransactionAcqError, TransactionMut, ID};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashSet;
@@ -178,7 +178,7 @@ where
             }
         }
 
-        let mut insertions = DeleteSet::new();
+        let mut insertions = IdSet::new();
         for (client, &end_clock) in txn.after_state().iter() {
             let start_clock = txn.before_state.get(client);
             let diff = end_clock - start_clock;
@@ -216,7 +216,7 @@ where
         }
         // make sure that deleted structs are not gc'd
         let ds = txn.delete_set.clone();
-        let mut deleted = ds.deleted_blocks();
+        let mut deleted = ds.blocks();
         while let Some(slice) = deleted.next(txn) {
             if let Some(item) = slice.as_item() {
                 if inner.scope.iter().any(|b| b.is_parent_of(Some(item))) {
@@ -510,7 +510,7 @@ where
     }
 
     fn clear_item<T: ReadTxn>(scope: &HashSet<BranchPtr>, txn: &T, stack_item: StackItem<M>) {
-        let mut deleted = stack_item.deletions.deleted_blocks();
+        let mut deleted = stack_item.deletions.blocks();
         while let Some(slice) = deleted.next(txn) {
             if let Some(item) = slice.as_item() {
                 if scope.iter().any(|b| b.is_parent_of(Some(item))) {
@@ -756,7 +756,7 @@ where
             let mut to_delete = Vec::<ItemPtr>::new();
             let mut change_performed = false;
 
-            let deleted: Vec<_> = item.insertions.deleted_blocks().collect(txn);
+            let deleted: Vec<_> = item.insertions.blocks().collect(txn);
             for slice in deleted {
                 if let BlockSlice::Item(slice) = slice {
                     let mut item = txn.store.materialize(slice);
@@ -771,12 +771,12 @@ where
                 }
             }
 
-            let mut deleted = item.deletions.deleted_blocks();
+            let mut deleted = item.deletions.blocks();
             while let Some(slice) = deleted.next(txn) {
                 if let BlockSlice::Item(slice) = slice {
                     let ptr = txn.store.materialize(slice);
                     if scope.iter().any(|b| b.is_parent_of(Some(ptr)))
-                        && !item.insertions.is_deleted(ptr.id())
+                        && !item.insertions.contains(ptr.id())
                     // Never redo structs in stackItem.insertions because they were created and deleted in the same capture interval.
                     {
                         to_redo.insert(ptr);
@@ -853,7 +853,7 @@ impl<M> DerefMut for UndoStack<M> {
 impl<M> UndoStack<M> {
     pub fn is_deleted(&self, id: &ID) -> bool {
         for item in self.0.iter() {
-            if item.deletions.is_deleted(id) {
+            if item.deletions.contains(id) {
                 return true;
             }
         }
@@ -915,8 +915,8 @@ impl<M> Default for Options<M> {
 /// the end of the last stack item batch.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct StackItem<T> {
-    deletions: DeleteSet,
-    insertions: DeleteSet,
+    deletions: IdSet,
+    insertions: IdSet,
 
     /// A custom user metadata that can be attached to a particular [StackItem]. It can be used
     /// to carry over the additional information (such as ie. user cursor position) between
@@ -925,7 +925,7 @@ pub struct StackItem<T> {
 }
 
 impl<M> StackItem<M> {
-    pub fn with_meta(deletions: DeleteSet, insertions: DeleteSet, meta: M) -> Self {
+    pub fn with_meta(deletions: IdSet, insertions: IdSet, meta: M) -> Self {
         StackItem {
             deletions,
             insertions,
@@ -935,13 +935,13 @@ impl<M> StackItem<M> {
 
     /// A set of identifiers of element deleted at part of the timeframe current [StackItem] is
     /// responsible for.
-    pub fn deletions(&self) -> &DeleteSet {
+    pub fn deletions(&self) -> &IdSet {
         &self.deletions
     }
 
     /// A set of identifiers of element inserted at part of the timeframe current [StackItem] is
     /// responsible for.
-    pub fn insertions(&self) -> &DeleteSet {
+    pub fn insertions(&self) -> &IdSet {
         &self.insertions
     }
 
@@ -963,7 +963,7 @@ impl<M> StackItem<M> {
 }
 
 impl<M: Default> StackItem<M> {
-    pub fn new(deletions: DeleteSet, insertions: DeleteSet) -> Self {
+    pub fn new(deletions: IdSet, insertions: IdSet) -> Self {
         Self::with_meta(deletions, insertions, M::default())
     }
 }

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -10,7 +10,7 @@ use crate::block::{
 };
 use crate::encoding::read::Error;
 use crate::error::UpdateError;
-use crate::id_set::{DeleteSet, IdSet};
+use crate::id_set::IdSet;
 use crate::slice::ItemSlice;
 #[cfg(test)]
 use crate::store::Store;
@@ -91,7 +91,7 @@ impl std::fmt::Display for BlockCarrier {
 #[derive(Default, PartialEq)]
 pub struct Update {
     pub(crate) blocks: UpdateBlocks,
-    pub(crate) delete_set: DeleteSet,
+    pub(crate) delete_set: IdSet,
 }
 
 impl Update {
@@ -192,7 +192,7 @@ impl Update {
     }
 
     /// Returns a delete set associated with current update.
-    pub fn delete_set(&self) -> &DeleteSet {
+    pub fn delete_set(&self) -> &IdSet {
         &self.delete_set
     }
 
@@ -375,7 +375,7 @@ impl Update {
                 Some(PendingUpdate {
                     update: Update {
                         blocks: remaining,
-                        delete_set: DeleteSet::new(),
+                        delete_set: IdSet::new(),
                     },
                     missing: missing_sv,
                 })
@@ -827,7 +827,7 @@ impl Decode for Update {
             }
         }
         // read delete set
-        let delete_set = DeleteSet::decode(decoder)?;
+        let delete_set = IdSet::decode(decoder)?;
         Ok(Update { blocks, delete_set })
     }
 }
@@ -1171,7 +1171,7 @@ mod test {
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::Encode;
     use crate::{
-        merge_updates_v1, Any, DeleteSet, Doc, GetString, Options, ReadTxn, StateVector, Text,
+        merge_updates_v1, Any, Doc, GetString, IdSet, Options, ReadTxn, StateVector, Text,
         Transact, WriteTxn, XmlFragment, XmlOut, ID,
     };
 
@@ -1565,7 +1565,7 @@ mod test {
                     ]),
                 )]),
             },
-            delete_set: DeleteSet::default(),
+            delete_set: IdSet::default(),
         }
     }
 

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -188,7 +188,6 @@ impl Update {
                 }
             }
         }
-        insertions.squash();
         insertions
     }
 

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -626,7 +626,7 @@ impl Update {
         let update_blocks: Vec<UpdateBlocks> = block_stores
             .into_iter()
             .map(|update| {
-                result.delete_set.merge(update.delete_set);
+                result.delete_set.merge_with(update.delete_set);
                 update.blocks
             })
             .collect();

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -13,7 +13,9 @@ use serde::Serialize;
 
 /// Serialize a value to JsValue using JSON-compatible settings.
 /// This ensures maps are serialized as plain JS objects (not ES2015 Map).
-pub fn to_js<T: Serialize + ?Sized>(value: &T) -> std::result::Result<JsValue, serde_wasm_bindgen::Error> {
+pub fn to_js<T: Serialize + ?Sized>(
+    value: &T,
+) -> std::result::Result<JsValue, serde_wasm_bindgen::Error> {
     value.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
 }
 use std::collections::{Bound, HashMap};
@@ -569,7 +571,7 @@ pub(crate) mod convert {
     use yrs::types::text::{ChangeKind, Diff, YChange};
     use yrs::types::{Change, Delta, EntryChange, Event, Events, Path, PathSegment};
     use yrs::updates::decoder::Decode;
-    use yrs::{DeleteSet, Doc, StateVector, TransactionMut};
+    use yrs::{Doc, IdSet, StateVector, TransactionMut};
 
     pub fn js_into_delta(js: JsValue) -> crate::Result<Delta<Js>> {
         let attributes = js_sys::Reflect::get(&js, &JsValue::from("attributes"));
@@ -661,8 +663,7 @@ pub(crate) mod convert {
                 )?;
 
                 if let Some(attrs) = attrs {
-                    let attrs = to_js(attrs)
-                        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+                    let attrs = to_js(attrs).map_err(|e| JsValue::from_str(&e.to_string()))?;
                     js_sys::Reflect::set(&result, &JsValue::from("attributes"), &attrs)?;
                 }
             }
@@ -671,8 +672,7 @@ pub(crate) mod convert {
                 js_sys::Reflect::set(&result, &JsValue::from("retain"), &value)?;
 
                 if let Some(attrs) = attrs {
-                    let attrs = to_js(&attrs)
-                        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+                    let attrs = to_js(&attrs).map_err(|e| JsValue::from_str(&e.to_string()))?;
                     js_sys::Reflect::set(&result, &JsValue::from("attributes"), &attrs)?;
                 }
             }
@@ -742,7 +742,7 @@ pub(crate) mod convert {
         map
     }
 
-    pub fn delete_set_to_js(ds: &DeleteSet) -> js_sys::Map {
+    pub fn delete_set_to_js(ds: &IdSet) -> js_sys::Map {
         let map = js_sys::Map::new();
         for (&client_id, range) in ds.iter() {
             let r = js_sys::Array::new();
@@ -766,8 +766,7 @@ pub(crate) mod convert {
             ChangeKind::Removed => JsValue::from("removed"),
         };
         let result = if let Some(func) = compute_ychange {
-            let id =
-                to_js(&change.id).map_err(|e| JsValue::from_str(&e.to_string()))?;
+            let id = to_js(&change.id).map_err(|e| JsValue::from_str(&e.to_string()))?;
             func.call2(&JsValue::UNDEFINED, &kind, &id).unwrap()
         } else {
             let js: JsValue = js_sys::Object::new().into();


### PR DESCRIPTION
Renamed `DeleteSet` to `IdSet`. Improved operation speed and added union/intersection/exclusion methods.