### PR TITLE
Client 53bit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,11 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: build default
-        run: cargo test --release --all-features -p yrs -p yffi
+      - name: test default
+        run: cargo test --release -p yrs
+
+      - name: test all
+        run: cargo test --release --all-features -p yrs
 
   wasm:
     runs-on: ubuntu-latest

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -318,7 +318,7 @@ impl Into<Options> for YOptions {
             Some(str)
         };
         Options {
-            client_id: self.id as ClientID,
+            client_id: ClientID::new(self.id),
             guid,
             collection_id,
             skip_gc: if self.skip_gc == 0 { false } else { true },
@@ -332,7 +332,7 @@ impl Into<Options> for YOptions {
 impl From<Options> for YOptions {
     fn from(o: Options) -> Self {
         YOptions {
-            id: o.client_id,
+            id: o.client_id.get(),
             guid: CString::new(o.guid.as_ref()).unwrap().into_raw(),
             collection_id: if let Some(collection_id) = o.collection_id {
                 CString::new(collection_id.to_string()).unwrap().into_raw()
@@ -431,7 +431,7 @@ pub extern "C" fn ydoc_new_with_options(options: YOptions) -> *mut Doc {
 #[no_mangle]
 pub unsafe extern "C" fn ydoc_id(doc: *mut Doc) -> u64 {
     let doc = doc.as_ref().unwrap();
-    doc.client_id()
+    doc.client_id().get()
 }
 
 /// Returns a unique document identifier of this [Doc] instance.
@@ -3975,7 +3975,7 @@ impl YStateVector {
         let mut client_ids = Vec::with_capacity(sv.len());
         let mut clocks = Vec::with_capacity(sv.len());
         for (&client, &clock) in sv.iter() {
-            client_ids.push(client as u64);
+            client_ids.push(client.get());
             clocks.push(clock as u32);
         }
 
@@ -5843,7 +5843,7 @@ pub unsafe extern "C" fn ybranch_id(branch: *const Branch) -> YBranchId {
     let branch = branch.as_ref().unwrap();
     match branch.id() {
         BranchID::Nested(id) => YBranchId {
-            client_or_len: id.client as i64,
+            client_or_len: id.client.get() as i64,
             variant: YBranchIdVariant { clock: id.clock },
         },
         BranchID::Root(name) => {
@@ -5872,7 +5872,7 @@ pub unsafe extern "C" fn ybranch_get(
     let branch_id = branch_id.as_ref().unwrap();
     let client_or_len = branch_id.client_or_len;
     let ptr = if client_or_len >= 0 {
-        BranchID::get_nested(txn, &ID::new(client_or_len as u64, branch_id.variant.clock))
+        BranchID::get_nested(txn, &ID::new(ClientID::new(client_or_len as u64), branch_id.variant.clock))
     } else {
         let name = std::slice::from_raw_parts(branch_id.variant.name, (-client_or_len) as usize);
         BranchID::get_root(txn, std::str::from_utf8_unchecked(name))

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -4019,7 +4019,7 @@ impl YDeleteSet {
         let mut ranges = Vec::with_capacity(len);
 
         for (&client, range) in ds.iter() {
-            client_ids.push(client);
+            client_ids.push(client.get());
             let seq: Vec<_> = range
                 .iter()
                 .map(|r| YIdRange {

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -14,6 +14,7 @@ readme = "./README.md"
 default = []
 weak = []
 sync = []
+small-client = []
 
 [dependencies]
 thiserror = "2"

--- a/yrs/benches/id_set.rs
+++ b/yrs/benches/id_set.rs
@@ -1,8 +1,8 @@
 use criterion::*;
-use yrs::{IdSet, ID};
+use yrs::{ClientID, IdSet, ID};
 
-const CLIENT_A: u64 = 1;
-const CLIENT_B: u64 = 2;
+const CLIENT_A: ClientID = ClientID::new(1);
+const CLIENT_B: ClientID = ClientID::new(2);
 
 // Base set: 10 ranges for one client, spaced with gaps.
 // Pattern: [0..5), [10..15), [20..25), ..., [90..95).

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -84,14 +84,16 @@ type CID = u32;
 pub struct ClientID(CID);
 
 impl ClientID {
+    const MASK: u64 = u64::MAX << 53; // all 1 shifted by 53 bit
     /// Creates a [ClientID] from a yjs-compatible client identifier value.
     #[inline]
     pub const fn new(value: u64) -> Self {
         // SAFETY: (value << 1) | 1 is always >= 1
         #[cfg(not(feature = "small-client"))]
         {
-            debug_assert!(value < (1 << 53));
-            return ClientID(unsafe { std::num::NonZeroU64::new_unchecked((value << 1) | 1) });
+            // client ID should be 53bit: assert that we don't run over it
+            debug_assert!(value & Self::MASK == 0);
+            return ClientID(unsafe { std::num::NonZeroU64::new_unchecked(value | Self::MASK) });
         }
 
         #[cfg(feature = "small-client")]
@@ -105,7 +107,7 @@ impl ClientID {
     pub const fn get(&self) -> u64 {
         #[cfg(not(feature = "small-client"))]
         {
-            return self.0.get() >> 1;
+            return self.0.get() & !Self::MASK;
         }
 
         #[cfg(feature = "small-client")]

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -86,7 +86,7 @@ pub struct ClientID(CID);
 impl ClientID {
     /// Creates a [ClientID] from a yjs-compatible client identifier value.
     #[inline]
-    pub fn new(value: u64) -> Self {
+    pub const fn new(value: u64) -> Self {
         // SAFETY: (value << 1) | 1 is always >= 1
         #[cfg(not(feature = "small-client"))]
         {
@@ -102,7 +102,7 @@ impl ClientID {
 
     /// Returns the original yjs-compatible client identifier value.
     #[inline]
-    pub fn get(&self) -> u64 {
+    pub const fn get(&self) -> u64 {
         #[cfg(not(feature = "small-client"))]
         {
             return self.0.get() >> 1;

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -71,9 +71,85 @@ pub const HAS_ORIGIN: u8 = 0b10000000;
 /// for blocks which act as map-like types entries.
 pub const HAS_PARENT_SUB: u8 = 0b00100000;
 
-/// Globally unique client identifier. No two active peers are allowed to share the same [ClientID].
+#[cfg(not(feature = "small-client"))]
+type CID = std::num::NonZeroU64;
+
+#[cfg(feature = "small-client")]
+type CID = u32;
+
+/// Globally unique 53-bit client identifier. No two active peers are allowed to share the same [ClientID].
 /// If that happens, following updates may cause document store to be corrupted and desync in a result.
-pub type ClientID = u64;
+#[repr(transparent)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct ClientID(CID);
+
+impl ClientID {
+    /// Creates a [ClientID] from a yjs-compatible client identifier value.
+    #[inline]
+    pub fn new(value: u64) -> Self {
+        // SAFETY: (value << 1) | 1 is always >= 1
+        #[cfg(not(feature = "small-client"))]
+        {
+            debug_assert!(value < (1 << 53));
+            return ClientID(unsafe { std::num::NonZeroU64::new_unchecked((value << 1) | 1) });
+        }
+
+        #[cfg(feature = "small-client")]
+        {
+            return ClientID(value as u32);
+        }
+    }
+
+    /// Returns the original yjs-compatible client identifier value.
+    #[inline]
+    pub fn get(&self) -> u64 {
+        #[cfg(not(feature = "small-client"))]
+        {
+            return self.0.get() >> 1;
+        }
+
+        #[cfg(feature = "small-client")]
+        {
+            return self.0 as u64;
+        }
+    }
+
+    /// Generates a random 53bit [ClientID] (safe for JavaScript).
+    /// When `small-client` feature is used generates a 32-bit client ID (for old compatiblity).
+    pub fn random() -> Self {
+        let mut rng = fastrand::Rng::new();
+        #[cfg(not(feature = "small-client"))]
+        let value = rng.u64(0..(1u64 << 53));
+        #[cfg(feature = "small-client")]
+        let value = rng.u32(0..u32::MAX) as u64;
+        Self::new(value)
+    }
+}
+
+impl std::fmt::Debug for ClientID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ClientID({})", self.get())
+    }
+}
+
+impl std::fmt::Display for ClientID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get())
+    }
+}
+
+impl Serialize for ClientID {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.get().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ClientID {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = u64::deserialize(deserializer)?;
+        Ok(ClientID::new(value))
+    }
+}
 
 /// Block identifier, which allows to uniquely identify any element insertion in a global scope
 /// (across different replicas of the same document). It consists of client ID (which is a unique
@@ -1156,13 +1232,13 @@ impl BlockRange {
     /// # Example:
     ///
     /// ```rust
-    /// use yrs::block::BlockRange;
+    /// use yrs::block::{BlockRange, ClientID};
     /// use yrs::ID;
-    /// let a = BlockRange::new(ID::new(1, 2), 8); // range of clocks [2..10)
+    /// let a = BlockRange::new(ID::new(ClientID::new(1), 2), 8); // range of clocks [2..10)
     /// let b = a.slice(3); // range of clocks [5..10)
     ///
-    /// assert_eq!(b.id, ID::new(1, 5));
-    /// assert_eq!(b.last_id(), ID::new(1, 10));
+    /// assert_eq!(b.id, ID::new(ClientID::new(1), 5));
+    /// assert_eq!(b.last_id(), ID::new(ClientID::new(1), 10));
     /// ```
     pub fn slice(&self, offset: u32) -> Self {
         let mut next = self.clone();
@@ -2255,5 +2331,16 @@ mod test {
         let (a, b) = split_str(&s, 30, OffsetKind::Bytes);
         assert_eq!(a, "Zażółć gęślą jaźń😀");
         assert_eq!(b, "ありがとうございます");
+    }
+
+    #[test]
+    fn size_of_types() {
+        use super::*;
+        use std::mem::size_of;
+        println!("ClientID: {}", size_of::<ClientID>());
+        println!("Option<ClientID>: {}", size_of::<Option<ClientID>>());
+        println!("ID: {}", size_of::<ID>());
+        println!("Option<ID>: {}", size_of::<Option<ID>>());
+        println!("Item: {}", size_of::<Item>());
     }
 }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -99,8 +99,8 @@ impl Doc {
 
     /// Creates a new document with a specified `client_id`. It's up to a caller to guarantee that
     /// this identifier is unique across all communicating replicas of that document.
-    pub fn with_client_id(client_id: ClientID) -> Self {
-        Self::with_options(Options::with_client_id(client_id))
+    pub fn with_client_id(client_id: u64) -> Self {
+        Self::with_options(Options::with_client_id(ClientID::new(client_id)))
     }
 
     /// Creates a new document with a configured set of [Options].
@@ -956,10 +956,10 @@ impl Options {
 
 impl Default for Options {
     fn default() -> Self {
+        let client_id = ClientID::random();
         let mut rng = fastrand::Rng::new();
-        let client_id: u32 = rng.u32(0..u32::MAX);
         let uuid = uuid_v4_from(rng.u128(..));
-        Self::with_guid_and_client_id(uuid, client_id as ClientID)
+        Self::with_guid_and_client_id(uuid, client_id)
     }
 }
 
@@ -1205,6 +1205,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "small-client")]
     fn pending_update_integration() {
         let doc = Doc::new();
         let txt = doc.get_or_insert_text("source");
@@ -1252,6 +1253,7 @@ mod test {
         for u in updates {
             let mut txn = doc.transact_mut();
             let u = Update::decode_v1(u.as_slice()).unwrap();
+            println!("integrate pending update: {u:#?}");
             txn.apply_update(u).unwrap();
         }
         assert_eq!(txt.get_string(&doc.transact()), "abcd".to_string());
@@ -1448,7 +1450,7 @@ mod test {
         let _sub = d1.observe_update_v1(move |_: &TransactionMut, e| {
             let u = Update::decode_v1(&e.update).unwrap();
             for (&client_id, range) in u.delete_set.iter() {
-                if client_id == 1 {
+                if client_id == ClientID::new(1) {
                     let mut aref = a.lock().unwrap();
                     for r in range.iter() {
                         aref.push(r.clone());
@@ -1506,7 +1508,7 @@ mod test {
 
     #[test]
     fn snapshots_splitting_text() {
-        let mut options = Options::with_client_id(1);
+        let mut options = Options::with_client_id(ClientID::new(1));
         options.skip_gc = true;
 
         let d1 = Doc::with_options(options);
@@ -2240,7 +2242,7 @@ mod test {
     fn apply_snapshot_updates() {
         let update = {
             let doc = Doc::with_options(Options {
-                client_id: 1,
+                client_id: ClientID::new(1),
                 skip_gc: true,
                 offset_kind: OffsetKind::Utf16,
                 ..Options::default()
@@ -2375,7 +2377,7 @@ mod test {
             actual,
             Some(Arc::new((
                 StateVector::default(),
-                StateVector::from_iter([(1, 11)]),
+                StateVector::from_iter([(ClientID::new(1), 11)]),
                 IdSet::default()
             )))
         );
@@ -2385,11 +2387,11 @@ mod test {
         assert_eq!(
             actual,
             Some(Arc::new((
-                StateVector::from_iter([(1, 11)]),
-                StateVector::from_iter([(1, 11)]),
+                StateVector::from_iter([(ClientID::new(1), 11)]),
+                StateVector::from_iter([(ClientID::new(1), 11)]),
                 {
                     let mut ds = IdSet::new();
-                    ds.insert(ID::new(1, 2), 7);
+                    ds.insert(ID::new(ClientID::new(1), 2), 7);
                     ds
                 }
             )))
@@ -2414,7 +2416,7 @@ mod test {
     #[test]
     fn force_gc() {
         let doc = Doc::with_options(Options {
-            client_id: 1,
+            client_id: ClientID::new(1),
             skip_gc: true,
             ..Default::default()
         });
@@ -2437,7 +2439,7 @@ mod test {
                 let block = txn
                     .store()
                     .blocks
-                    .get_block(&ID::new(1, i))
+                    .get_block(&ID::new(ClientID::new(1), i))
                     .unwrap()
                     .as_item()
                     .unwrap();
@@ -2451,7 +2453,11 @@ mod test {
         doc.transact_mut().gc(None);
 
         let txn = doc.transact();
-        let block = txn.store().blocks.get_block(&ID::new(1, 1)).unwrap();
+        let block = txn
+            .store()
+            .blocks
+            .get_block(&ID::new(ClientID::new(1), 1))
+            .unwrap();
         assert_eq!(block.len(), 3, "GCed blocks should be squashed");
         assert!(block.is_deleted(), "`abc` should be deleted");
         assert_matches!(&block, &BlockCell::GC(_));
@@ -2460,7 +2466,7 @@ mod test {
     #[test]
     fn force_gc_with_delete_set() {
         let doc = Doc::with_options(Options {
-            client_id: 1,
+            client_id: ClientID::new(1),
             skip_gc: true,
             ..Default::default()
         });
@@ -2507,7 +2513,7 @@ mod test {
                 let block = txn
                     .store()
                     .blocks
-                    .get_block(&ID::new(1, i))
+                    .get_block(&ID::new(ClientID::new(1), i))
                     .unwrap()
                     .as_item()
                     .unwrap();
@@ -2522,7 +2528,11 @@ mod test {
 
         // verify that we GC 'abc' blocks and compressed them
         let txn = doc.transact();
-        let block = txn.store().blocks.get_block(&ID::new(1, 1)).unwrap();
+        let block = txn
+            .store()
+            .blocks
+            .get_block(&ID::new(ClientID::new(1), 1))
+            .unwrap();
         assert_eq!(
             block,
             &BlockCell::GC(GC::new(1, 3)),

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -524,7 +524,7 @@ impl Encode for IdSet {
         encoder.write_var(self.0.len() as u32);
         for (&client_id, block) in self.0.iter() {
             encoder.reset_ds_cur_val();
-            encoder.write_var(client_id);
+            encoder.write_var(client_id.get());
             block.encode(encoder);
         }
     }
@@ -537,9 +537,9 @@ impl Decode for IdSet {
         let mut i = 0;
         while i < client_len {
             decoder.reset_ds_cur_val();
-            let client: u32 = decoder.read_var()?;
+            let client: u64 = decoder.read_var()?;
             let range = IdRange::decode(decoder)?;
-            set.0.insert(client as ClientID, range);
+            set.0.insert(ClientID::new(client), range);
             i += 1;
         }
         Ok(set)
@@ -814,7 +814,7 @@ impl<'ds> TxnIterator for Blocks<'ds> {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockRange, ItemContent};
+    use crate::block::{BlockRange, ClientID, ItemContent};
     use crate::id_set::{DeleteSet, IdRange, IdSet};
     use crate::iter::TxnIterator;
     use crate::slice::BlockSlice;
@@ -1051,24 +1051,24 @@ mod test {
     #[test]
     fn id_set_remove() {
         // Removing from a client absent from the set is a no-op.
-        let mut set = IdSet::from_iter([(1, [0..10])]);
-        set.remove_range(&BlockRange::new(ID::new(2, 0), 5));
-        assert_eq!(set, IdSet::from_iter([(1, [0..10])]));
+        let mut set = IdSet::from_iter([(ClientID::new(1), [0..10])]);
+        set.remove_range(&BlockRange::new(ID::new(ClientID::new(2), 0), 5));
+        assert_eq!(set, IdSet::from_iter([(ClientID::new(1), [0..10])]));
 
         // Partial removal — split.
-        let mut set = IdSet::from_iter([(1, [0..10])]);
-        set.remove_range(&BlockRange::new(ID::new(1, 3), 4));
-        assert_eq!(set, IdSet::from_iter([(1, [0..3, 7..10])]));
+        let mut set = IdSet::from_iter([(ClientID::new(1), [0..10])]);
+        set.remove_range(&BlockRange::new(ID::new(ClientID::new(1), 3), 4));
+        assert_eq!(set, IdSet::from_iter([(ClientID::new(1), [0..3, 7..10])]));
 
         // Removing the entire IdRange drops the client.
-        let mut set = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
-        set.remove_range(&BlockRange::new(ID::new(1, 0), 10));
-        assert_eq!(set, IdSet::from_iter([(2, [0..5])]));
+        let mut set = IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [0..5])]);
+        set.remove_range(&BlockRange::new(ID::new(ClientID::new(1), 0), 10));
+        assert_eq!(set, IdSet::from_iter([(ClientID::new(2), [0..5])]));
 
         // Empty len is a no-op.
-        let mut set = IdSet::from_iter([(1, [0..10])]);
-        set.remove_range(&BlockRange::new(ID::new(1, 5), 0));
-        assert_eq!(set, IdSet::from_iter([(1, [0..10])]));
+        let mut set = IdSet::from_iter([(ClientID::new(1), [0..10])]);
+        set.remove_range(&BlockRange::new(ID::new(ClientID::new(1), 5), 0));
+        assert_eq!(set, IdSet::from_iter([(ClientID::new(1), [0..10])]));
     }
 
     #[test]
@@ -1214,51 +1214,54 @@ mod test {
     #[test]
     fn id_set_exclude() {
         // Clients only in `self` are untouched; clients only in `other` are ignored.
-        let mut a = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
-        let b = IdSet::from_iter([(2, [0..3]), (3, [0..100])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [0..5])]);
+        let b = IdSet::from_iter([(ClientID::new(2), [0..3]), (ClientID::new(3), [0..100])]);
         a.diff_with(&b);
-        assert_eq!(a, IdSet::from_iter([(1, [0..10]), (2, [3..5])]));
+        assert_eq!(
+            a,
+            IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [3..5])])
+        );
 
         // Per-client exclude carves the right shape (split into two).
-        let mut a = IdSet::from_iter([(1, [0..10])]);
-        let b = IdSet::from_iter([(1, [3..7])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
+        let b = IdSet::from_iter([(ClientID::new(1), [3..7])]);
         a.diff_with(&b);
-        assert_eq!(a, IdSet::from_iter([(1, [0..3, 7..10])]));
+        assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [0..3, 7..10])]));
 
         // Clients whose ranges become empty are dropped entirely.
-        let mut a = IdSet::from_iter([(1, [0..5]), (2, [0..5])]);
-        let b = IdSet::from_iter([(1, [0..5])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..5]), (ClientID::new(2), [0..5])]);
+        let b = IdSet::from_iter([(ClientID::new(1), [0..5])]);
         a.diff_with(&b);
-        assert_eq!(a, IdSet::from_iter([(2, [0..5])]));
+        assert_eq!(a, IdSet::from_iter([(ClientID::new(2), [0..5])]));
 
         // Excluding an empty other is a no-op.
-        let mut a = IdSet::from_iter([(1, [0..10])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         a.diff_with(&IdSet::new());
-        assert_eq!(a, IdSet::from_iter([(1, [0..10])]));
+        assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [0..10])]));
     }
 
     #[test]
     fn id_set_intersect() {
         // Clients present only in `self` are dropped.
-        let mut a = IdSet::from_iter([(1, [0..10]), (2, [0..5])]);
-        let b = IdSet::from_iter([(1, [5..15])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [0..5])]);
+        let b = IdSet::from_iter([(ClientID::new(1), [5..15])]);
         a.intersect_with(&b);
-        assert_eq!(a, IdSet::from_iter([(1, [5..10])]));
+        assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [5..10])]));
 
         // Clients present only in `other` are ignored.
-        let mut a = IdSet::from_iter([(1, [0..10])]);
-        let b = IdSet::from_iter([(1, [3..7]), (2, [0..100])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
+        let b = IdSet::from_iter([(ClientID::new(1), [3..7]), (ClientID::new(2), [0..100])]);
         a.intersect_with(&b);
-        assert_eq!(a, IdSet::from_iter([(1, [3..7])]));
+        assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [3..7])]));
 
         // Clients whose intersection is empty (disjoint ranges) are dropped.
-        let mut a = IdSet::from_iter([(1, [0..5]), (2, [0..5])]);
-        let b = IdSet::from_iter([(1, [10..20]), (2, [1..4])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..5]), (ClientID::new(2), [0..5])]);
+        let b = IdSet::from_iter([(ClientID::new(1), [10..20]), (ClientID::new(2), [1..4])]);
         a.intersect_with(&b);
-        assert_eq!(a, IdSet::from_iter([(2, [1..4])]));
+        assert_eq!(a, IdSet::from_iter([(ClientID::new(2), [1..4])]));
 
         // Intersecting with an empty other yields empty.
-        let mut a = IdSet::from_iter([(1, [0..10])]);
+        let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         a.intersect_with(&IdSet::new());
         assert!(a.is_empty());
     }
@@ -1266,9 +1269,9 @@ mod test {
     #[test]
     fn id_set_encode_decode() {
         let mut set = IdSet::new();
-        set.insert(ID::new(124, 0), 1);
-        set.insert(ID::new(1337, 0), 12);
-        set.insert(ID::new(124, 1), 3);
+        set.insert(ID::new(ClientID::new(124), 0), 1);
+        set.insert(ID::new(ClientID::new(1337), 0), 12);
+        set.insert(ID::new(ClientID::new(124), 1), 3);
 
         roundtrip(&set);
     }
@@ -1289,12 +1292,12 @@ mod test {
     #[test]
     fn deleted_blocks() {
         let mut o = Options::default();
-        o.client_id = 1;
+        o.client_id = ClientID::new(1);
         o.skip_gc = true;
         let d1 = Doc::with_options(o.clone());
         let t1 = d1.get_or_insert_text("test");
 
-        o.client_id = 2;
+        o.client_id = ClientID::new(2);
         let d2 = Doc::with_options(o);
         let t2 = d2.get_or_insert_text("test");
 
@@ -1341,10 +1344,10 @@ mod test {
         };
 
         let expected = HashSet::from([
-            (true, ID::new(1, 0), 1, "a".to_owned()),
-            (true, ID::new(1, 4), 1, "a".to_owned()),
-            (true, ID::new(1, 7), 1, "b".to_owned()),
-            (true, ID::new(2, 1), 2, "cc".to_owned()),
+            (true, ID::new(ClientID::new(1), 0), 1, "a".to_owned()),
+            (true, ID::new(ClientID::new(1), 4), 1, "a".to_owned()),
+            (true, ID::new(ClientID::new(1), 7), 1, "b".to_owned()),
+            (true, ID::new(ClientID::new(2), 1), 2, "cc".to_owned()),
         ]);
 
         assert_eq!(blocks, expected);
@@ -1356,7 +1359,7 @@ mod test {
         let doc = Doc::with_client_id(1);
         let txt = doc.get_or_insert_text("test");
         txt.push(&mut doc.transact_mut(), "testab");
-        ds.insert(ID::new(1, 5), 1);
+        ds.insert(ID::new(ClientID::new(1), 5), 1);
         let txn = doc.transact_mut();
         let mut i = ds.blocks();
         let ptr = i.next(&txn).unwrap();

--- a/yrs/src/iter.rs
+++ b/yrs/src/iter.rs
@@ -545,6 +545,7 @@ where
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::iter::{BlockIterator, BlockSliceIterator, IntoBlockIter, TxnIterator};
     use crate::test_utils::exchange_updates;
     use crate::{Array, Assoc, Doc, StickyIndex, Transact, ID};
@@ -718,8 +719,8 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 1), Assoc::Before);
-        let to = StickyIndex::from_id(ID::new(1, 4), Assoc::After);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 1), Assoc::Before);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 4), Assoc::After);
         let res: Vec<_> = array
             .as_ref()
             .start
@@ -741,8 +742,8 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 1), Assoc::After);
-        let to = StickyIndex::from_id(ID::new(1, 4), Assoc::After);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 1), Assoc::After);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 4), Assoc::After);
         let res: Vec<_> = array
             .as_ref()
             .start
@@ -764,8 +765,8 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 2), Assoc::After);
-        let to = StickyIndex::from_id(ID::new(1, 4), Assoc::After);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 2), Assoc::After);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 4), Assoc::After);
         let res: Vec<_> = array
             .as_ref()
             .start
@@ -787,8 +788,8 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 1), Assoc::Before);
-        let to = StickyIndex::from_id(ID::new(1, 5), Assoc::Before);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 1), Assoc::Before);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 5), Assoc::Before);
         let res: Vec<_> = array
             .as_ref()
             .start
@@ -810,8 +811,8 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 1), Assoc::Before);
-        let to = StickyIndex::from_id(ID::new(1, 4), Assoc::Before);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 1), Assoc::Before);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 4), Assoc::Before);
         let res: Vec<_> = array
             .as_ref()
             .start
@@ -860,7 +861,7 @@ mod test {
 
         let txn = doc.transact();
         let from = StickyIndex::from_type(&txn, &array, Assoc::Before);
-        let to = StickyIndex::from_id(ID::new(1, 2), Assoc::After);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 2), Assoc::After);
         let res: Vec<_> = array
             .as_ref()
             .start
@@ -882,7 +883,7 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 2), Assoc::Before);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 2), Assoc::Before);
         let to = StickyIndex::from_type(&txn, &array, Assoc::After);
         let res: Vec<_> = array
             .as_ref()
@@ -905,8 +906,8 @@ mod test {
         array.insert_range(&mut doc.transact_mut(), 4, [5, 6]);
 
         let txn = doc.transact();
-        let from = StickyIndex::from_id(ID::new(1, 1), Assoc::Before);
-        let to = StickyIndex::from_id(ID::new(1, 1), Assoc::After);
+        let from = StickyIndex::from_id(ID::new(ClientID::new(1), 1), Assoc::Before);
+        let to = StickyIndex::from_id(ID::new(ClientID::new(1), 1), Assoc::After);
         let res: Vec<_> = array
             .as_ref()
             .start

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -249,24 +249,27 @@
 //! collections and convert into [WeakRef] shared type.
 //!
 //! ```rust
-//! use yrs::{Doc, Text, Transact, GetString, Quotable, Map};
+//! #[cfg(feature = "weak")]
+//! fn example() {
+//!     use yrs::{Doc, Text, Transact, GetString, Quotable, Map};
 //!
-//! let doc = Doc::new();
-//! let text = doc.get_or_insert_text("text");
-//! let map = doc.get_or_insert_map("map");
-//! let mut txn = doc.transact_mut();
-//! text.insert(&mut txn, 0, "hello!");
-//! let quote = text.quote(&txn, 0..5).unwrap();
-//! let quote = map.insert(&mut txn, "title", quote);
+//!     let doc = Doc::new();
+//!     let text = doc.get_or_insert_text("text");
+//!     let map = doc.get_or_insert_map("map");
+//!     let mut txn = doc.transact_mut();
+//!     text.insert(&mut txn, 0, "hello!");
+//!     let quote = text.quote(&txn, 0..5).unwrap();
+//!     let quote = map.insert(&mut txn, "title", quote);
 //!
-//! // retrieve quoted text fragment
-//! assert_eq!(quote.get_string(&txn), "hello".to_string());
+//!     // retrieve quoted text fragment
+//!     assert_eq!(quote.get_string(&txn), "hello".to_string());
 //!
-//! // quotations are actively reacting to changes happening at source within quoted range
-//! text.insert(&mut txn, 5, " world");
-//! // since quoted range 0..5 was right-side exclusive, index 5 itself is not included in range,
-//! // but inserts between position 4 and 5 are
-//! assert_eq!(quote.get_string(&txn), "hello world".to_string());
+//!     // quotations are actively reacting to changes happening at source within quoted range
+//!     text.insert(&mut txn, 5, " world");
+//!     // since quoted range 0..5 was right-side exclusive, index 5 itself is not included in range,
+//!     // but inserts between position 4 and 5 are
+//!     assert_eq!(quote.get_string(&txn), "hello world".to_string());
+//! }
 //! ```
 //!
 //! Weak refs also expose observer API that allows to subscribe to changes happening in source
@@ -276,22 +279,25 @@
 //! collection removes a quoted element, it will no longer be accessible from weak ref:
 //!
 //! ```rust
-//! use yrs::{Doc, Transact, Quotable, Map};
+//! #[cfg(feature = "weak")]
+//! fn example() {
+//!     use yrs::{Doc, Transact, Quotable, Map};
 //!
-//! let doc = Doc::new();
-//! let map = doc.get_or_insert_map("map");
-//! let mut txn = doc.transact_mut();
-//! map.insert(&mut txn, "origin", "value");
-//! // establish a link 'origin' entry
-//! let link = map.link(&txn, "origin").unwrap();
-//! let link = map.insert(&mut txn, "link", link);
-//! let linked_value: String = link.try_deref(&txn).unwrap();
-//! assert_eq!(linked_value, "value".to_string());
+//!     let doc = Doc::new();
+//!     let map = doc.get_or_insert_map("map");
+//!     let mut txn = doc.transact_mut();
+//!     map.insert(&mut txn, "origin", "value");
+//!     // establish a link 'origin' entry
+//!     let link = map.link(&txn, "origin").unwrap();
+//!     let link = map.insert(&mut txn, "link", link);
+//!     let linked_value: String = link.try_deref(&txn).unwrap();
+//!     assert_eq!(linked_value, "value".to_string());
 //!
-//! // remove original value
-//! map.remove(&mut txn, "origin");
-//! let linked_value = link.try_deref_value(&txn);
-//! assert_eq!(linked_value, None); // linked value is no longer accessible
+//!     // remove original value
+//!     map.remove(&mut txn, "origin");
+//!     let linked_value = link.try_deref_value(&txn);
+//!     assert_eq!(linked_value, None); // linked value is no longer accessible
+//! }
 //! ```
 //!
 //! # Undo/redo

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -12,6 +12,9 @@
 //!
 //! # Features
 //!
+//! - `small-client` this feature is used for compatibility with older versions of
+//!    yrs (v0.26 and below) and yjs (pre v14). It uses 32bit [crate::ClientID]. The current default
+//!    uses 53-bit (max safe integer number in JavaScript/Yjs).
 //! - `weak` this feature enables weak references and quotations (see: [crate::WeakRef]).
 //! - `sync` this feature modifies observers callback constraints to use `Send` and `Sync` traits.
 //!   These are required when using yrs features in multithreaded environments.
@@ -157,7 +160,7 @@
 //! on following example:
 //!
 //! ```rust
-//! use yrs::{Doc, GetString, ReadTxn, StateVector, Text, Transact, Update};
+//! use yrs::{Doc, ClientID, GetString, ReadTxn, StateVector, Text, Transact, Update};
 //! use yrs::updates::decoder::Decode;
 //!
 //! let doc1 = Doc::with_client_id(1);
@@ -192,7 +195,7 @@
 //! location, that will persist between concurrent updates being made:
 //!
 //! ```rust
-//! use yrs::{Assoc, Doc, GetString, ReadTxn, IndexedSequence, StateVector, Text, Transact, Update};
+//! use yrs::{Assoc, ClientID, Doc, GetString, ReadTxn, IndexedSequence, StateVector, Text, Transact, Update};
 //! use yrs::updates::decoder::Decode;
 //!
 //! let doc1 = Doc::with_client_id(1);
@@ -200,7 +203,7 @@
 //! let mut txn1 = doc1.transact_mut();
 //! text1.insert(&mut txn1, 0, "hello");
 //!
-//! let doc2 = Doc::with_client_id(2);
+//! let doc2 = Doc::with_client_id(1);
 //! let text2 = doc2.get_or_insert_text("article");
 //! let mut txn2 = doc2.transact_mut();
 //! text2.insert(&mut txn2, 0, "world");
@@ -463,7 +466,7 @@
 //! replicas living on other peers. This is possible via hooks:
 //!
 //! ```rust
-//! use yrs::{Array, ArrayRef, Doc, Hook, MapPrelim, ReadTxn, RootRef, SharedRef, Transact, Update};
+//! use yrs::{Array, ArrayRef, ClientID, Doc, Hook, MapPrelim, ReadTxn, RootRef, SharedRef, Transact, Update};
 //! use yrs::types::ToJson;
 //! use yrs::updates::decoder::Decode;
 //!
@@ -643,6 +646,7 @@ pub use crate::alt::{
     encode_state_vector_from_update_v2, merge_updates_v1, merge_updates_v2,
 };
 pub use crate::any::Any;
+pub use crate::block::ClientID;
 pub use crate::block::ID;
 pub use crate::branch::BranchID;
 pub use crate::branch::Hook;

--- a/yrs/src/moving.rs
+++ b/yrs/src/moving.rs
@@ -1,4 +1,4 @@
-use crate::block::{ItemContent, ItemPtr, Prelim, Unused};
+use crate::block::{ClientID, ItemContent, ItemPtr, Prelim, Unused};
 use crate::block_iter::BlockIter;
 use crate::branch::{Branch, BranchPtr};
 use crate::encoding::read::Error;
@@ -294,11 +294,11 @@ impl Encode for Move {
         };
         encoder.write_var(flags);
         let id = self.start.id().unwrap();
-        encoder.write_var(id.client);
+        encoder.write_var(id.client.get());
         encoder.write_var(id.clock);
         if !is_collapsed {
             let id = self.end.id().unwrap();
-            encoder.write_var(id.client);
+            encoder.write_var(id.client.get());
             encoder.write_var(id.clock);
         }
     }
@@ -321,11 +321,13 @@ impl Decode for Move {
         //TODO use BIT3 & BIT4 to indicate the case `null` is the start/end
         // BIT5 is reserved for future extensions
         let priority = flags >> 6;
-        let start_id = ID::new(decoder.read_var()?, decoder.read_var()?);
+        let start_client = ClientID::new(decoder.read_var::<u64>()?);
+        let start_id = ID::new(start_client, decoder.read_var()?);
         let end_id = if is_collapsed {
             start_id
         } else {
-            ID::new(decoder.read_var()?, decoder.read_var()?)
+            let end_client = ClientID::new(decoder.read_var::<u64>()?);
+            ID::new(end_client, decoder.read_var()?)
         };
         let start = StickyIndex::new(IndexScope::Relative(start_id), start_assoc);
         let end = StickyIndex::new(IndexScope::Relative(end_id), end_assoc);
@@ -826,12 +828,12 @@ impl Encode for IndexScope {
         match self {
             IndexScope::Relative(id) => {
                 encoder.write_var(0);
-                encoder.write_var(id.client);
+                encoder.write_var(id.client.get());
                 encoder.write_var(id.clock);
             }
             IndexScope::Nested(id) => {
                 encoder.write_var(2);
-                encoder.write_var(id.client);
+                encoder.write_var(id.client.get());
                 encoder.write_var(id.clock);
             }
             IndexScope::Root(type_name) => {
@@ -847,7 +849,7 @@ impl Decode for IndexScope {
         let tag: u8 = decoder.read_var()?;
         match tag {
             0 => {
-                let client = decoder.read_var()?;
+                let client = ClientID::new(decoder.read_var::<u64>()?);
                 let clock = decoder.read_var()?;
                 Ok(IndexScope::Relative(ID::new(client, clock)))
             }
@@ -856,7 +858,7 @@ impl Decode for IndexScope {
                 Ok(IndexScope::Root(type_name.into()))
             }
             2 => {
-                let client = decoder.read_var()?;
+                let client = ClientID::new(decoder.read_var::<u64>()?);
                 let clock = decoder.read_var()?;
                 Ok(IndexScope::Nested(ID::new(client, clock)))
             }
@@ -961,12 +963,7 @@ impl Decode for Assoc {
 pub trait IndexedSequence: AsRef<Branch> {
     /// Returns a [StickyIndex] equivalent to a human-readable `index`.
     /// Returns `None` if `index` is beyond the length of current sequence.
-    fn sticky_index<T: ReadTxn>(
-        &self,
-        txn: &T,
-        index: u32,
-        assoc: Assoc,
-    ) -> Option<StickyIndex> {
+    fn sticky_index<T: ReadTxn>(&self, txn: &T, index: u32, assoc: Assoc) -> Option<StickyIndex> {
         StickyIndex::at(txn, BranchPtr::from(self.as_ref()), index, assoc)
     }
 }
@@ -995,6 +992,7 @@ impl Offset {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::moving::Assoc;
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::Encode;
@@ -1140,11 +1138,17 @@ mod test {
         let data: AwarenessData = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(
             data.cursor.anchor,
-            StickyIndex::new(IndexScope::Relative(ID::new(3731284436, 20)), Assoc::Before)
+            StickyIndex::new(
+                IndexScope::Relative(ID::new(ClientID::new(3731284436), 20)),
+                Assoc::Before
+            )
         );
         assert_eq!(
             data.cursor.head,
-            StickyIndex::new(IndexScope::Relative(ID::new(3731284436, 20)), Assoc::Before)
+            StickyIndex::new(
+                IndexScope::Relative(ID::new(ClientID::new(3731284436), 20)),
+                Assoc::Before
+            )
         );
         let json2 = serde_json::to_value(&data).unwrap();
         assert_eq!(

--- a/yrs/src/state_vector.rs
+++ b/yrs/src/state_vector.rs
@@ -120,9 +120,9 @@ impl Decode for StateVector {
         let mut sv = HashMap::with_capacity_and_hasher(len, BuildHasherDefault::default());
         let mut i = 0;
         while i < len {
-            let client = decoder.read_var()?;
+            let client: u64 = decoder.read_var()?;
             let clock = decoder.read_var()?;
-            sv.insert(client, clock);
+            sv.insert(ClientID::new(client), clock);
             i += 1;
         }
         Ok(StateVector(sv))
@@ -133,7 +133,7 @@ impl Encode for StateVector {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         encoder.write_var(self.len());
         for (&client, &clock) in self.iter() {
-            encoder.write_var(client);
+            encoder.write_var(client.get());
             encoder.write_var(clock);
         }
     }
@@ -208,6 +208,7 @@ impl Decode for Snapshot {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::{Doc, ReadTxn, StateVector, Text, Transact, WriteTxn};
     use std::cmp::Ordering;
     use std::iter::FromIterator;
@@ -215,7 +216,11 @@ mod test {
     #[test]
     fn ordering() {
         fn s(a: u32, b: u32, c: u32) -> StateVector {
-            StateVector::from_iter([(1, a), (2, b), (3, c)])
+            StateVector::from_iter([
+                (ClientID::new(1), a),
+                (ClientID::new(2), b),
+                (ClientID::new(3), c),
+            ])
         }
 
         assert_eq!(s(1, 2, 3).partial_cmp(&s(1, 2, 3)), Some(Ordering::Equal));
@@ -226,20 +231,32 @@ mod test {
 
     #[test]
     fn ordering_missing_fields() {
-        let a = StateVector::from_iter([(1, 1), (2, 2)]);
-        let b = StateVector::from_iter([(2, 1), (3, 2)]);
+        let a = StateVector::from_iter([(ClientID::new(1), 1), (ClientID::new(2), 2)]);
+        let b = StateVector::from_iter([(ClientID::new(2), 1), (ClientID::new(3), 2)]);
         assert_eq!(a.partial_cmp(&b), None);
 
-        let a = StateVector::from_iter([(1, 1), (2, 2)]);
-        let b = StateVector::from_iter([(1, 1), (2, 1), (3, 2)]);
+        let a = StateVector::from_iter([(ClientID::new(1), 1), (ClientID::new(2), 2)]);
+        let b = StateVector::from_iter([
+            (ClientID::new(1), 1),
+            (ClientID::new(2), 1),
+            (ClientID::new(3), 2),
+        ]);
         assert_eq!(a.partial_cmp(&b), None);
 
-        let a = StateVector::from_iter([(1, 1), (2, 2), (3, 3)]);
-        let b = StateVector::from_iter([(2, 2), (3, 3)]);
+        let a = StateVector::from_iter([
+            (ClientID::new(1), 1),
+            (ClientID::new(2), 2),
+            (ClientID::new(3), 3),
+        ]);
+        let b = StateVector::from_iter([(ClientID::new(2), 2), (ClientID::new(3), 3)]);
         assert_eq!(a.partial_cmp(&b), Some(Ordering::Greater));
 
-        let a = StateVector::from_iter([(2, 2), (3, 2)]);
-        let b = StateVector::from_iter([(1, 1), (2, 2), (3, 2)]);
+        let a = StateVector::from_iter([(ClientID::new(2), 2), (ClientID::new(3), 2)]);
+        let b = StateVector::from_iter([
+            (ClientID::new(1), 1),
+            (ClientID::new(2), 2),
+            (ClientID::new(3), 2),
+        ]);
         assert_eq!(a.partial_cmp(&b), Some(Ordering::Less));
 
         let a = StateVector::default();

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -540,7 +540,7 @@ impl Encode for AwarenessUpdate {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         encoder.write_var(self.clients.len());
         for (&client_id, e) in self.clients.iter() {
-            encoder.write_var(client_id);
+            encoder.write_var(client_id.get());
             encoder.write_var(e.clock);
             encoder.write_string(&e.json);
         }
@@ -552,7 +552,7 @@ impl Decode for AwarenessUpdate {
         let len: usize = decoder.read_var()?;
         let mut clients = HashMap::with_capacity(len);
         for _ in 0..len {
-            let client_id: ClientID = decoder.read_var()?;
+            let client_id = ClientID::new(decoder.read_var::<u64>()?);
             let clock: u32 = decoder.read_var()?;
             let json: Arc<str> = decoder.read_string()?.into();
             clients.insert(client_id, AwarenessUpdateEntry { clock, json });
@@ -657,6 +657,7 @@ mod test {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use crate::block::ClientID;
     use crate::sync::awareness::{AwarenessUpdateSummary, Event};
     use crate::sync::Awareness;
     use crate::Doc;
@@ -696,20 +697,29 @@ mod test {
         local.set_local_state(json!({"x":3})).unwrap();
         exchange(&update, &local, &mut remote);
         let _e_local = last_change_local.swap(None).unwrap();
-        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":3}));
-        assert_eq!(remote.states.get(&1).unwrap().clock, 1);
-        assert_eq!(last_change_remote.swap(None).unwrap().added(), &[1]);
+        assert_eq!(
+            remote.state::<Value>(ClientID::new(1)).unwrap(),
+            json!({"x":3})
+        );
+        assert_eq!(remote.states.get(&ClientID::new(1)).unwrap().clock, 1);
+        assert_eq!(
+            last_change_remote.swap(None).unwrap().added(),
+            &[ClientID::new(1)]
+        );
 
         local.set_local_state(json!({"x":4})).unwrap();
         exchange(&update, &local, &mut remote);
         let e_local = last_change_local.swap(None).unwrap();
         let e_remote = last_change_remote.swap(None).unwrap();
-        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":4}));
+        assert_eq!(
+            remote.state::<Value>(ClientID::new(1)).unwrap(),
+            json!({"x":4})
+        );
         assert_eq!(
             e_remote.summary,
             AwarenessUpdateSummary {
                 added: vec![],
-                updated: vec![1],
+                updated: vec![ClientID::new(1)],
                 removed: vec![]
             }
         );
@@ -719,8 +729,11 @@ mod test {
         exchange(&update, &local, &mut remote);
         let e_local = last_change_local.swap(None);
         let e_remote = last_change_remote.swap(None);
-        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":4}));
-        assert_eq!(remote.states.get(&1).unwrap().clock, 3);
+        assert_eq!(
+            remote.state::<Value>(ClientID::new(1)).unwrap(),
+            json!({"x":4})
+        );
+        assert_eq!(remote.states.get(&ClientID::new(1)).unwrap().clock, 3);
         assert_eq!(e_remote, e_local);
 
         local.clean_local_state();
@@ -728,7 +741,7 @@ mod test {
         let e_local = last_change_local.swap(None).unwrap();
         let e_remote = last_change_remote.swap(None).unwrap();
         assert_eq!(e_remote.removed().len(), 1);
-        assert!(local.state::<Value>(1).is_none());
+        assert!(local.state::<Value>(ClientID::new(1)).is_none());
         assert_eq!(e_remote.summary, e_local.summary);
         assert_eq!(e_remote, e_local);
     }
@@ -741,12 +754,15 @@ mod test {
         local.set_local_state(json!({"x":3})).unwrap();
         let update = local.update_with_clients([local.client_id()])?;
         let summary = remote.apply_update_summary(update)?;
-        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":3}));
-        assert_eq!(remote.states.get(&1).unwrap().clock, 1);
+        assert_eq!(
+            remote.state::<Value>(ClientID::new(1)).unwrap(),
+            json!({"x":3})
+        );
+        assert_eq!(remote.states.get(&ClientID::new(1)).unwrap().clock, 1);
         assert_eq!(
             summary,
             Some(AwarenessUpdateSummary {
-                added: vec![1],
+                added: vec![ClientID::new(1)],
                 updated: vec![],
                 removed: vec![]
             })
@@ -755,12 +771,15 @@ mod test {
         local.set_local_state(json!({"x":4})).unwrap();
         let update = local.update_with_clients([local.client_id()])?;
         let summary = remote.apply_update_summary(update)?;
-        assert_eq!(remote.state::<Value>(1).unwrap(), json!({"x":4}));
+        assert_eq!(
+            remote.state::<Value>(ClientID::new(1)).unwrap(),
+            json!({"x":4})
+        );
         assert_eq!(
             summary,
             Some(AwarenessUpdateSummary {
                 added: vec![],
-                updated: vec![1],
+                updated: vec![ClientID::new(1)],
                 removed: vec![]
             })
         );
@@ -776,10 +795,10 @@ mod test {
             Some(AwarenessUpdateSummary {
                 added: vec![],
                 updated: vec![],
-                removed: vec![1]
+                removed: vec![ClientID::new(1)]
             })
         );
-        assert!(local.state::<Value>(1).is_none());
+        assert!(local.state::<Value>(ClientID::new(1)).is_none());
         let local_states: HashMap<_, _> = local.iter().collect();
         let remote_states: HashMap<_, _> = remote.iter().collect();
         assert_eq!(local_states, remote_states);

--- a/yrs/src/sync/protocol.rs
+++ b/yrs/src/sync/protocol.rs
@@ -529,6 +529,7 @@ impl<'a, D: Decoder> Iterator for MessageReader<'a, D> {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::encoding::read::Cursor;
     use crate::sync::protocol::MessageReader;
     use crate::sync::{Awareness, Protocol};
@@ -689,6 +690,9 @@ mod test {
             .iter()
             .flat_map(|(id, state)| state.data.map(|data| (id, data)))
             .collect();
-        assert_eq!(a2_clients, HashMap::from([(1, "{\"x\":3}".into())]));
+        assert_eq!(
+            a2_clients,
+            HashMap::from([(ClientID::new(1), "{\"x\":3}".into())])
+        );
     }
 }

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -10,7 +10,7 @@ use crate::encoding::read::{Cursor, Read};
 use crate::transaction::ReadTxn;
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::{Encode, Encoder, EncoderV1};
-use crate::{Doc, StateVector, Transact, Update};
+use crate::{Doc, Options, StateVector, Transact, Update};
 
 pub const EXCHANGE_UPDATES_ORIGIN: &str = "exchange_updates";
 
@@ -103,7 +103,7 @@ impl TestConnector {
     pub fn with_peer_num(rng: Rng, peer_num: u64) -> Self {
         let mut tc = Self::with_rng(rng);
         for client_id in 0..peer_num {
-            let peer = tc.create_peer(client_id as ClientID);
+            let peer = tc.create_peer(ClientID::new(client_id));
             let peer_state = peer.state();
             peer_state.doc.get_or_insert_text("text");
             peer_state.doc.get_or_insert_map("map");
@@ -477,7 +477,7 @@ impl TestPeer {
     pub fn new(client_id: ClientID) -> Self {
         TestPeer {
             state: Arc::new(Mutex::new(TestPeerState {
-                doc: Doc::with_client_id(client_id),
+                doc: Doc::with_options(Options::with_client_id(client_id)),
                 receiving: HashMap::new(),
                 updates: VecDeque::new(),
             })),

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -45,7 +45,8 @@ fn text_insert_delete() {
         97, 98, 193, 152, 234, 173, 126, 4, 152, 234, 173, 126, 0, 1, 129, 152, 234, 173, 126, 2,
         1, 132, 152, 234, 173, 126, 6, 2, 104, 105, 1, 152, 234, 173, 126, 2, 0, 3, 5, 2,
     ];
-    const CLIENT_ID: ClientID = 264992024;
+    #[allow(non_snake_case)]
+    let CLIENT_ID: ClientID = ClientID::new(264992024);
     let expected_blocks = vec![
         Item::new(
             ID::new(CLIENT_ID, 0),
@@ -147,7 +148,8 @@ fn map_set() {
            console.log(payload_v2);
         ```
     */
-    const CLIENT_ID: ClientID = 440166001;
+    #[allow(non_snake_case)]
+    let CLIENT_ID: ClientID = ClientID::new(440166001);
     let expected = vec![
         Item::new(
             ID::new(CLIENT_ID, 0),
@@ -203,7 +205,8 @@ fn array_insert() {
            console.log(payload_v2);
         ```
     */
-    const CLIENT_ID: ClientID = 2525665872;
+    #[allow(non_snake_case)]
+    let CLIENT_ID: ClientID = ClientID::new(2525665872);
     let expected = vec![Item::new(
         ID::new(CLIENT_ID, 0),
         None,
@@ -246,7 +249,8 @@ fn xml_fragment_insert() {
            console.log(payload_v2);
         ```
     */
-    const CLIENT_ID: ClientID = 2459881872;
+    #[allow(non_snake_case)]
+    let CLIENT_ID: ClientID = ClientID::new(2459881872);
     let expected = vec![
         Item::new(
             ID::new(CLIENT_ID, 0),
@@ -307,8 +311,8 @@ fn state_vector() {
     */
     let payload = &[2, 178, 219, 218, 44, 3, 190, 212, 225, 6, 2];
     let mut expected = StateVector::default();
-    expected.inc_by(14182974, 2);
-    expected.inc_by(93760946, 3);
+    expected.inc_by(ClientID::new(14182974), 2);
+    expected.inc_by(ClientID::new(93760946), 3);
 
     let sv = StateVector::decode_v1(payload).unwrap();
     assert_eq!(sv, expected);

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1244,6 +1244,12 @@ impl From<String> for Origin {
     }
 }
 
+impl From<crate::block::ClientID> for Origin {
+    fn from(v: crate::block::ClientID) -> Origin {
+        Origin(SmallVec::from_slice(&v.get().to_be_bytes()))
+    }
+}
+
 impl std::fmt::Debug for Origin {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -638,6 +638,7 @@ impl ArrayEvent {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::test_utils::{exchange_updates, run_scenario, RngExt};
     use crate::types::map::MapPrelim;
     use crate::types::{Change, DeepObservable, Event, Out, Path, PathSegment, ToJson};
@@ -1051,7 +1052,9 @@ mod test {
         }
         assert_eq!(
             added.swap(None),
-            Some(HashSet::from([ID::new(1, 0), ID::new(1, 1)]).into())
+            Some(
+                HashSet::from([ID::new(ClientID::new(1), 0), ID::new(ClientID::new(1), 1)]).into()
+            )
         );
         assert_eq!(removed.swap(None), Some(HashSet::new().into()));
         assert_eq!(
@@ -1072,7 +1075,7 @@ mod test {
         assert_eq!(added.swap(None), Some(HashSet::new().into()));
         assert_eq!(
             removed.swap(None),
-            Some(HashSet::from([ID::new(1, 0)]).into())
+            Some(HashSet::from([ID::new(ClientID::new(1), 0)]).into())
         );
         assert_eq!(delta.swap(None), Some(vec![Change::Removed(1)].into()));
 
@@ -1082,7 +1085,7 @@ mod test {
         }
         assert_eq!(
             added.swap(None),
-            Some(HashSet::from([ID::new(1, 2)]).into())
+            Some(HashSet::from([ID::new(ClientID::new(1), 2)]).into())
         );
         assert_eq!(removed.swap(None), Some(HashSet::new().into()));
         assert_eq!(
@@ -1118,7 +1121,7 @@ mod test {
 
         assert_eq!(
             added.swap(None),
-            Some(HashSet::from([ID::new(1, 1)]).into())
+            Some(HashSet::from([ID::new(ClientID::new(1), 1)]).into())
         );
         assert_eq!(removed.swap(None), Some(HashSet::new().into()));
         assert_eq!(

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -10,7 +10,7 @@ pub use map::MapRef;
 pub use text::Text;
 pub use text::TextRef;
 
-use crate::block::{Item, ItemContent, ItemPtr, Prelim};
+use crate::block::{ClientID, Item, ItemContent, ItemPtr, Prelim};
 use crate::branch::{Branch, BranchPtr};
 use crate::encoding::read::Error;
 use crate::transaction::TransactionMut;
@@ -121,7 +121,7 @@ impl TypeRef {
         encoder.write_u8(info);
         match data.quote_start.scope() {
             IndexScope::Relative(id) | IndexScope::Nested(id) => {
-                encoder.write_var(id.client);
+                encoder.write_var(id.client.get());
                 encoder.write_var(id.clock);
             }
             IndexScope::Root(name) => {
@@ -131,14 +131,14 @@ impl TypeRef {
 
         match data.quote_end.scope() {
             IndexScope::Relative(id) if !is_single => {
-                encoder.write_var(id.client);
+                encoder.write_var(id.client.get());
                 encoder.write_var(id.clock);
             }
             IndexScope::Relative(id) => {
                 // for single element id is the same as start so we can infer it
             }
             IndexScope::Nested(id) => {
-                encoder.write_var(id.client);
+                encoder.write_var(id.client.get());
                 encoder.write_var(id.clock);
             }
             IndexScope::Root(name) => {
@@ -170,10 +170,10 @@ impl TypeRef {
                 let name = decoder.read_string()?;
                 IndexScope::Root(name.into())
             } else {
-                IndexScope::Nested(ID::new(decoder.read_var()?, decoder.read_var()?))
+                IndexScope::Nested(ID::new(ClientID::new(decoder.read_var::<u64>()?), decoder.read_var()?))
             }
         } else {
-            IndexScope::Relative(ID::new(decoder.read_var()?, decoder.read_var()?))
+            IndexScope::Relative(ID::new(ClientID::new(decoder.read_var::<u64>()?), decoder.read_var()?))
         };
 
         let end_scope = if is_end_unbounded {
@@ -181,12 +181,12 @@ impl TypeRef {
                 let name = decoder.read_string()?;
                 IndexScope::Root(name.into())
             } else {
-                IndexScope::Nested(ID::new(decoder.read_var()?, decoder.read_var()?))
+                IndexScope::Nested(ID::new(ClientID::new(decoder.read_var::<u64>()?), decoder.read_var()?))
             }
         } else if is_single {
             start_scope.clone()
         } else {
-            IndexScope::Relative(ID::new(decoder.read_var()?, decoder.read_var()?))
+            IndexScope::Relative(ID::new(ClientID::new(decoder.read_var::<u64>()?), decoder.read_var()?))
         };
         let start = StickyIndex::new(start_scope, start_assoc);
         let end = StickyIndex::new(end_scope, end_assoc);

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1503,6 +1503,7 @@ impl Into<EmbedPrelim<TextPrelim>> for TextPrelim {
 
 #[cfg(test)]
 mod test {
+    use crate::block::ClientID;
     use crate::doc::{OffsetKind, Options};
     use crate::test_utils::{exchange_updates, run_scenario, RngExt};
     use crate::transaction::ReadTxn;
@@ -2497,11 +2498,7 @@ mod test {
             "👩‍❤️‍💋‍👨".len() as u32,
             HashMap::new(),
         );
-        txt.remove_range(
-            &mut txn,
-            "👯❤️❤️🙇‍♀️🙇‍♀️⏰⏰👩‍❤️‍💋‍👩".len() as u32,
-            "👩‍❤️‍💋‍👨".len() as u32,
-        );
+        txt.remove_range(&mut txn, "👯❤️❤️🙇‍♀️🙇‍♀️⏰⏰👩‍❤️‍💋‍👩".len() as u32, "👩‍❤️‍💋‍👨".len() as u32);
         assert_eq!(txt.get_string(&txn).as_str(), "👯❤️❤️🙇‍♀️🙇‍♀️⏰⏰👩‍❤️‍💋‍👨");
     }
 
@@ -2570,7 +2567,10 @@ mod test {
                 Diff::with_change(
                     " world".into(),
                     None,
-                    Some(YChange::new(ChangeKind::Added, ID::new(1, 5)))
+                    Some(YChange::new(
+                        ChangeKind::Added,
+                        ID::new(ClientID::new(1), 5)
+                    ))
                 )
             ]
         )
@@ -2739,7 +2739,7 @@ mod test {
     #[test]
     fn delta_snapshots() {
         let doc = Doc::with_options(Options {
-            client_id: 1,
+            client_id: ClientID::new(1),
             skip_gc: true,
             ..Default::default()
         });
@@ -2784,10 +2784,7 @@ mod test {
                     attributes: None,
                     ychange: Some(YChange {
                         kind: ChangeKind::Added,
-                        id: ID {
-                            client: 1,
-                            clock: 4
-                        }
+                        id: ID::new(ClientID::new(1), 4)
                     })
                 },
                 Diff {
@@ -2795,10 +2792,7 @@ mod test {
                     attributes: None,
                     ychange: Some(YChange {
                         kind: ChangeKind::Removed,
-                        id: ID {
-                            client: 1,
-                            clock: 1
-                        }
+                        id: ID::new(ClientID::new(1), 1)
                     })
                 },
                 Diff {
@@ -2813,7 +2807,7 @@ mod test {
     #[test]
     fn snapshot_delete_after() {
         let doc = Doc::with_options(Options {
-            client_id: 1,
+            client_id: ClientID::new(1),
             skip_gc: true,
             ..Default::default()
         });

--- a/yrs/src/types/weak.rs
+++ b/yrs/src/types/weak.rs
@@ -879,7 +879,7 @@ mod test {
     use crate::Assoc::{After, Before};
     use crate::{
         Array, ArrayRef, DeepObservable, Doc, GetString, Map, MapPrelim, MapRef, Observable,
-        Quotable, ReadTxn, Text, TextRef, Transact, WriteTxn, XmlTextRef,
+        Quotable, Text, TextRef, Transact, WriteTxn, XmlTextRef,
     };
 
     #[test]

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -1056,6 +1056,7 @@ mod test {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
+    use crate::block::ClientID;
     use crate::test_utils::exchange_updates;
     use crate::types::text::{Diff, YChange};
     use crate::types::{Attrs, ToJson};
@@ -1510,7 +1511,7 @@ mod test {
         // This issue has been reported in https://github.com/yjs/yjs/issues/317
         let doc = Doc::with_options(crate::doc::Options {
             skip_gc: true,
-            client_id: 1,
+            client_id: ClientID::new(1),
             ..crate::doc::Options::default()
         });
         let design = doc.get_or_insert_map("map");
@@ -1713,7 +1714,7 @@ mod test {
         // https://github.com/yjs/yjs/issues/343
         let doc = Doc::with_options({
             let mut o = crate::doc::Options::default();
-            o.client_id = 1;
+            o.client_id = ClientID::new(1);
             o.skip_gc = true;
             o
         });

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1058,7 +1058,7 @@ impl Into<Store> for Update {
     fn into(self) -> Store {
         use crate::doc::Options;
 
-        let mut store = Store::new(&Options::with_client_id(0));
+        let mut store = Store::new(&Options::with_client_id(ClientID::new(0)));
         for (_, vec) in self.blocks.clients {
             for block in vec {
                 if let BlockCarrier::Item(block) = block {
@@ -1197,7 +1197,7 @@ mod test {
         let mut decoder = DecoderV1::from(update);
         let u = Update::decode(&mut decoder).unwrap();
 
-        let id = ID::new(2026372272, 0);
+        let id = ID::new(ClientID::new(2026372272), 0);
         let block = u.blocks.clients.get(&id.client).unwrap();
         let mut expected: Vec<BlockCarrier> = Vec::new();
         expected.push(
@@ -1334,7 +1334,7 @@ mod test {
         ];
         let doc = Doc::with_options(Options {
             skip_gc: true,
-            client_id: 1,
+            client_id: ClientID::new(1),
             ..Default::default()
         });
         let prosemirror = doc.get_or_insert_xml_fragment("prosemirror");
@@ -1444,46 +1444,50 @@ mod test {
     fn update_state_vector_with_skips() {
         let mut update = Update::new();
         // skip followed by item => not included in state vector as it's not continuous from 0
-        update
-            .blocks
-            .add_block(BlockCarrier::Skip(BlockRange::new(ID::new(1, 0), 1)));
-        update.blocks.add_block(test_item(1, 1, 1));
+        update.blocks.add_block(BlockCarrier::Skip(BlockRange::new(
+            ID::new(ClientID::new(1), 0),
+            1,
+        )));
+        update.blocks.add_block(test_item(ClientID::new(1), 1, 1));
         // item starting from non-0 => not included
-        update.blocks.add_block(test_item(2, 1, 1));
+        update.blocks.add_block(test_item(ClientID::new(2), 1, 1));
         // item => skip => item : second item not included
-        update.blocks.add_block(test_item(3, 0, 1));
-        update
-            .blocks
-            .add_block(BlockCarrier::Skip(BlockRange::new(ID::new(3, 1), 1)));
-        update.blocks.add_block(test_item(3, 2, 1));
+        update.blocks.add_block(test_item(ClientID::new(3), 0, 1));
+        update.blocks.add_block(BlockCarrier::Skip(BlockRange::new(
+            ID::new(ClientID::new(3), 1),
+            1,
+        )));
+        update.blocks.add_block(test_item(ClientID::new(3), 2, 1));
 
         let sv = update.state_vector();
-        assert_eq!(sv, StateVector::from_iter([(3, 1)]));
+        assert_eq!(sv, StateVector::from_iter([(ClientID::new(3), 1)]));
     }
 
     #[test]
     fn test_extends() {
         let mut u = Update::new();
-        u.blocks.add_block(test_item(1, 0, 2)); // new data with partial duplicate
-        assert!(u.extends(&StateVector::from_iter([(1, 1)])));
+        u.blocks.add_block(test_item(ClientID::new(1), 0, 2)); // new data with partial duplicate
+        assert!(u.extends(&StateVector::from_iter([(ClientID::new(1), 1)])));
 
         let mut u = Update::new();
-        u.blocks.add_block(test_item(1, 0, 1)); // duplicate
-        assert!(!u.extends(&StateVector::from_iter([(1, 1)])));
+        u.blocks.add_block(test_item(ClientID::new(1), 0, 1)); // duplicate
+        assert!(!u.extends(&StateVector::from_iter([(ClientID::new(1), 1)])));
 
         let mut u = Update::new();
-        u.blocks
-            .add_block(BlockCarrier::Skip(BlockRange::new(ID::new(1, 0), 2)));
-        u.blocks.add_block(test_item(1, 2, 1)); // skip cause disjoin in updates
-        assert!(!u.extends(&StateVector::from_iter([(1, 1)])));
+        u.blocks.add_block(BlockCarrier::Skip(BlockRange::new(
+            ID::new(ClientID::new(1), 0),
+            2,
+        )));
+        u.blocks.add_block(test_item(ClientID::new(1), 2, 1)); // skip cause disjoin in updates
+        assert!(!u.extends(&StateVector::from_iter([(ClientID::new(1), 1)])));
 
         let mut u = Update::new();
-        u.blocks.add_block(test_item(1, 1, 1)); // adjacent
-        assert!(u.extends(&StateVector::from_iter([(1, 1)])));
+        u.blocks.add_block(test_item(ClientID::new(1), 1, 1)); // adjacent
+        assert!(u.extends(&StateVector::from_iter([(ClientID::new(1), 1)])));
 
         let mut u = Update::new();
-        u.blocks.add_block(test_item(1, 2, 1)); // disjoint
-        assert!(!u.extends(&StateVector::from_iter([(1, 1)])));
+        u.blocks.add_block(test_item(ClientID::new(1), 2, 1)); // disjoint
+        assert!(!u.extends(&StateVector::from_iter([(ClientID::new(1), 1)])));
     }
 
     #[test]
@@ -1533,11 +1537,11 @@ mod test {
         Update {
             blocks: UpdateBlocks {
                 clients: HashMap::from_iter([(
-                    1,
+                    ClientID::new(1),
                     VecDeque::from_iter([
                         BlockCarrier::Item(
                             Item::new(
-                                ID::new(1, 0),
+                                ID::new(ClientID::new(1), 0),
                                 None,
                                 None,
                                 None,
@@ -1548,12 +1552,12 @@ mod test {
                             )
                             .unwrap(),
                         ),
-                        BlockCarrier::Skip(BlockRange::new(ID::new(1, 5), 3)),
+                        BlockCarrier::Skip(BlockRange::new(ID::new(ClientID::new(1), 5), 3)),
                         BlockCarrier::Item(
                             Item::new(
-                                ID::new(1, 8),
+                                ID::new(ClientID::new(1), 8),
                                 None,
-                                Some(ID::new(1, 7)),
+                                Some(ID::new(ClientID::new(1), 7)),
                                 None,
                                 None,
                                 TypePtr::Unknown,

--- a/yrs/src/updates/decoder.rs
+++ b/yrs/src/updates/decoder.rs
@@ -83,9 +83,12 @@ impl<'a> DecoderV1<'a> {
     }
 
     fn read_id(&mut self) -> Result<ID, Error> {
+        #[cfg(not(feature = "small-client"))]
+        let client: u64 = self.read_var()?;
+        #[cfg(feature = "small-client")]
         let client: u32 = self.read_var()?;
         let clock = self.read_var()?;
-        Ok(ID::new(client as ClientID, clock))
+        Ok(ID::new(ClientID::new(client as u64), clock))
     }
 }
 
@@ -141,8 +144,11 @@ impl<'a> Decoder for DecoderV1<'a> {
 
     #[inline]
     fn read_client(&mut self) -> Result<ClientID, Error> {
+        #[cfg(not(feature = "small-client"))]
+        let client: u64 = self.cursor.read_var()?;
+        #[cfg(feature = "small-client")]
         let client: u32 = self.cursor.read_var()?;
-        Ok(client as ClientID)
+        Ok(ClientID::new(client as u64))
     }
 
     #[inline]
@@ -312,20 +318,20 @@ impl<'a> Decoder for DecoderV2<'a> {
 
     fn read_left_id(&mut self) -> Result<ID, Error> {
         Ok(ID::new(
-            self.client_decoder.read_u64()? as ClientID,
+            ClientID::new(self.client_decoder.read_u64()?),
             self.left_clock_decoder.read_u32()?,
         ))
     }
 
     fn read_right_id(&mut self) -> Result<ID, Error> {
         Ok(ID::new(
-            self.client_decoder.read_u64()? as ClientID,
+            ClientID::new(self.client_decoder.read_u64()?),
             self.right_clock_decoder.read_u32()?,
         ))
     }
 
     fn read_client(&mut self) -> Result<ClientID, Error> {
-        Ok(self.client_decoder.read_u64()? as ClientID)
+        Ok(ClientID::new(self.client_decoder.read_u64()?))
     }
 
     fn read_info(&mut self) -> Result<u8, Error> {

--- a/yrs/src/updates/encoder.rs
+++ b/yrs/src/updates/encoder.rs
@@ -89,7 +89,7 @@ impl EncoderV1 {
     }
 
     fn write_id(&mut self, id: &ID) {
-        self.write_var(id.client);
+        self.write_var(id.client.get());
         self.write_var(id.clock)
     }
 }
@@ -139,7 +139,7 @@ impl Encoder for EncoderV1 {
 
     #[inline]
     fn write_client(&mut self, client: ClientID) {
-        self.write_var(client)
+        self.write_var(client.get())
     }
 
     #[inline]
@@ -277,18 +277,18 @@ impl Encoder for EncoderV2 {
     }
 
     fn write_left_id(&mut self, id: &ID) {
-        self.client_encoder.write_u64(id.client as u64);
+        self.client_encoder.write_u64(id.client.get());
         self.left_clock_encoder.write_u32(id.clock)
     }
 
     fn write_right_id(&mut self, id: &ID) {
-        self.client_encoder.write_u64(id.client as u64);
+        self.client_encoder.write_u64(id.client.get());
         self.right_clock_encoder.write_u32(id.clock)
     }
 
     #[inline]
     fn write_client(&mut self, client: ClientID) {
-        self.client_encoder.write_u64(client as u64)
+        self.client_encoder.write_u64(client.get())
     }
 
     #[inline]

--- a/ywasm/src/awareness.rs
+++ b/ywasm/src/awareness.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
+use yrs::block::ClientID;
 use yrs::sync::{Awareness as YAwareness, AwarenessUpdate, Timestamp};
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
@@ -42,7 +43,7 @@ impl Awareness {
                 last_updated: state.last_updated,
             };
             let info = crate::js::to_js(&info).map_err(|e| JsValue::from_str(&e.to_string()))?;
-            result.set(&JsValue::from_f64(client_id as f64), &info);
+            result.set(&JsValue::from_f64(client_id.get() as f64), &info);
         }
         Ok(result)
     }
@@ -84,7 +85,7 @@ impl Awareness {
         for (client_id, state) in self.inner.iter() {
             if let Some(data) = &state.data {
                 let state = js_sys::JSON::parse(data.as_ref())?;
-                result.set(&JsValue::from_f64(client_id as f64), &state);
+                result.set(&JsValue::from_f64(client_id.get() as f64), &state);
             }
         }
         Ok(result)
@@ -129,7 +130,7 @@ impl Awareness {
 #[wasm_bindgen(js_name = removeAwarenessStates)]
 pub fn remove_states(awareness: &Awareness, clients: Vec<u64>) -> crate::Result<()> {
     for client_id in clients {
-        awareness.inner.remove_state(client_id);
+        awareness.inner.remove_state(ClientID::new(client_id));
     }
     Ok(())
 }
@@ -141,7 +142,7 @@ pub fn encode_update(awareness: &Awareness, clients: JsValue) -> crate::Result<U
     } else {
         let client_ids: Vec<u64> =
             serde_wasm_bindgen::from_value(clients).map_err(|e| JsValue::from_str(&e.to_string()))?;
-        awareness.inner.update_with_clients(client_ids)
+        awareness.inner.update_with_clients(client_ids.into_iter().map(ClientID::new))
     };
 
     let update = res.map_err(|e| JsValue::from_str(&e.to_string()))?;
@@ -155,7 +156,7 @@ pub fn modify_update(update: Uint8Array, modify: js_sys::Function) -> crate::Res
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
     for (client_id, state) in update.clients.iter_mut() {
         let js = js_sys::JSON::parse(&state.json)?;
-        let new_state = modify.call2(&JsValue::NULL, &js, &JsValue::from(*client_id))?;
+        let new_state = modify.call2(&JsValue::NULL, &js, &JsValue::from(client_id.get()))?;
         let json: String = js_sys::JSON::stringify(&new_state)?.into();
         state.json = json.into();
     }

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -13,6 +13,7 @@ use std::ops::Deref;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::types::TYPE_REFS_DOC;
+use yrs::block::ClientID;
 use yrs::{Doc, OffsetKind, Options, ReadTxn, Transact};
 
 /// A ywasm document type. Documents are most important units of collaborative resources management.
@@ -100,7 +101,7 @@ impl YDoc {
     /// Gets unique peer identifier of this `YDoc` instance.
     #[wasm_bindgen(getter)]
     pub fn id(&self) -> f64 {
-        self.client_id() as f64
+        self.client_id().get() as f64
     }
 
     /// Gets globally unique identifier of this `YDoc` instance.
@@ -500,7 +501,7 @@ pub struct DocOptions {
 impl DocOptions {
     fn fill(self, options: &mut Options) {
         if let Some(value) = self.client_id {
-            options.client_id = value;
+            options.client_id = ClientID::new(value);
         }
         if let Some(value) = self.guid {
             options.guid = value.into();

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -735,7 +735,7 @@ pub(crate) mod convert {
         let map = js_sys::Map::new();
         for (&client_id, &clock) in sv.iter() {
             map.set(
-                &JsValue::from_f64(client_id as f64),
+                &JsValue::from_f64(client_id.get() as f64),
                 &JsValue::from_f64(clock as f64),
             );
         }
@@ -752,7 +752,7 @@ pub(crate) mod convert {
                 let segment = js_sys::Array::from_iter([start, end]);
                 r.push(&segment.into());
             }
-            map.set(&JsValue::from_f64(client_id as f64), &r.into());
+            map.set(&JsValue::from_f64(client_id.get() as f64), &r.into());
         }
         map
     }


### PR DESCRIPTION
Obsoletes: #610, #604
Addresses issues in: #609 

This PR changes `ClientID` into its own struct. It modifies the behaviour to use 53bit integers by default (same as yjs v14). For backward compatibility, we still can use old 32bit clients (which are also smaller) by using `small-client` feature flag.

The major caveat is that now "small-client" `ClientID` is `u32` while default one is `NonZeroU64` with bit shift (which is useful because we use `Option<ID>` a lot and this way a lot of structs like `Item` can now be even smaller). This slightly affects performance but within a reasonable threshold.

# Benchmarks

```[B1.1] Append N characters/6000                                                                           
                        time:   [63.644 ms 63.946 ms 64.479 ms]
                        change: [-2.6871% -0.9253% +1.2352%] (p = 0.39 > 0.05)
                        No change in performance detected.

[B1.2] Insert string of length N/1                                                                            
                        time:   [6.1119 µs 6.1240 µs 6.1515 µs]
                        change: [-2.9266% -1.8197% -0.8335%] (p = 0.00 < 0.05)
                        Change within noise threshold.

[B1.3] Prepend N characters/6000                                                                            
                        time:   [3.6499 ms 3.6965 ms 3.7635 ms]
                        change: [-2.1646% -1.1535% -0.0758%] (p = 0.06 > 0.05)
                        No change in performance detected.

[B1.4] Insert N characters at random positions/6000                                                                           
                        time:   [33.412 ms 35.051 ms 35.941 ms]
                        change: [-3.5608% +0.6340% +4.6487%] (p = 0.78 > 0.05)
                        No change in performance detected.

[B1.5] Insert N words at random positions/6000                                                                           
                        time:   [18.402 ms 18.654 ms 18.968 ms]
                        change: [-1.7482% -0.7459% +0.3581%] (p = 0.22 > 0.05)
                        No change in performance detected.

Benchmarking [B1.7] Insert/Delete strings at random positions/6000: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.6s or enable flat sampling.
[B1.7] Insert/Delete strings at random positions/6000                                                                          
                        time:   [396.37 ms 502.14 ms 564.51 ms]
                        change: [-26.340% -2.4293% +25.811%] (p = 0.87 > 0.05)
                        No change in performance detected.

[B1.8] Append N numbers/6000                                                                            
                        time:   [3.4853 ms 3.5158 ms 3.5372 ms]
                        change: [+0.1924% +0.8990% +1.6023%] (p = 0.03 < 0.05)
                        Change within noise threshold.

[B1.9] Insert Array of N numbers/1                                                                           
                        time:   [64.735 µs 67.497 µs 70.343 µs]
                        change: [-5.1406% -1.1757% +2.4960%] (p = 0.62 > 0.05)
                        No change in performance detected.

[B1.10] Prepend N numbers/6000                                                                            
                        time:   [3.9391 ms 3.9489 ms 3.9619 ms]
                        change: [-2.3823% -1.7335% -1.0625%] (p = 0.00 < 0.05)
                        Performance has improved.

[B1.11] Insert N numbers at random positions/6000                                                                           
                        time:   [74.161 ms 74.607 ms 75.756 ms]
                        change: [+11.166% +12.180% +13.483%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B2.1] Concurrently insert string of length N at index 0/6000                                                                            
                        time:   [33.729 µs 33.865 µs 34.021 µs]
                        change: [-1.7442% -0.8458% +0.1045%] (p = 0.12 > 0.05)
                        No change in performance detected.

[B2.2] Concurrently insert N characters at random positions/6000                                                                          
                        time:   [198.48 ms 201.14 ms 204.38 ms]
                        change: [+1.5951% +3.0992% +4.5948%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B2.3] Concurrently insert N words at random positions/6000                                                                          
                        time:   [277.93 ms 279.16 ms 280.46 ms]
                        change: [+1.0340% +2.0913% +3.1225%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B2.4] Concurrently insert & delete/6000                                                                          
                        time:   [858.72 ms 980.95 ms 1.1016 s]
                        change: [-20.010% -3.5276% +14.019%] (p = 0.70 > 0.05)
                        No change in performance detected.

[B3.1] 20√N clients concurrently set number in Map/1540                                                                             
                        time:   [23.429 ms 23.633 ms 23.765 ms]
                        change: [+0.5797% +1.4578% +2.1953%] (p = 0.00 < 0.05)
                        Change within noise threshold.

[B3.2] 20√N clients concurrently set Object in Map/1540                                                                             
                        time:   [23.513 ms 24.111 ms 24.930 ms]
                        change: [+0.5221% +3.2914% +5.6935%] (p = 0.03 < 0.05)
                        Change within noise threshold.

[B3.3] 20√N clients concurrently set String in Map/1540                                                                             
                        time:   [26.753 ms 26.986 ms 27.171 ms]
                        change: [+2.6863% +4.5612% +6.6007%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B3.4] 20√N clients concurrently insert text in Array/1540                                                                             
                        time:   [24.054 ms 24.302 ms 24.723 ms]
                        change: [+3.4850% +5.5202% +7.5955%] (p = 0.00 < 0.05)
                        Performance has regressed.

[B4.2] Apply real-world document snapshot of size/400972                                                                            
                        time:   [1.6794 ms 1.6873 ms 1.6952 ms]
                        change: [-4.0044% -3.3523% -2.7620%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking [B4.1] Apply real-world editing dataset/259778: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 47.9s.
[B4.1] Apply real-world editing dataset/259778                                                                          
                        time:   [4.6892 s 4.7186 s 4.7494 s]
                        change: [-3.6354% -2.7604% -1.9663%] (p = 0.00 < 0.05)
                        Performance has improved.

Gnuplot not found, using plotters backend
id_set/insert_1_then_squash                                                                            
                        time:   [14.056 ns 14.293 ns 14.683 ns]
                        change: [+2.1649% +3.4423% +5.2319%] (p = 0.00 < 0.05)
                        Performance has regressed.

id_set/insert_5_then_squash                                                                            
                        time:   [62.003 ns 62.175 ns 62.366 ns]
                        change: [-1.4109% -0.4378% +0.4421%] (p = 0.37 > 0.05)
                        No change in performance detected.

id_set/merge/disjoint_same_client                                                                             
                        time:   [103.47 ns 103.62 ns 103.79 ns]
                        change: [-5.0487% -4.5666% -4.1080%] (p = 0.00 < 0.05)
                        Performance has improved.
id_set/merge/unique_clients                                                                             
                        time:   [28.465 ns 28.636 ns 28.829 ns]
                        change: [+0.2629% +1.1948% +2.1684%] (p = 0.01 < 0.05)
                        Change within noise threshold.
id_set/merge/overlapping                                                                             
                        time:   [140.61 ns 141.46 ns 142.76 ns]
                        change: [-12.552% -11.852% -11.080%] (p = 0.00 < 0.05)
                        Performance has improved.

id_set/exclude/disjoint_same_client                                                                             
                        time:   [191.09 ns 191.68 ns 192.36 ns]
                        change: [+0.7603% +1.2164% +1.8825%] (p = 0.00 < 0.05)
                        Change within noise threshold.
id_set/exclude/unique_clients                                                                             
                        time:   [41.272 ns 41.481 ns 41.673 ns]
                        change: [+4.7393% +5.8116% +6.9055%] (p = 0.00 < 0.05)
                        Performance has regressed.
id_set/exclude/overlapping                                                                             
                        time:   [204.68 ns 205.30 ns 205.91 ns]
                        change: [+4.8506% +5.2911% +5.7403%] (p = 0.00 < 0.05)
                        Performance has regressed.

id_set/intersect/disjoint_same_client                                                                             
                        time:   [74.223 ns 74.413 ns 74.600 ns]
                        change: [-5.1902% -4.5924% -4.0227%] (p = 0.00 < 0.05)
                        Performance has improved.
id_set/intersect/unique_clients                                                                             
                        time:   [57.630 ns 58.150 ns 59.007 ns]
                        change: [+0.7531% +1.6575% +2.7510%] (p = 0.00 < 0.05)
                        Change within noise threshold.
id_set/intersect/overlapping                                                                             
                        time:   [186.84 ns 187.47 ns 188.19 ns]
                        change: [-1.7905% -1.1074% -0.4686%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```