### PR TITLE
release v0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "yffi"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "serde_json",
  "yrs",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "arc-swap",
  "assert_matches2",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.25.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.26.0", features = ["weak"] }
 serde_json = { version = "1.0" }
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.25.0"
+version = "0.26.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.25.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.26.0", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
- `ClientID` is now a struct (not alias), and supports 53bit space (same as yjs v14): #612
    - For old behaviour (32bit ClientID), use `small-client` feature flag.
- Renamed `DeleteSet` &rarr; `IdSet`: #613
- Fix: applying delete set skipped blocks after GC block was found: #614
