### PR TITLE
IdMap support

### DIFF
--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt::Formatter;
 use std::hash::Hash;
-use std::ops::{Deref, DerefMut};
+use std::ops::{Deref, DerefMut, Range};
 use std::panic;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -1226,6 +1226,11 @@ impl BlockRange {
     /// Returns an [ID] of the last update fitting into the bounds of current [BlockRange]
     pub fn last_id(&self) -> ID {
         ID::new(self.id.client, self.id.clock + self.len)
+    }
+
+    /// Returns a range describing the clocks covered by this [BlockRange].
+    pub fn clock_range(&self) -> Range<u32> {
+        self.id.clock..(self.id.clock + self.len)
     }
 
     /// Returns a slice of a current [BlockRange], which starts at a given offset (relative to

--- a/yrs/src/id_map.rs
+++ b/yrs/src/id_map.rs
@@ -246,6 +246,14 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
         filtered
     }
 
+    /// Converts current [IdMap] into [IdSet] which has equivalent ranges, but is stripped of values.
+    /// The adjacent ranges (which were separated because their values were different) will be
+    /// coalesced together in the result.
+    pub fn as_id_set(&self) -> IdSet {
+        let inner = self.inner.map(|_| ());
+        IdSet(inner)
+    }
+
     /// Add `attrs` to local attribute set of current [IdMap]. If the attribute was already in set,
     /// reuse the already cached version.
     fn ensure_attrs(&mut self, attrs: &mut [ContentAttribute<A>]) {
@@ -762,6 +770,32 @@ mod test {
         let mut ids1_copy = ids1.clone();
         ids1_copy.diff_with(&intersected);
         assert_eq!(ids1_copy, diffed1);
+    }
+
+    #[test]
+    fn as_id_set_merges_adjacent_ranges_with_different_values() {
+        let mut id_map = IdMap::new();
+        let client = ClientID::new(1);
+
+        // [0..3) with value 1, [3..6) with value 2, [8..10) with value 3
+        id_map.insert(
+            BlockRange::new(ID::new(client, 0), 3),
+            vec![ContentAttribute::new("a", 1)],
+        );
+        id_map.insert(
+            BlockRange::new(ID::new(client, 3), 3),
+            vec![ContentAttribute::new("a", 2)],
+        );
+        id_map.insert(
+            BlockRange::new(ID::new(client, 8), 2),
+            vec![ContentAttribute::new("a", 3)],
+        );
+
+        let set = id_map.as_id_set();
+
+        // [0..3) and [3..6) should merge into [0..6); [8..10) stays separate
+        let expected = IdSet::from_iter([(client, [0..6, 8..10])]);
+        assert_eq!(set, expected);
     }
 
     #[ignore]

--- a/yrs/src/id_map.rs
+++ b/yrs/src/id_map.rs
@@ -1,5 +1,6 @@
 use crate::block::{BlockRange, ClientID};
 use crate::encoding::read::Error;
+use crate::encoding::serde::{from_any, to_any};
 use crate::id_set::IdRange;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
@@ -9,8 +10,8 @@ use serde::Serialize;
 use smallvec::{smallvec, SmallVec};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
-use std::hash::{Hash, Hasher};
-use std::ops::{Deref, Index, Range};
+use std::hash::Hash;
+use std::ops::{Deref, Range};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -113,7 +114,7 @@ impl<A: PartialEq + Eq + Hash> IdMap<A> {
         result
     }
 
-    pub fn insert<I>(&mut self, range: BlockRange, attrs: Vec<ContentAttribute<A>>) {
+    pub fn insert(&mut self, range: BlockRange, attrs: Vec<ContentAttribute<A>>) {
         if attrs.is_empty() {
             return;
         }
@@ -305,131 +306,112 @@ impl<A> From<IdMap<A>> for IdSet {
 
 impl<A: Serialize> Encode for IdMap<A> {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
-        encoder.write_var(self.clients.len());
-        let mut last_written_client_id = 0;
-        let mut visited_attributions = HashMap::new();
-        let mut visited_attr_names = HashMap::new();
+        encoder.write_var(self.clients.len() as u32);
+        let mut last_written_client_id: u64 = 0;
+        // Use Arc pointer identity to deduplicate attributions across ranges
+        let mut visited_attributions: HashMap<*const ContentAttributeInner<A>, usize> =
+            HashMap::new();
+        let mut visited_attr_names: HashMap<&str, usize> = HashMap::new();
 
-        // Ensure that the ids are written in a deterministic order (smaller clientids first)
-        let mut keys = self.clients.keys().copied().collect::<Vec<_>>();
+        // Ensure that the ids are written in a deterministic order (smaller client ids first)
+        let mut keys: Vec<_> = self.clients.keys().copied().collect();
         keys.sort();
+
         for client_id in keys {
-            let ranges = self.clients.get(&client_id).unwrap();
-            todo!()
-        }
+            let ranges = &self.clients[&client_id];
+            encoder.reset_ds_cur_val();
+            let diff = client_id.get() - last_written_client_id;
+            encoder.write_var(diff);
+            last_written_client_id = client_id.get();
+            encoder.write_var(ranges.0.len() as u32);
 
-        /*
+            for item in &ranges.0 {
+                encoder.write_ds_clock(item.range.start);
+                encoder.write_ds_len(item.range.end - item.range.start);
+                encoder.write_var(item.attrs.len() as u32);
 
-        encoding.writeVarUint(encoder.restEncoder, idmap.clients.size)
-        let lastWrittenClientId = 0
-        /**
-         * @type {Map<ContentAttribute<Attr>, number>}
-         */
-        const visitedAttributions = map.create()
-        /**
-         * @type {Map<string, number>}
-         */
-        const visitedAttrNames = map.create()
-        // Ensure that the ids are written in a deterministic order (smaller clientids first)
-        array.from(idmap.clients.entries())
-          .sort((a, b) => a[0] - b[0])
-          .forEach(([client, _idRanges]) => {
-            const attrRanges = _idRanges.getIds()
-            encoder.resetIdSetCurVal()
-            const diff = client - lastWrittenClientId
-            encoding.writeVarUint(encoder.restEncoder, diff)
-            lastWrittenClientId = client
-            const len = attrRanges.length
-            encoding.writeVarUint(encoder.restEncoder, len)
-            for (let i = 0; i < len; i++) {
-              const item = attrRanges[i]
-              const attrs = item.attrs
-              const attrLen = attrs.length
-              encoder.writeIdSetClock(item.clock)
-              encoder.writeIdSetLen(item.len)
-              encoding.writeVarUint(encoder.restEncoder, attrLen)
-              for (let j = 0; j < attrLen; j++) {
-                const attr = attrs[j]
-                const attrId = visitedAttributions.get(attr)
-                if (attrId != null) {
-                  encoding.writeVarUint(encoder.restEncoder, attrId)
-                } else {
-                  const newAttrId = visitedAttributions.size
-                  visitedAttributions.set(attr, newAttrId)
-                  encoding.writeVarUint(encoder.restEncoder, newAttrId)
-                  const attrNameId = visitedAttrNames.get(attr.name)
-                  // write attr.name
-                  if (attrNameId != null) {
-                    encoding.writeVarUint(encoder.restEncoder, attrNameId)
-                  } else {
-                    const newAttrNameId = visitedAttrNames.size
-                    encoding.writeVarUint(encoder.restEncoder, newAttrNameId)
-                    encoding.writeVarString(encoder.restEncoder, attr.name)
-                    visitedAttrNames.set(attr.name, newAttrNameId)
-                  }
-                  encoding.writeAny(encoder.restEncoder, /** @type {any} */ (attr.val))
+                for attr in &item.attrs {
+                    let ptr = Arc::as_ptr(&attr.0);
+                    if let Some(&attr_id) = visited_attributions.get(&ptr) {
+                        encoder.write_var(attr_id as u32);
+                    } else {
+                        let new_attr_id = visited_attributions.len();
+                        visited_attributions.insert(ptr, new_attr_id);
+                        encoder.write_var(new_attr_id as u32);
+
+                        let name = &attr.0.name;
+                        if let Some(&name_id) = visited_attr_names.get(name.as_str()) {
+                            encoder.write_var(name_id as u32);
+                        } else {
+                            let new_name_id = visited_attr_names.len();
+                            encoder.write_var(new_name_id as u32);
+                            encoder.write_string(name);
+                            visited_attr_names.insert(name, new_name_id);
+                        }
+
+                        let any = to_any(&attr.0.value).unwrap();
+                        encoder.write_any(&any);
+                    }
                 }
-              }
             }
-          })
-               */
+        }
     }
 }
 
-impl<A: DeserializeOwned> Decode for IdMap<A> {
+impl<A: DeserializeOwned + PartialEq + Eq + Hash> Decode for IdMap<A> {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
-        /*
-        const idmap = new IdMap()
-        const numClients = decoding.readVarUint(decoder.restDecoder)
-        /**
-         * @type {Array<ContentAttribute<any>>}
-         */
-        const visitedAttributions = []
-        /**
-         * @type {Array<string>}
-         */
-        const visitedAttrNames = []
-        let lastClientId = 0
-        for (let i = 0; i < numClients; i++) {
-          decoder.resetDsCurVal()
-          const client = lastClientId + decoding.readVarUint(decoder.restDecoder)
-          lastClientId = client
-          const numberOfDeletes = decoding.readVarUint(decoder.restDecoder)
-          /**
-           * @type {Array<AttrRange<any>>}
-           */
-          const attrRanges = []
-          for (let i = 0; i < numberOfDeletes; i++) {
-            const rangeClock = decoder.readDsClock()
-            const rangeLen = decoder.readDsLen()
-            /**
-             * @type {Array<ContentAttribute<any>>}
-             */
-            const attrs = []
-            const attrsLen = decoding.readVarUint(decoder.restDecoder)
-            for (let j = 0; j < attrsLen; j++) {
-              const attrId = decoding.readVarUint(decoder.restDecoder)
-              if (attrId >= visitedAttributions.length) {
-                // attrId not known yet
-                const attrNameId = decoding.readVarUint(decoder.restDecoder)
-                if (attrNameId >= visitedAttrNames.length) {
-                  visitedAttrNames.push(decoding.readVarString(decoder.restDecoder))
+        let mut id_map = IdMap::new();
+        let num_clients: u32 = decoder.read_var()?;
+        let mut visited_attributions: Vec<ContentAttribute<A>> = Vec::new();
+        let mut visited_attr_names: Vec<String> = Vec::new();
+        let mut last_client_id: u64 = 0;
+
+        for _ in 0..num_clients {
+            decoder.reset_ds_cur_val();
+            let diff: u64 = decoder.read_var()?;
+            let client = last_client_id + diff;
+            last_client_id = client;
+            let num_ranges: u32 = decoder.read_var()?;
+            let mut attr_ranges: SmallVec<[AttrRange<A>; 1]> = SmallVec::new();
+
+            for _ in 0..num_ranges {
+                let range_clock = decoder.read_ds_clock()?;
+                let range_len = decoder.read_ds_len()?;
+                let attrs_len: u32 = decoder.read_var()?;
+                let mut attrs: SmallVec<[ContentAttribute<A>; 2]> = SmallVec::new();
+
+                for _ in 0..attrs_len {
+                    let attr_id: usize = decoder.read_var()?;
+                    if attr_id >= visited_attributions.len() {
+                        let attr_name_id: usize = decoder.read_var()?;
+                        if attr_name_id >= visited_attr_names.len() {
+                            let name = decoder.read_string()?.to_string();
+                            visited_attr_names.push(name);
+                        }
+                        let any = decoder.read_any()?;
+                        let value: A = from_any(&any)?;
+                        visited_attributions.push(ContentAttribute::new(
+                            visited_attr_names[attr_name_id].clone(),
+                            value,
+                        ));
+                    }
+                    attrs.push(visited_attributions[attr_id].clone());
                 }
-                visitedAttributions.push(new ContentAttribute(visitedAttrNames[attrNameId], decoding.readAny(decoder.restDecoder)))
-              }
-              attrs.push(visitedAttributions[attrId])
+
+                attr_ranges
+                    .push(AttrRange::new(range_clock..(range_clock + range_len)).with_attrs(attrs));
             }
-            attrRanges.push(new AttrRange(rangeClock, rangeLen, attrs))
-          }
-          idmap.clients.set(client, new AttrRanges(attrRanges))
+
+            id_map
+                .clients
+                .insert(ClientID::new(client), AttrRanges(attr_ranges));
         }
-        visitedAttributions.forEach(attr => {
-          idmap.attrs.add(attr)
-          idmap.attrsH.set(attr.hash(), attr)
-        })
-        return idmap
-               */
-        todo!()
+
+        for attr in visited_attributions {
+            id_map.attrs.insert(attr);
+        }
+
+        Ok(id_map)
     }
 }
 
@@ -525,8 +507,19 @@ struct ContentAttributeInner<A> {
 }
 
 impl<A> ContentAttribute<A> {
-    pub fn new(name: String, value: A) -> Self {
-        ContentAttribute(Arc::new(ContentAttributeInner { name, value }))
+    pub fn new<S: Into<String>>(name: S, value: A) -> Self {
+        ContentAttribute(Arc::new(ContentAttributeInner {
+            name: name.into(),
+            value,
+        }))
+    }
+
+    pub fn name(&self) -> &str {
+        &self.0.name
+    }
+
+    pub fn value(&self) -> &A {
+        &self.0.value
     }
 }
 
@@ -548,7 +541,7 @@ mod test {
     use crate::id_map::{ContentAttribute, Diff, IdMap};
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::Encode;
-    use crate::{Any, IdSet, ID};
+    use crate::{IdSet, ID};
     use serde::Serialize;
     use std::hash::Hash;
 
@@ -629,7 +622,7 @@ mod test {
 
     #[test]
     fn repeat_merging_mutliple_maps() {
-        const CLIENTS: u32 = 4;
+        const CLIENTS: u64 = 4;
         const CLOCK_RANGE: u32 = 5;
         let mut sets = Vec::new();
         for _ in 0..3 {
@@ -655,7 +648,10 @@ mod test {
                     if !a.attrs.is_empty() {
                         let clock = a.range.start;
                         let len = a.range.end - a.range.start;
-                        composed.insert(BlockRange::new(ID::new(client_id, clock), len), a.attrs);
+                        composed.insert(
+                            BlockRange::new(ID::new(client_id, clock), len),
+                            a.attrs.to_vec(),
+                        );
                     }
                 }
             }
@@ -665,7 +661,7 @@ mod test {
 
     #[test]
     fn repeat_random_diffing() {
-        const CLIENTS: u32 = 4;
+        const CLIENTS: u64 = 4;
         const CLOCK_RANGE: u32 = 5;
         let attrs = vec![1, 2, 3];
         let mut id_map_1 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
@@ -681,7 +677,7 @@ mod test {
 
     #[test]
     fn repeat_random_diffing_2() {
-        const CLIENTS: u32 = 4;
+        const CLIENTS: u64 = 4;
         const CLOCK_RANGE: u32 = 100;
         let attrs = vec![1, 2, 3];
         let mut id_map_1 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
@@ -703,13 +699,13 @@ mod test {
 
     #[test]
     fn repeat_random_deletes() {
-        const CLIENTS: u32 = 1;
+        const CLIENTS: u64 = 1;
         const CLOCK_RANGE: u32 = 100;
         let mut id_map: IdMap<i32> = random_id_map(CLIENTS, CLOCK_RANGE, vec![]);
         let client = *id_map.clients.keys().next().unwrap();
         let clock = fastrand::u32(0..CLOCK_RANGE);
         let len = fastrand::u32(0..((CLOCK_RANGE - clock) as f64 * 1.2).round() as u32); // allow exceeding range to cover more edge cases
-        let mut ds_map = IdMap::new();
+        let mut ds_map: IdMap<i32> = IdMap::new();
         ds_map.insert(BlockRange::new(ID::new(client, clock), len), vec![]);
         let mut diffed = id_map.clone();
         diffed.diff_with(&ds_map);
@@ -724,16 +720,17 @@ mod test {
 
     #[test]
     fn repeat_random_intersects() {
-        const CLIENTS: u32 = 4;
+        const CLIENTS: u64 = 4;
         const CLOCK_RANGE: u32 = 100;
-        let mut ids1: IdMap<Any> = random_id_map(CLIENTS, CLOCK_RANGE, vec![1.into()]);
-        let ids2: IdMap<Any> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["two".into()]);
+        let mut ids1: IdMap<String> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["one".into()]);
+        let ids2: IdMap<String> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["two".into()]);
         let mut intersected = ids1.clone();
         intersected.intersect_with(&ids2);
 
         for client in 0..CLIENTS {
+            let client = ClientID::new(client as u64);
             for clock in 0..CLOCK_RANGE {
-                let id = ID::new(client as ClientID, clock);
+                let id = ID::new(client, clock);
                 assert_eq!(
                     ids1.contains(&id) && ids2.contains(&id),
                     intersected.contains(&id),
@@ -807,7 +804,6 @@ mod test {
           t.info('size per change: ' + math.floor((encAttributions.byteLength / N) * 100) / 100 + ' bytes')
         })
                */
-        todo!()
     }
 
     fn construct<const N: usize>(ops: [(u64, u32, u32, Vec<u32>); N]) -> IdMap<u32> {
@@ -825,12 +821,12 @@ mod test {
         id_map
     }
 
-    fn random_id_set(clients: u32, clock_range: u32) -> IdSet {
+    fn random_id_set(clients: u64, clock_range: u32) -> IdSet {
         const MAX_OPS: u32 = 5;
-        let num_ops = (clients * clock_range) / MAX_OPS;
+        let num_ops = (clients as u32 * clock_range) / MAX_OPS;
         let mut id_set = IdSet::new();
         for _ in 0..num_ops {
-            let client = fastrand::u32(0..(clients - 1)) as ClientID;
+            let client = ClientID::new(fastrand::u64(0..(clients - 1)));
             let clock_start = fastrand::u32(0..clock_range);
             let len = fastrand::u32(0..(clock_range - clock_start));
             id_set.insert(ID::new(client, clock_start), len);
@@ -841,16 +837,16 @@ mod test {
         id_set
     }
 
-    fn random_id_map<T: Hash + Clone + PartialEq + Serialize>(
-        clients: u32,
+    fn random_id_map<T: Hash + Clone + PartialEq + Eq + Serialize>(
+        clients: u64,
         clock_range: u32,
         attr_choices: Vec<T>,
     ) -> IdMap<T> {
         const MAX_OP_LEN: u32 = 5;
-        let num_ops = ((clients * clock_range) / MAX_OP_LEN).max(1);
+        let num_ops = ((clients as u32 * clock_range) / MAX_OP_LEN).max(1);
         let mut id_map = IdMap::new();
         for i in 0..num_ops {
-            let client = fastrand::u32(0..(clients - 1)) as ClientID;
+            let client = ClientID::new(fastrand::u64(0..(clients - 1)));
             let clock_start = fastrand::u32(0..clock_range);
             let len = fastrand::u32(0..(clock_range - clock_start));
             let mut attrs = vec![ContentAttribute::new(

--- a/yrs/src/id_map.rs
+++ b/yrs/src/id_map.rs
@@ -1,57 +1,108 @@
 use crate::block::{BlockRange, ClientID};
 use crate::encoding::read::Error;
 use crate::encoding::serde::{from_any, to_any};
-use crate::id_set::IdRange;
+use crate::ids::{IdMapInner, IdRanges, Merge};
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::{IdSet, ID};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use smallvec::{smallvec, SmallVec};
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use smallvec::SmallVec;
+use std::collections::HashSet;
 use std::hash::Hash;
 use std::ops::{Deref, Range};
 use std::sync::Arc;
 
-#[derive(Debug, Clone)]
-pub struct IdMap<A> {
-    attrs: HashSet<ContentAttribute<A>>,
-    clients: HashMap<ClientID, AttrRanges<A>>,
+// ---------------------------------------------------------------------------
+// ContentAttributes<A> — per-range attribute set with Merge support
+// ---------------------------------------------------------------------------
+
+/// A set of [`ContentAttribute<A>`] values attached to a range.
+/// Implements [`Merge`] by unioning attributes.
+#[derive(Eq, Default, Debug)]
+pub struct ContentAttributes<A>(pub SmallVec<[ContentAttribute<A>; 2]>);
+
+impl<A> Clone for ContentAttributes<A> {
+    fn clone(&self) -> Self {
+        ContentAttributes(self.0.clone())
+    }
 }
 
-impl<A> IdMap<A> {
+impl<A: PartialEq> PartialEq for ContentAttributes<A> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.0.len() != other.0.len() {
+            return false;
+        }
+        // Set equality — every element in self must be in other
+        self.0.iter().all(|a| other.0.contains(a))
+    }
+}
+
+impl<A: PartialEq + Eq + Hash + Clone> Merge for ContentAttributes<A> {
+    fn merge(&mut self, other: &Self) {
+        for attr in &other.0 {
+            if !self.0.contains(attr) {
+                self.0.push(attr.clone());
+            }
+        }
+    }
+}
+
+impl<A> Deref for ContentAttributes<A> {
+    type Target = [ContentAttribute<A>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<A> ContentAttributes<A> {
+    pub fn new() -> Self {
+        ContentAttributes(SmallVec::new())
+    }
+
+    pub fn from_attrs(attrs: SmallVec<[ContentAttribute<A>; 2]>) -> Self {
+        ContentAttributes(attrs)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IdMap<A>
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct IdMap<A: PartialEq + Eq + Hash + Clone> {
+    attrs: HashSet<ContentAttribute<A>>,
+    inner: IdMapInner<ContentAttributes<A>>,
+}
+
+impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
     pub fn new() -> Self {
         IdMap {
-            clients: Default::default(),
+            inner: IdMapInner::new(),
             attrs: Default::default(),
         }
     }
 }
 
-impl<A> Default for IdMap<A> {
+impl<A: PartialEq + Eq + Hash + Clone> Default for IdMap<A> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<A: PartialEq + Eq + Hash> IdMap<A> {
+impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
     pub fn from_set(id_set: IdSet, attrs: Vec<ContentAttribute<A>>) -> Self {
-        let mut id_map = IdMap {
-            clients: HashMap::with_capacity(id_set.len()),
-            attrs: HashSet::with_capacity(attrs.len()),
-        };
+        let mut id_map = IdMap::new();
         let mut attrs: SmallVec<[ContentAttribute<A>; 2]> = attrs.into();
         attrs.dedup();
         id_map.ensure_attrs(&mut attrs);
+        let content_attrs = ContentAttributes(attrs);
         for (client, ranges) in id_set.iter() {
-            let attr_ranges = AttrRanges(
-                ranges
-                    .iter()
-                    .map(|range| AttrRange::new(range.clone()).with_attrs(attrs.clone()))
-                    .collect(),
-            );
-            id_map.clients.insert(*client, attr_ranges);
+            let mut id_ranges = IdRanges::new();
+            for range in ranges.iter() {
+                id_ranges.insert_with(range.clone(), content_attrs.clone());
+            }
+            id_map.inner.clients_mut().insert(*client, id_ranges);
         }
         id_map
     }
@@ -61,14 +112,11 @@ impl<A: PartialEq + Eq + Hash> IdMap<A> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.clients.is_empty()
+        self.inner.is_empty()
     }
 
     pub fn contains(&self, id: &ID) -> bool {
-        if let Some(ranges) = self.clients.get(&id.client) {
-            return Self::range_binary_search(ranges, id.clock).is_some();
-        }
-        false
+        self.inner.contains(id)
     }
 
     pub fn attributions(&self, range: &BlockRange) -> Vec<AttrRange<A>> {
@@ -77,26 +125,32 @@ impl<A: PartialEq + Eq + Hash> IdMap<A> {
         let len = range.len;
         let mut result: Vec<AttrRange<A>> = Vec::new();
 
-        if let Some(dr) = self.clients.get(&client) {
+        if let Some(dr) = self.inner.get(&client) {
             if let Some(mut index) = dr.find_start(clock) {
+                let entries = dr.as_slice();
                 let mut prev_end = clock;
-                while index < dr.len() {
-                    let mut r = dr[index].clone();
-                    if r.range.start < clock {
-                        r.range = clock..r.range.end;
+                while index < entries.len() {
+                    let (ref entry_range, ref entry_attrs) = entries[index];
+                    let mut r_start = entry_range.start;
+                    let mut r_end = entry_range.end;
+                    if r_start < clock {
+                        r_start = clock;
                     }
-                    if r.range.end > clock + len {
-                        r.range = r.range.start..(clock + len);
+                    if r_end > clock + len {
+                        r_end = clock + len;
                     }
-                    if r.range.start >= r.range.end {
+                    if r_start >= r_end {
                         break;
                     }
                     // Fill gap before this range
-                    if prev_end < r.range.start {
-                        result.push(AttrRange::new(prev_end..r.range.start));
+                    if prev_end < r_start {
+                        result.push(AttrRange::new(prev_end..r_start));
                     }
-                    prev_end = r.range.end;
-                    result.push(r);
+                    prev_end = r_end;
+                    result.push(AttrRange {
+                        range: r_start..r_end,
+                        attrs: entry_attrs.clone(),
+                    });
                     index += 1;
                 }
             }
@@ -115,20 +169,15 @@ impl<A: PartialEq + Eq + Hash> IdMap<A> {
     }
 
     pub fn insert(&mut self, range: BlockRange, attrs: Vec<ContentAttribute<A>>) {
-        if attrs.is_empty() {
+        if attrs.is_empty() || range.len == 0 {
             return;
         }
 
         let mut attrs = attrs;
         self.ensure_attrs(&mut attrs);
-        let attr_range =
-            AttrRange::new(range.id.clock..(range.id.clock + range.len)).with_attrs(attrs.into());
-        match self.clients.entry(range.id.client) {
-            Entry::Occupied(mut e) => e.get_mut().insert(attr_range),
-            Entry::Vacant(e) => {
-                e.insert(AttrRanges(smallvec![attr_range]));
-            }
-        }
+        let content_attrs = ContentAttributes(attrs.into());
+        self.inner
+            .insert_range(range.id.client, range.id.clock..(range.id.clock + range.len), content_attrs);
     }
 
     pub fn remove(&mut self, range: &BlockRange) {
@@ -140,88 +189,66 @@ impl<A: PartialEq + Eq + Hash> IdMap<A> {
             return;
         }
 
-        let mut remove_client = false;
-        if let Some(dr) = self.clients.get_mut(&client) {
-            if let Some(mut index) = dr.find_start(clock) {
-                let ids = &mut self.clients.get_mut(&client).unwrap().0;
-                while index < ids.len() && ids[index].range.start < clock + len {
-                    let ar = &mut ids[index];
-                    if ar.range.start < clock + len {
-                        if ar.range.start < clock {
-                            // Range starts before delete region — trim it to end at clock
-                            ar.range = ar.range.start..clock;
-                            if clock + len < ar.range.end {
-                                // Delete doesn't cover the whole range — keep the tail
-                                let mut tail = ar.clone();
-                                tail.range = (clock + len)..ar.range.end;
-                                ids.insert(index + 1, tail);
-                            }
-                            index += 1;
-                        } else if clock + len < ar.range.end {
-                            // Delete ends before this range ends — keep tail
-                            ar.range = (clock + len)..ar.range.end;
-                            index += 1;
-                        } else if ids.len() == 1 {
-                            // Only range for this client — remove entire client entry
-                            remove_client = true;
-                            break;
-                        } else {
-                            // Fully covered by delete — remove this range
-                            ids.remove(index);
-                            // Don't increment: next element shifted into current position
-                        }
-                    } else {
-                        break;
-                    }
-                }
+        if let Some(r) = self.inner.get_mut(&client) {
+            r.remove(clock..(clock + len));
+            if r.is_empty() {
+                self.inner.clients_mut().remove(&client);
             }
-        }
-
-        if remove_client {
-            self.clients.remove(&client);
         }
     }
 
     pub fn merge_with(&mut self, other: Self) {
-        todo!()
+        self.inner.merge_with(&other.inner);
+        // Merge the attr dedup sets
+        for attr in other.attrs {
+            self.attrs.insert(attr);
+        }
     }
 
-    pub fn merge_many(id_maps: &[Self]) -> Self {
-        todo!()
+    pub fn merge_many(id_maps: &[Self]) -> Self
+    where
+        A: Clone,
+    {
+        let mut result = IdMap::new();
+        for map in id_maps {
+            result.inner.merge_with(&map.inner);
+            for attr in &map.attrs {
+                result.attrs.insert(attr.clone());
+            }
+        }
+        result
     }
 
     pub fn intersect_with(&mut self, other: &Self) {
-        todo!()
+        self.inner.intersect_with(&other.inner);
+    }
+
+    pub fn diff_with<T: Merge>(&mut self, other: &IdMapInner<T>) {
+        self.inner.diff_with(other);
     }
 
     pub fn filter<F>(&self, predicate: F) -> Self
     where
         F: Fn(&[ContentAttribute<A>]) -> bool,
+        A: Clone,
     {
-        /*
-        const filtered = createIdMap()
-        idmap.clients.forEach((ranges, client) => {
-          /**
-           * @type {Array<AttrRange<Attrs>>}
-           */
-          const attrRanges = []
-          ranges.getIds().forEach((range) => {
-            if (predicate(range.attrs)) {
-              const rangeCpy = range.copyWith(range.clock, range.len)
-              attrRanges.push(rangeCpy)
-              rangeCpy.attrs.forEach(attr => {
-                filtered.attrs.add(attr)
-                filtered.attrsH.set(attr.hash(), attr)
-              })
+        let mut filtered = IdMap::new();
+        for (client, ranges) in self.inner.iter() {
+            let mut attr_ranges: SmallVec<[(Range<u32>, ContentAttributes<A>); 1]> = SmallVec::new();
+            for (range, attrs) in ranges.iter() {
+                if predicate(&attrs.0) {
+                    let range_copy = (range.clone(), attrs.clone());
+                    for attr in &attrs.0 {
+                        filtered.attrs.insert(attr.clone());
+                    }
+                    attr_ranges.push(range_copy);
+                }
             }
-          })
-          if (attrRanges.length > 0) {
-            filtered.clients.set(client, new AttrRanges(attrRanges))
-          }
-        })
-        return filtered
-               */
-        todo!()
+            if !attr_ranges.is_empty() {
+                filtered.inner.clients_mut().insert(*client, IdRanges::from_raw(attr_ranges));
+            }
+        }
+        filtered
     }
 
     /// Add `attrs` to local attribute set of current [IdMap]. If the attribute was already in set,
@@ -236,101 +263,93 @@ impl<A: PartialEq + Eq + Hash> IdMap<A> {
         }
     }
 
-    fn range_binary_search(dis: &[AttrRange<A>], clock: u32) -> Option<usize> {
-        let mut left = 0;
-        let mut right = dis.len() - 1;
-        while left <= right {
-            let mid_idx = (left + right) / 2;
-            let attr_range = &dis[mid_idx];
-            if attr_range.range.start <= clock {
-                if clock < attr_range.range.end {
-                    return Some(mid_idx);
-                }
-                left = mid_idx + 1;
-            } else {
-                right = mid_idx - 1;
-            }
-        }
-        None
+    /// Access the inner [IdMapInner] (crate-internal).
+    pub(crate) fn inner(&self) -> &IdMapInner<ContentAttributes<A>> {
+        &self.inner
     }
 }
 
-impl<A: PartialEq + Eq + Hash> PartialEq for IdMap<A> {
+impl<A: PartialEq + Eq + Hash + Clone> PartialEq for IdMap<A> {
     fn eq(&self, other: &Self) -> bool {
-        self.attrs == other.attrs && self.clients == other.clients
+        self.inner == other.inner
     }
 }
 
-pub struct Iter<'a, A> {
-    _b: &'a IdMap<A>,
+pub struct Iter<'a, A: PartialEq + Eq + Hash + Clone> {
+    inner: std::collections::btree_map::Iter<'a, ClientID, IdRanges<ContentAttributes<A>>>,
+    current_client: Option<ClientID>,
+    current_iter: Option<std::slice::Iter<'a, (Range<u32>, ContentAttributes<A>)>>,
 }
 
-impl<'a, A> Iter<'a, A> {
+impl<'a, A: PartialEq + Eq + Hash + Clone> Iter<'a, A> {
     fn new(id_map: &'a IdMap<A>) -> Self {
-        todo!()
+        Iter {
+            inner: id_map.inner.clients().iter(),
+            current_client: None,
+            current_iter: None,
+        }
     }
 }
 
-impl<'a, A> Iterator for Iter<'a, A> {
+impl<'a, A: PartialEq + Eq + Hash + Clone> Iterator for Iter<'a, A> {
     type Item = (ClientID, AttrRange<A>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        todo!()
+        loop {
+            if let Some(iter) = self.current_iter.as_mut() {
+                if let Some((range, attrs)) = iter.next() {
+                    return Some((
+                        self.current_client.unwrap(),
+                        AttrRange {
+                            range: range.clone(),
+                            attrs: attrs.clone(),
+                        },
+                    ));
+                }
+            }
+            let (client, ranges) = self.inner.next()?;
+            self.current_client = Some(*client);
+            self.current_iter = Some(ranges.iter());
+        }
     }
 }
 
-pub trait Diff<T> {
-    fn diff_with(&mut self, other: &T);
-}
-
-impl<A> Diff<IdSet> for IdMap<A> {
-    fn diff_with(&mut self, other: &IdSet) {}
-}
-
-impl<A> Diff<IdMap<A>> for IdMap<A> {
-    fn diff_with(&mut self, other: &IdMap<A>) {}
-}
-
-impl<A> From<IdMap<A>> for IdSet {
+impl<A: PartialEq + Eq + Hash + Clone> From<IdMap<A>> for IdSet {
     fn from(value: IdMap<A>) -> Self {
         let mut set = IdSet::default();
-        for (client, ranges) in value.clients {
-            let range = set.range_mut(client);
-            for attr_range in ranges.0 {
-                range.insert(attr_range.range);
+        for (client, ranges) in value.inner.clients() {
+            let range = set.range_mut(*client);
+            for (r, _) in ranges.iter() {
+                range.insert(r.clone());
             }
         }
         set
     }
 }
 
-impl<A: Serialize> Encode for IdMap<A> {
+impl<A: Serialize + PartialEq + Eq + Hash + Clone> Encode for IdMap<A> {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
-        encoder.write_var(self.clients.len() as u32);
+        encoder.write_var(self.inner.len() as u32);
         let mut last_written_client_id: u64 = 0;
-        // Use Arc pointer identity to deduplicate attributions across ranges
-        let mut visited_attributions: HashMap<*const ContentAttributeInner<A>, usize> =
-            HashMap::new();
-        let mut visited_attr_names: HashMap<&str, usize> = HashMap::new();
+        let mut visited_attributions: std::collections::HashMap<*const ContentAttributeInner<A>, usize> =
+            std::collections::HashMap::new();
+        let mut visited_attr_names: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
 
-        // Ensure that the ids are written in a deterministic order (smaller client ids first)
-        let mut keys: Vec<_> = self.clients.keys().copied().collect();
-        keys.sort();
-
-        for client_id in keys {
-            let ranges = &self.clients[&client_id];
+        // Ensure deterministic order (BTreeMap already sorted)
+        for (client_id, ranges) in self.inner.iter() {
             encoder.reset_ds_cur_val();
             let diff = client_id.get() - last_written_client_id;
             encoder.write_var(diff);
             last_written_client_id = client_id.get();
-            encoder.write_var(ranges.0.len() as u32);
+            encoder.write_var(ranges.len() as u32);
 
-            for item in &ranges.0 {
-                encoder.write_ds_clock(item.range.start);
-                encoder.write_ds_len(item.range.end - item.range.start);
-                encoder.write_var(item.attrs.len() as u32);
+            for (range, attrs) in ranges.iter() {
+                encoder.write_ds_clock(range.start);
+                encoder.write_ds_len(range.end - range.start);
+                encoder.write_var(attrs.0.len() as u32);
 
-                for attr in &item.attrs {
+                for attr in &attrs.0 {
                     let ptr = Arc::as_ptr(&attr.0);
                     if let Some(&attr_id) = visited_attributions.get(&ptr) {
                         encoder.write_var(attr_id as u32);
@@ -358,7 +377,7 @@ impl<A: Serialize> Encode for IdMap<A> {
     }
 }
 
-impl<A: DeserializeOwned + PartialEq + Eq + Hash> Decode for IdMap<A> {
+impl<A: DeserializeOwned + PartialEq + Eq + Hash + Clone> Decode for IdMap<A> {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
         let mut id_map = IdMap::new();
         let num_clients: u32 = decoder.read_var()?;
@@ -372,7 +391,7 @@ impl<A: DeserializeOwned + PartialEq + Eq + Hash> Decode for IdMap<A> {
             let client = last_client_id + diff;
             last_client_id = client;
             let num_ranges: u32 = decoder.read_var()?;
-            let mut attr_ranges: SmallVec<[AttrRange<A>; 1]> = SmallVec::new();
+            let mut entries: SmallVec<[(Range<u32>, ContentAttributes<A>); 1]> = SmallVec::new();
 
             for _ in 0..num_ranges {
                 let range_clock = decoder.read_ds_clock()?;
@@ -398,13 +417,13 @@ impl<A: DeserializeOwned + PartialEq + Eq + Hash> Decode for IdMap<A> {
                     attrs.push(visited_attributions[attr_id].clone());
                 }
 
-                attr_ranges
-                    .push(AttrRange::new(range_clock..(range_clock + range_len)).with_attrs(attrs));
+                entries.push((range_clock..(range_clock + range_len), ContentAttributes(attrs)));
             }
 
             id_map
-                .clients
-                .insert(ClientID::new(client), AttrRanges(attr_ranges));
+                .inner
+                .clients_mut()
+                .insert(ClientID::new(client), IdRanges::from_raw(entries));
         }
 
         for attr in visited_attributions {
@@ -415,75 +434,28 @@ impl<A: DeserializeOwned + PartialEq + Eq + Hash> Decode for IdMap<A> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct AttrRanges<A>(SmallVec<[AttrRange<A>; 1]>);
-
-impl<A> AttrRanges<A> {
-    #[inline]
-    pub fn new(attrs: SmallVec<[AttrRange<A>; 1]>) -> Self {
-        Self(attrs)
-    }
-
-    pub fn insert(&mut self, range: AttrRange<A>) {
-        todo!()
-    }
-
-    pub fn get_ids(&self) -> IdRange {
-        let mut ranges = SmallVec::with_capacity(self.0.len());
-        for attr_range in &self.0 {
-            ranges.push(attr_range.range.clone());
-        }
-        IdRange::new(ranges)
-    }
-
-    pub fn find_start(&self, clock: u32) -> Option<usize> {
-        let mut left = 0;
-        let mut right = self.0.len() - 1;
-        while left <= right {
-            let mid_idx = (left + right) / 2;
-            let a = &self.0[mid_idx];
-            if a.range.start <= clock {
-                if clock < a.range.end {
-                    return Some(mid_idx);
-                }
-                left = mid_idx + 1;
-            } else {
-                right = mid_idx - 1;
-            }
-        }
-        if left < self.0.len() {
-            Some(left)
-        } else {
-            None
-        }
-    }
-}
-
-impl<A> Deref for AttrRanges<A> {
-    type Target = [AttrRange<A>];
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+// ---------------------------------------------------------------------------
+// AttrRange<A> — public API type for attributions results
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AttrRange<A> {
-    range: Range<u32>,
-    attrs: SmallVec<[ContentAttribute<A>; 2]>,
+    pub range: Range<u32>,
+    pub attrs: ContentAttributes<A>,
 }
 
 impl<A> AttrRange<A> {
     pub fn new(range: Range<u32>) -> Self {
         AttrRange {
             range,
-            attrs: Default::default(),
+            attrs: ContentAttributes::new(),
         }
     }
 
     pub fn with_attrs(self, attrs: SmallVec<[ContentAttribute<A>; 2]>) -> Self {
         AttrRange {
             range: self.range,
-            attrs,
+            attrs: ContentAttributes(attrs),
         }
     }
 }
@@ -496,6 +468,10 @@ impl<A> Clone for AttrRange<A> {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// ContentAttribute<A>
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ContentAttribute<A>(Arc<ContentAttributeInner<A>>);
@@ -538,7 +514,7 @@ impl<A: std::fmt::Display> std::fmt::Display for ContentAttribute<A> {
 #[cfg(test)]
 mod test {
     use crate::block::{BlockRange, ClientID};
-    use crate::id_map::{ContentAttribute, Diff, IdMap};
+    use crate::id_map::{ContentAttribute, IdMap};
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::Encode;
     use crate::{IdSet, ID};
@@ -650,7 +626,7 @@ mod test {
                         let len = a.range.end - a.range.start;
                         composed.insert(
                             BlockRange::new(ID::new(client_id, clock), len),
-                            a.attrs.to_vec(),
+                            a.attrs.0.to_vec(),
                         );
                     }
                 }
@@ -667,8 +643,8 @@ mod test {
         let mut id_map_1 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
         let id_map_2 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
         let mut merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
-        id_map_1.diff_with(&id_map_2);
-        merged.diff_with(&id_map_2);
+        id_map_1.diff_with(&id_map_2.inner);
+        merged.diff_with(&id_map_2.inner);
         assert_eq!(merged, id_map_1);
 
         let copy = IdMap::decode_v1(&id_map_1.encode_v1()).unwrap();
@@ -685,10 +661,10 @@ mod test {
         let id_exclude = random_id_set(CLIENTS, CLOCK_RANGE);
         let mut merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
         let mut merge_excluded = merged.clone();
-        merge_excluded.diff_with(&id_exclude);
+        merge_excluded.diff_with(id_exclude.inner());
 
-        id_map_1.diff_with(&id_exclude);
-        id_map_2.diff_with(&id_exclude);
+        id_map_1.diff_with(id_exclude.inner());
+        id_map_2.diff_with(id_exclude.inner());
 
         let excluded_merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
         assert_eq!(merge_excluded, excluded_merged);
@@ -699,20 +675,23 @@ mod test {
 
     #[test]
     fn repeat_random_deletes() {
-        const CLIENTS: u64 = 1;
+        const CLIENTS: u64 = 2;
         const CLOCK_RANGE: u32 = 100;
-        let mut id_map: IdMap<i32> = random_id_map(CLIENTS, CLOCK_RANGE, vec![]);
-        let client = *id_map.clients.keys().next().unwrap();
+        let mut id_map: IdMap<i32> = random_id_map(CLIENTS, CLOCK_RANGE, vec![1]);
+        let client = *id_map.inner.clients().keys().next().unwrap();
         let clock = fastrand::u32(0..CLOCK_RANGE);
-        let len = fastrand::u32(0..((CLOCK_RANGE - clock) as f64 * 1.2).round() as u32); // allow exceeding range to cover more edge cases
-        let mut ds_map: IdMap<i32> = IdMap::new();
-        ds_map.insert(BlockRange::new(ID::new(client, clock), len), vec![]);
+        let len = fastrand::u32(1..((CLOCK_RANGE - clock) as f64 * 1.2).round().max(2.0) as u32);
+        // Build an IdSet representing the delete range (diff_with works on clock positions only)
+        let mut ds = IdSet::new();
+        ds.insert(ID::new(client, clock), len);
         let mut diffed = id_map.clone();
-        diffed.diff_with(&ds_map);
+        diffed.diff_with(ds.inner());
         id_map.remove(&BlockRange::new(ID::new(client, clock), len));
 
-        for i in 0..len {
-            assert!(id_map.contains(&ID::new(client, clock + i)));
+        // After removal, the removed clocks should NOT be contained
+        for i in 0..len.min(CLOCK_RANGE - clock) {
+            assert!(!id_map.contains(&ID::new(client, clock + i)),
+                "clock {} should have been removed", clock + i);
         }
 
         assert_eq!(id_map, diffed);
@@ -722,7 +701,7 @@ mod test {
     fn repeat_random_intersects() {
         const CLIENTS: u64 = 4;
         const CLOCK_RANGE: u32 = 100;
-        let mut ids1: IdMap<String> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["one".into()]);
+        let ids1: IdMap<String> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["one".into()]);
         let ids2: IdMap<String> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["two".into()]);
         let mut intersected = ids1.clone();
         intersected.intersect_with(&ids2);
@@ -737,73 +716,36 @@ mod test {
                     "if both maps contain ID, so should intersection"
                 );
 
-                let range1 = ids1.attributions(&BlockRange::new(id, 1)).first().cloned();
-                let range2 = ids2.attributions(&BlockRange::new(id, 1)).first().cloned();
+                // For clocks in the intersection, verify attrs are merged from both
+                if ids1.contains(&id) && ids2.contains(&id) {
+                    let attr1 = ids1.attributions(&BlockRange::new(id, 1)).first().cloned().unwrap();
+                    let attr2 = ids2.attributions(&BlockRange::new(id, 1)).first().cloned().unwrap();
+                    let intersect_attr = intersected.attributions(&BlockRange::new(id, 1)).first().cloned().unwrap();
 
-                let expected_attrs: Vec<_> = [range1, range2]
-                    .into_iter()
-                    .filter_map(|x| x.clone())
-                    .collect();
-                let attrs = if let Some(attr) = intersected
-                    .attributions(&BlockRange::new(id, 1))
-                    .first()
-                    .cloned()
-                {
-                    vec![attr]
-                } else {
-                    Vec::new()
-                };
-                assert_eq!(attrs, expected_attrs);
+                    // The intersected attrs should contain all attrs from both sides
+                    for a in attr1.attrs.iter() {
+                        assert!(intersect_attr.attrs.contains(a),
+                            "intersected attribution should contain attrs from first map");
+                    }
+                    for a in attr2.attrs.iter() {
+                        assert!(intersect_attr.attrs.contains(a),
+                            "intersected attribution should contain attrs from second map");
+                    }
+                }
             }
         }
 
         let mut diffed1 = ids1.clone();
-        diffed1.diff_with(&ids2);
-        ids1.diff_with(&intersected);
-        assert_eq!(ids1, diffed1);
+        diffed1.diff_with(&ids2.inner);
+        let mut ids1_copy = ids1.clone();
+        ids1_copy.diff_with(&intersected.inner);
+        assert_eq!(ids1_copy, diffed1);
     }
 
     #[ignore]
     #[test]
     fn attribution_encoding() {
-        //TODO: to make this test pass, we need to update transaction with notion of inset/delete id sets
-
-        /*
-
-        /**
-         * @todo debug why this approach needs 30 bytes per item
-         * @todo it should be possible to only use a single idmap and, in each attr entry, encode the diff
-         * to the previous entries (e.g. remove a,b, insert c,d)
-         */
-        const attributions = createIdMap()
-        const currentTime = time.getUnixTime()
-        const ydoc = new YY.Doc()
-        ydoc.on('afterTransaction', tr => {
-          ids.insertIntoIdMap(attributions, ids.createIdMapFromIdSet(tr.insertSet, [createContentAttribute('insert', 'userX'), createContentAttribute('insertAt', currentTime)]))
-          ids.insertIntoIdMap(attributions, ids.createIdMapFromIdSet(tr.deleteSet, [createContentAttribute('delete', 'userX'), createContentAttribute('deleteAt', currentTime)]))
-        })
-        const ytext = ydoc.get()
-        const N = 10000
-        t.measureTime(`time to attribute ${N / 1000}k changes`, () => {
-          for (let i = 0; i < N; i++) {
-            if (i % 2 > 0 && ytext.length > 0) {
-              const pos = prng.int31(tc.prng, 0, ytext.length)
-              const delLen = prng.int31(tc.prng, 0, ytext.length - pos)
-              ytext.delete(pos, delLen)
-            } else {
-              ytext.insert(prng.int31(tc.prng, 0, ytext.length), prng.word(tc.prng))
-            }
-          }
-        })
-        t.measureTime('time to encode attributions map', () => {
-          /**
-           * @todo I can optimize size by encoding only the differences to the prev item.
-           */
-          const encAttributions = ids.encodeIdMap(attributions)
-          t.info('encoded size: ' + encAttributions.byteLength)
-          t.info('size per change: ' + math.floor((encAttributions.byteLength / N) * 100) / 100 + ' bytes')
-        })
-               */
+        //TODO: to make this test pass, we need to update transaction with notion of insert/delete id sets
     }
 
     fn construct<const N: usize>(ops: [(u64, u32, u32, Vec<u32>); N]) -> IdMap<u32> {
@@ -845,7 +787,7 @@ mod test {
         const MAX_OP_LEN: u32 = 5;
         let num_ops = ((clients as u32 * clock_range) / MAX_OP_LEN).max(1);
         let mut id_map = IdMap::new();
-        for i in 0..num_ops {
+        for _i in 0..num_ops {
             let client = ClientID::new(fastrand::u64(0..(clients - 1)));
             let clock_start = fastrand::u32(0..clock_range);
             let len = fastrand::u32(0..(clock_range - clock_start));
@@ -864,11 +806,8 @@ mod test {
             let range = BlockRange::new(ID::new(client, clock_start), len);
             id_map.insert(range, attrs);
         }
-        let attr_len = attr_choices.len();
-        let enc_len = id_map.encode_v1().len();
-        //println!(
-        //    "created IdMap with {num_ops} ranges and {attr_len} different attributes. Encoded size: {enc_len}",
-        //);
+        let _attr_len = attr_choices.len();
+        let _enc_len = id_map.encode_v1().len();
         id_map
     }
 }

--- a/yrs/src/id_map.rs
+++ b/yrs/src/id_map.rs
@@ -1,0 +1,878 @@
+use crate::block::{BlockRange, ClientID};
+use crate::encoding::read::Error;
+use crate::id_set::IdRange;
+use crate::updates::decoder::{Decode, Decoder};
+use crate::updates::encoder::{Encode, Encoder};
+use crate::{IdSet, ID};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use smallvec::{smallvec, SmallVec};
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::hash::{Hash, Hasher};
+use std::ops::{Deref, Index, Range};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub struct IdMap<A> {
+    attrs: HashSet<ContentAttribute<A>>,
+    clients: HashMap<ClientID, AttrRanges<A>>,
+}
+
+impl<A> IdMap<A> {
+    pub fn new() -> Self {
+        IdMap {
+            clients: Default::default(),
+            attrs: Default::default(),
+        }
+    }
+}
+
+impl<A> Default for IdMap<A> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<A: PartialEq + Eq + Hash> IdMap<A> {
+    pub fn from_set(id_set: IdSet, attrs: Vec<ContentAttribute<A>>) -> Self {
+        let mut id_map = IdMap {
+            clients: HashMap::with_capacity(id_set.len()),
+            attrs: HashSet::with_capacity(attrs.len()),
+        };
+        let mut attrs: SmallVec<[ContentAttribute<A>; 2]> = attrs.into();
+        attrs.dedup();
+        id_map.ensure_attrs(&mut attrs);
+        for (client, ranges) in id_set.iter() {
+            let attr_ranges = AttrRanges(
+                ranges
+                    .iter()
+                    .map(|range| AttrRange::new(range.clone()).with_attrs(attrs.clone()))
+                    .collect(),
+            );
+            id_map.clients.insert(*client, attr_ranges);
+        }
+        id_map
+    }
+
+    pub fn iter(&self) -> Iter<'_, A> {
+        Iter::new(self)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.clients.is_empty()
+    }
+
+    pub fn contains(&self, id: &ID) -> bool {
+        if let Some(ranges) = self.clients.get(&id.client) {
+            return Self::range_binary_search(ranges, id.clock).is_some();
+        }
+        false
+    }
+
+    pub fn attributions(&self, range: &BlockRange) -> Vec<AttrRange<A>> {
+        let client = range.id.client;
+        let clock = range.id.clock;
+        let len = range.len;
+        let mut result: Vec<AttrRange<A>> = Vec::new();
+
+        if let Some(dr) = self.clients.get(&client) {
+            if let Some(mut index) = dr.find_start(clock) {
+                let mut prev_end = clock;
+                while index < dr.len() {
+                    let mut r = dr[index].clone();
+                    if r.range.start < clock {
+                        r.range = clock..r.range.end;
+                    }
+                    if r.range.end > clock + len {
+                        r.range = r.range.start..(clock + len);
+                    }
+                    if r.range.start >= r.range.end {
+                        break;
+                    }
+                    // Fill gap before this range
+                    if prev_end < r.range.start {
+                        result.push(AttrRange::new(prev_end..r.range.start));
+                    }
+                    prev_end = r.range.end;
+                    result.push(r);
+                    index += 1;
+                }
+            }
+        }
+
+        if let Some(last) = result.last() {
+            let end = last.range.end;
+            if end < clock + len {
+                result.push(AttrRange::new(end..(clock + len)));
+            }
+        } else {
+            result.push(AttrRange::new(clock..(clock + len)));
+        }
+
+        result
+    }
+
+    pub fn insert<I>(&mut self, range: BlockRange, attrs: Vec<ContentAttribute<A>>) {
+        if attrs.is_empty() {
+            return;
+        }
+
+        let mut attrs = attrs;
+        self.ensure_attrs(&mut attrs);
+        let attr_range =
+            AttrRange::new(range.id.clock..(range.id.clock + range.len)).with_attrs(attrs.into());
+        match self.clients.entry(range.id.client) {
+            Entry::Occupied(mut e) => e.get_mut().insert(attr_range),
+            Entry::Vacant(e) => {
+                e.insert(AttrRanges(smallvec![attr_range]));
+            }
+        }
+    }
+
+    pub fn remove(&mut self, range: &BlockRange) {
+        let client = range.id.client;
+        let clock = range.id.clock;
+        let len = range.len;
+
+        if len == 0 {
+            return;
+        }
+
+        let mut remove_client = false;
+        if let Some(dr) = self.clients.get_mut(&client) {
+            if let Some(mut index) = dr.find_start(clock) {
+                let ids = &mut self.clients.get_mut(&client).unwrap().0;
+                while index < ids.len() && ids[index].range.start < clock + len {
+                    let ar = &mut ids[index];
+                    if ar.range.start < clock + len {
+                        if ar.range.start < clock {
+                            // Range starts before delete region — trim it to end at clock
+                            ar.range = ar.range.start..clock;
+                            if clock + len < ar.range.end {
+                                // Delete doesn't cover the whole range — keep the tail
+                                let mut tail = ar.clone();
+                                tail.range = (clock + len)..ar.range.end;
+                                ids.insert(index + 1, tail);
+                            }
+                            index += 1;
+                        } else if clock + len < ar.range.end {
+                            // Delete ends before this range ends — keep tail
+                            ar.range = (clock + len)..ar.range.end;
+                            index += 1;
+                        } else if ids.len() == 1 {
+                            // Only range for this client — remove entire client entry
+                            remove_client = true;
+                            break;
+                        } else {
+                            // Fully covered by delete — remove this range
+                            ids.remove(index);
+                            // Don't increment: next element shifted into current position
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        if remove_client {
+            self.clients.remove(&client);
+        }
+    }
+
+    pub fn merge_with(&mut self, other: Self) {
+        todo!()
+    }
+
+    pub fn merge_many(id_maps: &[Self]) -> Self {
+        todo!()
+    }
+
+    pub fn intersect_with(&mut self, other: &Self) {
+        todo!()
+    }
+
+    pub fn filter<F>(&self, predicate: F) -> Self
+    where
+        F: Fn(&[ContentAttribute<A>]) -> bool,
+    {
+        /*
+        const filtered = createIdMap()
+        idmap.clients.forEach((ranges, client) => {
+          /**
+           * @type {Array<AttrRange<Attrs>>}
+           */
+          const attrRanges = []
+          ranges.getIds().forEach((range) => {
+            if (predicate(range.attrs)) {
+              const rangeCpy = range.copyWith(range.clock, range.len)
+              attrRanges.push(rangeCpy)
+              rangeCpy.attrs.forEach(attr => {
+                filtered.attrs.add(attr)
+                filtered.attrsH.set(attr.hash(), attr)
+              })
+            }
+          })
+          if (attrRanges.length > 0) {
+            filtered.clients.set(client, new AttrRanges(attrRanges))
+          }
+        })
+        return filtered
+               */
+        todo!()
+    }
+
+    /// Add `attrs` to local attribute set of current [IdMap]. If the attribute was already in set,
+    /// reuse the already cached version.
+    fn ensure_attrs(&mut self, attrs: &mut [ContentAttribute<A>]) {
+        for a in attrs {
+            if let Some(existing) = self.attrs.get(a).cloned() {
+                *a = existing;
+            } else {
+                self.attrs.insert(a.clone());
+            }
+        }
+    }
+
+    fn range_binary_search(dis: &[AttrRange<A>], clock: u32) -> Option<usize> {
+        let mut left = 0;
+        let mut right = dis.len() - 1;
+        while left <= right {
+            let mid_idx = (left + right) / 2;
+            let attr_range = &dis[mid_idx];
+            if attr_range.range.start <= clock {
+                if clock < attr_range.range.end {
+                    return Some(mid_idx);
+                }
+                left = mid_idx + 1;
+            } else {
+                right = mid_idx - 1;
+            }
+        }
+        None
+    }
+}
+
+impl<A: PartialEq + Eq + Hash> PartialEq for IdMap<A> {
+    fn eq(&self, other: &Self) -> bool {
+        self.attrs == other.attrs && self.clients == other.clients
+    }
+}
+
+pub struct Iter<'a, A> {
+    _b: &'a IdMap<A>,
+}
+
+impl<'a, A> Iter<'a, A> {
+    fn new(id_map: &'a IdMap<A>) -> Self {
+        todo!()
+    }
+}
+
+impl<'a, A> Iterator for Iter<'a, A> {
+    type Item = (ClientID, AttrRange<A>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        todo!()
+    }
+}
+
+pub trait Diff<T> {
+    fn diff_with(&mut self, other: &T);
+}
+
+impl<A> Diff<IdSet> for IdMap<A> {
+    fn diff_with(&mut self, other: &IdSet) {}
+}
+
+impl<A> Diff<IdMap<A>> for IdMap<A> {
+    fn diff_with(&mut self, other: &IdMap<A>) {}
+}
+
+impl<A> From<IdMap<A>> for IdSet {
+    fn from(value: IdMap<A>) -> Self {
+        let mut set = IdSet::default();
+        for (client, ranges) in value.clients {
+            let range = set.range_mut(client);
+            for attr_range in ranges.0 {
+                range.insert(attr_range.range);
+            }
+        }
+        set
+    }
+}
+
+impl<A: Serialize> Encode for IdMap<A> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        encoder.write_var(self.clients.len());
+        let mut last_written_client_id = 0;
+        let mut visited_attributions = HashMap::new();
+        let mut visited_attr_names = HashMap::new();
+
+        // Ensure that the ids are written in a deterministic order (smaller clientids first)
+        let mut keys = self.clients.keys().copied().collect::<Vec<_>>();
+        keys.sort();
+        for client_id in keys {
+            let ranges = self.clients.get(&client_id).unwrap();
+            todo!()
+        }
+
+        /*
+
+        encoding.writeVarUint(encoder.restEncoder, idmap.clients.size)
+        let lastWrittenClientId = 0
+        /**
+         * @type {Map<ContentAttribute<Attr>, number>}
+         */
+        const visitedAttributions = map.create()
+        /**
+         * @type {Map<string, number>}
+         */
+        const visitedAttrNames = map.create()
+        // Ensure that the ids are written in a deterministic order (smaller clientids first)
+        array.from(idmap.clients.entries())
+          .sort((a, b) => a[0] - b[0])
+          .forEach(([client, _idRanges]) => {
+            const attrRanges = _idRanges.getIds()
+            encoder.resetIdSetCurVal()
+            const diff = client - lastWrittenClientId
+            encoding.writeVarUint(encoder.restEncoder, diff)
+            lastWrittenClientId = client
+            const len = attrRanges.length
+            encoding.writeVarUint(encoder.restEncoder, len)
+            for (let i = 0; i < len; i++) {
+              const item = attrRanges[i]
+              const attrs = item.attrs
+              const attrLen = attrs.length
+              encoder.writeIdSetClock(item.clock)
+              encoder.writeIdSetLen(item.len)
+              encoding.writeVarUint(encoder.restEncoder, attrLen)
+              for (let j = 0; j < attrLen; j++) {
+                const attr = attrs[j]
+                const attrId = visitedAttributions.get(attr)
+                if (attrId != null) {
+                  encoding.writeVarUint(encoder.restEncoder, attrId)
+                } else {
+                  const newAttrId = visitedAttributions.size
+                  visitedAttributions.set(attr, newAttrId)
+                  encoding.writeVarUint(encoder.restEncoder, newAttrId)
+                  const attrNameId = visitedAttrNames.get(attr.name)
+                  // write attr.name
+                  if (attrNameId != null) {
+                    encoding.writeVarUint(encoder.restEncoder, attrNameId)
+                  } else {
+                    const newAttrNameId = visitedAttrNames.size
+                    encoding.writeVarUint(encoder.restEncoder, newAttrNameId)
+                    encoding.writeVarString(encoder.restEncoder, attr.name)
+                    visitedAttrNames.set(attr.name, newAttrNameId)
+                  }
+                  encoding.writeAny(encoder.restEncoder, /** @type {any} */ (attr.val))
+                }
+              }
+            }
+          })
+               */
+    }
+}
+
+impl<A: DeserializeOwned> Decode for IdMap<A> {
+    fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
+        /*
+        const idmap = new IdMap()
+        const numClients = decoding.readVarUint(decoder.restDecoder)
+        /**
+         * @type {Array<ContentAttribute<any>>}
+         */
+        const visitedAttributions = []
+        /**
+         * @type {Array<string>}
+         */
+        const visitedAttrNames = []
+        let lastClientId = 0
+        for (let i = 0; i < numClients; i++) {
+          decoder.resetDsCurVal()
+          const client = lastClientId + decoding.readVarUint(decoder.restDecoder)
+          lastClientId = client
+          const numberOfDeletes = decoding.readVarUint(decoder.restDecoder)
+          /**
+           * @type {Array<AttrRange<any>>}
+           */
+          const attrRanges = []
+          for (let i = 0; i < numberOfDeletes; i++) {
+            const rangeClock = decoder.readDsClock()
+            const rangeLen = decoder.readDsLen()
+            /**
+             * @type {Array<ContentAttribute<any>>}
+             */
+            const attrs = []
+            const attrsLen = decoding.readVarUint(decoder.restDecoder)
+            for (let j = 0; j < attrsLen; j++) {
+              const attrId = decoding.readVarUint(decoder.restDecoder)
+              if (attrId >= visitedAttributions.length) {
+                // attrId not known yet
+                const attrNameId = decoding.readVarUint(decoder.restDecoder)
+                if (attrNameId >= visitedAttrNames.length) {
+                  visitedAttrNames.push(decoding.readVarString(decoder.restDecoder))
+                }
+                visitedAttributions.push(new ContentAttribute(visitedAttrNames[attrNameId], decoding.readAny(decoder.restDecoder)))
+              }
+              attrs.push(visitedAttributions[attrId])
+            }
+            attrRanges.push(new AttrRange(rangeClock, rangeLen, attrs))
+          }
+          idmap.clients.set(client, new AttrRanges(attrRanges))
+        }
+        visitedAttributions.forEach(attr => {
+          idmap.attrs.add(attr)
+          idmap.attrsH.set(attr.hash(), attr)
+        })
+        return idmap
+               */
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AttrRanges<A>(SmallVec<[AttrRange<A>; 1]>);
+
+impl<A> AttrRanges<A> {
+    #[inline]
+    pub fn new(attrs: SmallVec<[AttrRange<A>; 1]>) -> Self {
+        Self(attrs)
+    }
+
+    pub fn insert(&mut self, range: AttrRange<A>) {
+        todo!()
+    }
+
+    pub fn get_ids(&self) -> IdRange {
+        let mut ranges = SmallVec::with_capacity(self.0.len());
+        for attr_range in &self.0 {
+            ranges.push(attr_range.range.clone());
+        }
+        IdRange::new(ranges)
+    }
+
+    pub fn find_start(&self, clock: u32) -> Option<usize> {
+        let mut left = 0;
+        let mut right = self.0.len() - 1;
+        while left <= right {
+            let mid_idx = (left + right) / 2;
+            let a = &self.0[mid_idx];
+            if a.range.start <= clock {
+                if clock < a.range.end {
+                    return Some(mid_idx);
+                }
+                left = mid_idx + 1;
+            } else {
+                right = mid_idx - 1;
+            }
+        }
+        if left < self.0.len() {
+            Some(left)
+        } else {
+            None
+        }
+    }
+}
+
+impl<A> Deref for AttrRanges<A> {
+    type Target = [AttrRange<A>];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct AttrRange<A> {
+    range: Range<u32>,
+    attrs: SmallVec<[ContentAttribute<A>; 2]>,
+}
+
+impl<A> AttrRange<A> {
+    pub fn new(range: Range<u32>) -> Self {
+        AttrRange {
+            range,
+            attrs: Default::default(),
+        }
+    }
+
+    pub fn with_attrs(self, attrs: SmallVec<[ContentAttribute<A>; 2]>) -> Self {
+        AttrRange {
+            range: self.range,
+            attrs,
+        }
+    }
+}
+
+impl<A> Clone for AttrRange<A> {
+    fn clone(&self) -> Self {
+        AttrRange {
+            range: self.range.clone(),
+            attrs: self.attrs.clone(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
+pub struct ContentAttribute<A>(Arc<ContentAttributeInner<A>>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
+struct ContentAttributeInner<A> {
+    name: String,
+    value: A,
+}
+
+impl<A> ContentAttribute<A> {
+    pub fn new(name: String, value: A) -> Self {
+        ContentAttribute(Arc::new(ContentAttributeInner { name, value }))
+    }
+}
+
+impl<A> Clone for ContentAttribute<A> {
+    fn clone(&self) -> Self {
+        ContentAttribute(self.0.clone())
+    }
+}
+
+impl<A: std::fmt::Display> std::fmt::Display for ContentAttribute<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "(\"{}\": {})", self.0.name, self.0.value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::block::{BlockRange, ClientID};
+    use crate::id_map::{ContentAttribute, Diff, IdMap};
+    use crate::updates::decoder::Decode;
+    use crate::updates::encoder::Encode;
+    use crate::{Any, IdSet, ID};
+    use serde::Serialize;
+    use std::hash::Hash;
+
+    #[test]
+    fn am_merge_filter_out_empty_items() {
+        let attrs = vec![42];
+        let a = construct([(0, 1, 0, attrs)]);
+        let b = construct([]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_merge_filter_out_empty_items_2() {
+        let attrs = vec![42];
+        let a = construct([(0, 1, 0, attrs.clone()), (0, 2, 0, attrs)]);
+        let b = construct([]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_merge_filter_out_empty_items_end() {
+        let attrs = vec![42];
+        let a = construct([(0, 1, 1, attrs.clone()), (0, 2, 0, attrs.clone())]);
+        let b = construct([(0, 1, 1, attrs.clone())]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_merge_filter_out_empty_items_4_middle() {
+        let attrs = vec![42];
+        let a = construct([
+            (0, 1, 1, attrs.clone()),
+            (0, 2, 0, attrs.clone()),
+            (0, 3, 1, attrs.clone()),
+        ]);
+        let b = construct([(0, 1, 1, attrs.clone()), (0, 3, 1, attrs.clone())]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_merge_filter_out_empty_items_5_start() {
+        let attrs = vec![42];
+        let a = construct([
+            (0, 1, 0, attrs.clone()),
+            (0, 2, 1, attrs.clone()),
+            (0, 3, 1, attrs.clone()),
+        ]);
+        let b = construct([(0, 2, 1, attrs.clone()), (0, 3, 1, attrs.clone())]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_merge_merges_overlapping_id_ranges() {
+        let attrs = vec![42];
+        let a = construct([(0, 1, 2, attrs.clone()), (0, 0, 2, attrs.clone())]);
+        let b = construct([(0, 0, 3, attrs.clone())]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_merge_construct_without_hole() {
+        let attrs = vec![42];
+        let a = construct([(0, 1, 2, attrs.clone()), (0, 3, 1, attrs.clone())]);
+        let b = construct([(0, 1, 3, attrs.clone())]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn am_doesnt_merge_overlapping_id_ranges_with_different_attributes() {
+        let a = construct([(0, 1, 2, vec![1]), (0, 0, 2, vec![2])]);
+        let b = construct([
+            (0, 0, 1, vec![2]),
+            (0, 1, 1, vec![1, 2]),
+            (0, 2, 1, vec![1]),
+        ]);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn repeat_merging_mutliple_maps() {
+        const CLIENTS: u32 = 4;
+        const CLOCK_RANGE: u32 = 5;
+        let mut sets = Vec::new();
+        for _ in 0..3 {
+            sets.push(random_id_map(CLIENTS, CLOCK_RANGE, vec![1, 2, 3]));
+        }
+
+        let merged = IdMap::merge_many(&sets);
+        sets.reverse();
+        let merge_reversed = IdMap::merge_many(&sets);
+        assert_eq!(merged, merge_reversed);
+
+        let mut composed = IdMap::new();
+        for i_client in 0..CLIENTS {
+            for i_clock in 0..(CLOCK_RANGE + 42) {
+                let client_id = ClientID::new(i_client as u64);
+                let id = ID::new(client_id, i_clock);
+                let merged_contains = merged.contains(&id);
+                let exists = sets.iter().any(|set| set.contains(&id));
+                assert_eq!(exists, merged_contains);
+
+                let merged_attrs = merged.attributions(&BlockRange::new(id, 1));
+                for a in merged_attrs {
+                    if !a.attrs.is_empty() {
+                        let clock = a.range.start;
+                        let len = a.range.end - a.range.start;
+                        composed.insert(BlockRange::new(ID::new(client_id, clock), len), a.attrs);
+                    }
+                }
+            }
+        }
+        assert_eq!(merged, composed);
+    }
+
+    #[test]
+    fn repeat_random_diffing() {
+        const CLIENTS: u32 = 4;
+        const CLOCK_RANGE: u32 = 5;
+        let attrs = vec![1, 2, 3];
+        let mut id_map_1 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
+        let id_map_2 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
+        let mut merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
+        id_map_1.diff_with(&id_map_2);
+        merged.diff_with(&id_map_2);
+        assert_eq!(merged, id_map_1);
+
+        let copy = IdMap::decode_v1(&id_map_1.encode_v1()).unwrap();
+        assert_eq!(id_map_1, copy);
+    }
+
+    #[test]
+    fn repeat_random_diffing_2() {
+        const CLIENTS: u32 = 4;
+        const CLOCK_RANGE: u32 = 100;
+        let attrs = vec![1, 2, 3];
+        let mut id_map_1 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
+        let mut id_map_2 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
+        let id_exclude = random_id_set(CLIENTS, CLOCK_RANGE);
+        let mut merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
+        let mut merge_excluded = merged.clone();
+        merge_excluded.diff_with(&id_exclude);
+
+        id_map_1.diff_with(&id_exclude);
+        id_map_2.diff_with(&id_exclude);
+
+        let excluded_merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
+        assert_eq!(merge_excluded, excluded_merged);
+
+        let copy = IdMap::decode_v1(&merge_excluded.encode_v1()).unwrap();
+        assert_eq!(merge_excluded, copy);
+    }
+
+    #[test]
+    fn repeat_random_deletes() {
+        const CLIENTS: u32 = 1;
+        const CLOCK_RANGE: u32 = 100;
+        let mut id_map: IdMap<i32> = random_id_map(CLIENTS, CLOCK_RANGE, vec![]);
+        let client = *id_map.clients.keys().next().unwrap();
+        let clock = fastrand::u32(0..CLOCK_RANGE);
+        let len = fastrand::u32(0..((CLOCK_RANGE - clock) as f64 * 1.2).round() as u32); // allow exceeding range to cover more edge cases
+        let mut ds_map = IdMap::new();
+        ds_map.insert(BlockRange::new(ID::new(client, clock), len), vec![]);
+        let mut diffed = id_map.clone();
+        diffed.diff_with(&ds_map);
+        id_map.remove(&BlockRange::new(ID::new(client, clock), len));
+
+        for i in 0..len {
+            assert!(id_map.contains(&ID::new(client, clock + i)));
+        }
+
+        assert_eq!(id_map, diffed);
+    }
+
+    #[test]
+    fn repeat_random_intersects() {
+        const CLIENTS: u32 = 4;
+        const CLOCK_RANGE: u32 = 100;
+        let mut ids1: IdMap<Any> = random_id_map(CLIENTS, CLOCK_RANGE, vec![1.into()]);
+        let ids2: IdMap<Any> = random_id_map(CLIENTS, CLOCK_RANGE, vec!["two".into()]);
+        let mut intersected = ids1.clone();
+        intersected.intersect_with(&ids2);
+
+        for client in 0..CLIENTS {
+            for clock in 0..CLOCK_RANGE {
+                let id = ID::new(client as ClientID, clock);
+                assert_eq!(
+                    ids1.contains(&id) && ids2.contains(&id),
+                    intersected.contains(&id),
+                    "if both maps contain ID, so should intersection"
+                );
+
+                let range1 = ids1.attributions(&BlockRange::new(id, 1)).first().cloned();
+                let range2 = ids2.attributions(&BlockRange::new(id, 1)).first().cloned();
+
+                let expected_attrs: Vec<_> = [range1, range2]
+                    .into_iter()
+                    .filter_map(|x| x.clone())
+                    .collect();
+                let attrs = if let Some(attr) = intersected
+                    .attributions(&BlockRange::new(id, 1))
+                    .first()
+                    .cloned()
+                {
+                    vec![attr]
+                } else {
+                    Vec::new()
+                };
+                assert_eq!(attrs, expected_attrs);
+            }
+        }
+
+        let mut diffed1 = ids1.clone();
+        diffed1.diff_with(&ids2);
+        ids1.diff_with(&intersected);
+        assert_eq!(ids1, diffed1);
+    }
+
+    #[ignore]
+    #[test]
+    fn attribution_encoding() {
+        //TODO: to make this test pass, we need to update transaction with notion of inset/delete id sets
+
+        /*
+
+        /**
+         * @todo debug why this approach needs 30 bytes per item
+         * @todo it should be possible to only use a single idmap and, in each attr entry, encode the diff
+         * to the previous entries (e.g. remove a,b, insert c,d)
+         */
+        const attributions = createIdMap()
+        const currentTime = time.getUnixTime()
+        const ydoc = new YY.Doc()
+        ydoc.on('afterTransaction', tr => {
+          ids.insertIntoIdMap(attributions, ids.createIdMapFromIdSet(tr.insertSet, [createContentAttribute('insert', 'userX'), createContentAttribute('insertAt', currentTime)]))
+          ids.insertIntoIdMap(attributions, ids.createIdMapFromIdSet(tr.deleteSet, [createContentAttribute('delete', 'userX'), createContentAttribute('deleteAt', currentTime)]))
+        })
+        const ytext = ydoc.get()
+        const N = 10000
+        t.measureTime(`time to attribute ${N / 1000}k changes`, () => {
+          for (let i = 0; i < N; i++) {
+            if (i % 2 > 0 && ytext.length > 0) {
+              const pos = prng.int31(tc.prng, 0, ytext.length)
+              const delLen = prng.int31(tc.prng, 0, ytext.length - pos)
+              ytext.delete(pos, delLen)
+            } else {
+              ytext.insert(prng.int31(tc.prng, 0, ytext.length), prng.word(tc.prng))
+            }
+          }
+        })
+        t.measureTime('time to encode attributions map', () => {
+          /**
+           * @todo I can optimize size by encoding only the differences to the prev item.
+           */
+          const encAttributions = ids.encodeIdMap(attributions)
+          t.info('encoded size: ' + encAttributions.byteLength)
+          t.info('size per change: ' + math.floor((encAttributions.byteLength / N) * 100) / 100 + ' bytes')
+        })
+               */
+        todo!()
+    }
+
+    fn construct<const N: usize>(ops: [(u64, u32, u32, Vec<u32>); N]) -> IdMap<u32> {
+        let mut id_map = IdMap::new();
+
+        for (client, clock, len, attrs) in ops {
+            let range = BlockRange::new(ID::new(ClientID::new(client), clock), len);
+            let attrs: Vec<_> = attrs
+                .iter()
+                .map(|i| ContentAttribute::new("", *i))
+                .collect();
+            id_map.insert(range, attrs);
+        }
+
+        id_map
+    }
+
+    fn random_id_set(clients: u32, clock_range: u32) -> IdSet {
+        const MAX_OPS: u32 = 5;
+        let num_ops = (clients * clock_range) / MAX_OPS;
+        let mut id_set = IdSet::new();
+        for _ in 0..num_ops {
+            let client = fastrand::u32(0..(clients - 1)) as ClientID;
+            let clock_start = fastrand::u32(0..clock_range);
+            let len = fastrand::u32(0..(clock_range - clock_start));
+            id_set.insert(ID::new(client, clock_start), len);
+        }
+        if id_set.len() == clients as usize && clients > 1 && fastrand::bool() {
+            // idset.clients.delete(prng.uint32(gen, 0, clients))
+        }
+        id_set
+    }
+
+    fn random_id_map<T: Hash + Clone + PartialEq + Serialize>(
+        clients: u32,
+        clock_range: u32,
+        attr_choices: Vec<T>,
+    ) -> IdMap<T> {
+        const MAX_OP_LEN: u32 = 5;
+        let num_ops = ((clients * clock_range) / MAX_OP_LEN).max(1);
+        let mut id_map = IdMap::new();
+        for i in 0..num_ops {
+            let client = fastrand::u32(0..(clients - 1)) as ClientID;
+            let clock_start = fastrand::u32(0..clock_range);
+            let len = fastrand::u32(0..(clock_range - clock_start));
+            let mut attrs = vec![ContentAttribute::new(
+                "",
+                fastrand::choice(&attr_choices).unwrap().clone(),
+            )];
+            // maybe add another attr
+            if fastrand::bool() {
+                let attr =
+                    ContentAttribute::new("", fastrand::choice(&attr_choices).unwrap().clone());
+                if attr != attrs[0] {
+                    attrs.push(attr);
+                }
+            }
+            let range = BlockRange::new(ID::new(client, clock_start), len);
+            id_map.insert(range, attrs);
+        }
+        let attr_len = attr_choices.len();
+        let enc_len = id_map.encode_v1().len();
+        //println!(
+        //    "created IdMap with {num_ops} ranges and {attr_len} different attributes. Encoded size: {enc_len}",
+        //);
+        id_map
+    }
+}

--- a/yrs/src/id_map.rs
+++ b/yrs/src/id_map.rs
@@ -8,14 +8,15 @@ use crate::{IdSet, ID};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use smallvec::SmallVec;
+use std::collections::btree_map::Entry;
 use std::collections::HashSet;
 use std::hash::Hash;
 use std::ops::{Deref, Range};
 use std::sync::Arc;
 
-// ---------------------------------------------------------------------------
-// ContentAttributes<A> — per-range attribute set with Merge support
-// ---------------------------------------------------------------------------
+pub trait Diff<D> {
+    fn diff_with(&mut self, other: &D);
+}
 
 /// A set of [`ContentAttribute<A>`] values attached to a range.
 /// Implements [`Merge`] by unioning attributes.
@@ -121,23 +122,23 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
 
     pub fn attributions(&self, range: &BlockRange) -> Vec<AttrRange<A>> {
         let client = range.id.client;
-        let clock = range.id.clock;
-        let len = range.len;
+        let block_start = range.id.clock;
+        let block_end = range.id.clock + range.len;
         let mut result: Vec<AttrRange<A>> = Vec::new();
 
         if let Some(dr) = self.inner.get(&client) {
-            if let Some(mut index) = dr.find_start(clock) {
+            if let Some(mut index) = dr.find_start(block_start) {
                 let entries = dr.as_slice();
-                let mut prev_end = clock;
+                let mut prev_end = block_start;
                 while index < entries.len() {
                     let (ref entry_range, ref entry_attrs) = entries[index];
                     let mut r_start = entry_range.start;
                     let mut r_end = entry_range.end;
-                    if r_start < clock {
-                        r_start = clock;
+                    if r_start < block_start {
+                        r_start = block_start;
                     }
-                    if r_end > clock + len {
-                        r_end = clock + len;
+                    if r_end > block_end {
+                        r_end = block_end;
                     }
                     if r_start >= r_end {
                         break;
@@ -158,11 +159,11 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
 
         if let Some(last) = result.last() {
             let end = last.range.end;
-            if end < clock + len {
-                result.push(AttrRange::new(end..(clock + len)));
+            if end < block_end {
+                result.push(AttrRange::new(end..block_end));
             }
         } else {
-            result.push(AttrRange::new(clock..(clock + len)));
+            result.push(AttrRange::new(block_start..block_end));
         }
 
         result
@@ -177,22 +178,19 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
         self.ensure_attrs(&mut attrs);
         let content_attrs = ContentAttributes(attrs.into());
         self.inner
-            .insert_range(range.id.client, range.id.clock..(range.id.clock + range.len), content_attrs);
+            .insert_range(range.id.client, range.clock_range(), content_attrs);
     }
 
     pub fn remove(&mut self, range: &BlockRange) {
-        let client = range.id.client;
-        let clock = range.id.clock;
-        let len = range.len;
-
-        if len == 0 {
+        if range.len == 0 {
             return;
         }
 
-        if let Some(r) = self.inner.get_mut(&client) {
-            r.remove(clock..(clock + len));
-            if r.is_empty() {
-                self.inner.clients_mut().remove(&client);
+        if let Entry::Occupied(mut e) = self.inner.entry(range.id.client) {
+            let ranges = e.get_mut();
+            ranges.remove(range.clock_range());
+            if ranges.is_empty() {
+                e.remove();
             }
         }
     }
@@ -205,10 +203,7 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
         }
     }
 
-    pub fn merge_many(id_maps: &[Self]) -> Self
-    where
-        A: Clone,
-    {
+    pub fn merge_many(id_maps: &[Self]) -> Self {
         let mut result = IdMap::new();
         for map in id_maps {
             result.inner.merge_with(&map.inner);
@@ -223,10 +218,6 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
         self.inner.intersect_with(&other.inner);
     }
 
-    pub fn diff_with<T: Merge>(&mut self, other: &IdMapInner<T>) {
-        self.inner.diff_with(other);
-    }
-
     pub fn filter<F>(&self, predicate: F) -> Self
     where
         F: Fn(&[ContentAttribute<A>]) -> bool,
@@ -234,7 +225,8 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
     {
         let mut filtered = IdMap::new();
         for (client, ranges) in self.inner.iter() {
-            let mut attr_ranges: SmallVec<[(Range<u32>, ContentAttributes<A>); 1]> = SmallVec::new();
+            let mut attr_ranges: SmallVec<[(Range<u32>, ContentAttributes<A>); 1]> =
+                SmallVec::new();
             for (range, attrs) in ranges.iter() {
                 if predicate(&attrs.0) {
                     let range_copy = (range.clone(), attrs.clone());
@@ -245,7 +237,10 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
                 }
             }
             if !attr_ranges.is_empty() {
-                filtered.inner.clients_mut().insert(*client, IdRanges::from_raw(attr_ranges));
+                filtered
+                    .inner
+                    .clients_mut()
+                    .insert(*client, IdRanges::from_raw(attr_ranges));
             }
         }
         filtered
@@ -262,16 +257,27 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
             }
         }
     }
-
-    /// Access the inner [IdMapInner] (crate-internal).
-    pub(crate) fn inner(&self) -> &IdMapInner<ContentAttributes<A>> {
-        &self.inner
-    }
 }
 
 impl<A: PartialEq + Eq + Hash + Clone> PartialEq for IdMap<A> {
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
+    }
+}
+
+impl<A: PartialEq + Eq + Hash + Clone> Diff<IdSet> for IdMap<A> {
+    fn diff_with(&mut self, other: &IdSet) {
+        self.inner.diff_with(&other.0);
+    }
+}
+
+impl<A, U> Diff<IdMap<U>> for IdMap<A>
+where
+    A: Eq + Hash + Clone,
+    U: Eq + Hash + Clone,
+{
+    fn diff_with(&mut self, other: &IdMap<U>) {
+        self.inner.diff_with(&other.inner);
     }
 }
 
@@ -331,8 +337,10 @@ impl<A: Serialize + PartialEq + Eq + Hash + Clone> Encode for IdMap<A> {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         encoder.write_var(self.inner.len() as u32);
         let mut last_written_client_id: u64 = 0;
-        let mut visited_attributions: std::collections::HashMap<*const ContentAttributeInner<A>, usize> =
-            std::collections::HashMap::new();
+        let mut visited_attributions: std::collections::HashMap<
+            *const ContentAttributeInner<A>,
+            usize,
+        > = std::collections::HashMap::new();
         let mut visited_attr_names: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
 
@@ -417,7 +425,10 @@ impl<A: DeserializeOwned + PartialEq + Eq + Hash + Clone> Decode for IdMap<A> {
                     attrs.push(visited_attributions[attr_id].clone());
                 }
 
-                entries.push((range_clock..(range_clock + range_len), ContentAttributes(attrs)));
+                entries.push((
+                    range_clock..(range_clock + range_len),
+                    ContentAttributes(attrs),
+                ));
             }
 
             id_map
@@ -433,10 +444,6 @@ impl<A: DeserializeOwned + PartialEq + Eq + Hash + Clone> Decode for IdMap<A> {
         Ok(id_map)
     }
 }
-
-// ---------------------------------------------------------------------------
-// AttrRange<A> — public API type for attributions results
-// ---------------------------------------------------------------------------
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct AttrRange<A> {
@@ -468,10 +475,6 @@ impl<A> Clone for AttrRange<A> {
         }
     }
 }
-
-// ---------------------------------------------------------------------------
-// ContentAttribute<A>
-// ---------------------------------------------------------------------------
 
 #[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct ContentAttribute<A>(Arc<ContentAttributeInner<A>>);
@@ -514,7 +517,7 @@ impl<A: std::fmt::Display> std::fmt::Display for ContentAttribute<A> {
 #[cfg(test)]
 mod test {
     use crate::block::{BlockRange, ClientID};
-    use crate::id_map::{ContentAttribute, IdMap};
+    use crate::id_map::{ContentAttribute, Diff, IdMap};
     use crate::updates::decoder::Decode;
     use crate::updates::encoder::Encode;
     use crate::{IdSet, ID};
@@ -643,8 +646,8 @@ mod test {
         let mut id_map_1 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
         let id_map_2 = random_id_map(CLIENTS, CLOCK_RANGE, attrs.clone());
         let mut merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
-        id_map_1.diff_with(&id_map_2.inner);
-        merged.diff_with(&id_map_2.inner);
+        id_map_1.diff_with(&id_map_2);
+        merged.diff_with(&id_map_2);
         assert_eq!(merged, id_map_1);
 
         let copy = IdMap::decode_v1(&id_map_1.encode_v1()).unwrap();
@@ -661,10 +664,10 @@ mod test {
         let id_exclude = random_id_set(CLIENTS, CLOCK_RANGE);
         let mut merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
         let mut merge_excluded = merged.clone();
-        merge_excluded.diff_with(id_exclude.inner());
+        merge_excluded.diff_with(&id_exclude);
 
-        id_map_1.diff_with(id_exclude.inner());
-        id_map_2.diff_with(id_exclude.inner());
+        id_map_1.diff_with(&id_exclude);
+        id_map_2.diff_with(&id_exclude);
 
         let excluded_merged = IdMap::merge_many(&[id_map_1.clone(), id_map_2.clone()]);
         assert_eq!(merge_excluded, excluded_merged);
@@ -685,13 +688,16 @@ mod test {
         let mut ds = IdSet::new();
         ds.insert(ID::new(client, clock), len);
         let mut diffed = id_map.clone();
-        diffed.diff_with(ds.inner());
+        diffed.diff_with(&ds);
         id_map.remove(&BlockRange::new(ID::new(client, clock), len));
 
         // After removal, the removed clocks should NOT be contained
         for i in 0..len.min(CLOCK_RANGE - clock) {
-            assert!(!id_map.contains(&ID::new(client, clock + i)),
-                "clock {} should have been removed", clock + i);
+            assert!(
+                !id_map.contains(&ID::new(client, clock + i)),
+                "clock {} should have been removed",
+                clock + i
+            );
         }
 
         assert_eq!(id_map, diffed);
@@ -718,27 +724,43 @@ mod test {
 
                 // For clocks in the intersection, verify attrs are merged from both
                 if ids1.contains(&id) && ids2.contains(&id) {
-                    let attr1 = ids1.attributions(&BlockRange::new(id, 1)).first().cloned().unwrap();
-                    let attr2 = ids2.attributions(&BlockRange::new(id, 1)).first().cloned().unwrap();
-                    let intersect_attr = intersected.attributions(&BlockRange::new(id, 1)).first().cloned().unwrap();
+                    let attr1 = ids1
+                        .attributions(&BlockRange::new(id, 1))
+                        .first()
+                        .cloned()
+                        .unwrap();
+                    let attr2 = ids2
+                        .attributions(&BlockRange::new(id, 1))
+                        .first()
+                        .cloned()
+                        .unwrap();
+                    let intersect_attr = intersected
+                        .attributions(&BlockRange::new(id, 1))
+                        .first()
+                        .cloned()
+                        .unwrap();
 
                     // The intersected attrs should contain all attrs from both sides
                     for a in attr1.attrs.iter() {
-                        assert!(intersect_attr.attrs.contains(a),
-                            "intersected attribution should contain attrs from first map");
+                        assert!(
+                            intersect_attr.attrs.contains(a),
+                            "intersected attribution should contain attrs from first map"
+                        );
                     }
                     for a in attr2.attrs.iter() {
-                        assert!(intersect_attr.attrs.contains(a),
-                            "intersected attribution should contain attrs from second map");
+                        assert!(
+                            intersect_attr.attrs.contains(a),
+                            "intersected attribution should contain attrs from second map"
+                        );
                     }
                 }
             }
         }
 
         let mut diffed1 = ids1.clone();
-        diffed1.diff_with(&ids2.inner);
+        diffed1.diff_with(&ids2);
         let mut ids1_copy = ids1.clone();
-        ids1_copy.diff_with(&intersected.inner);
+        ids1_copy.diff_with(&intersected);
         assert_eq!(ids1_copy, diffed1);
     }
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -1,20 +1,18 @@
 use crate::block::{BlockRange, ClientID, ID};
 use crate::block_store::BlockStore;
 use crate::encoding::read::Error;
+use crate::ids::{IdMapInner, IdRanges};
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::store::Store;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
-use crate::utils::client_hasher::ClientHasher;
 use crate::ReadTxn;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::fmt::Formatter;
-use std::hash::{BuildHasherDefault, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 use std::ops::Range;
 // Note: use native Rust [Range](https://doc.rust-lang.org/std/ops/struct.Range.html)
 // as it's left-inclusive/right-exclusive and defines the exact capabilities we care about here.
@@ -35,240 +33,36 @@ impl Decode for Range<u32> {
 }
 
 /// [IdRange] describes a set of elements, represented as ranges of `u32` clock values, created by
-/// specific client, included in a corresponding [IdSet].
+/// a specific client, included in a corresponding [IdSet].
 ///
-/// Internally backed by a [SmallVec] inlining a single [Range], so the common case of one
-/// continuous range incurs no heap allocation.
-///
-/// Within the `IdRange` all ranges are values sorted by `start` of the range, overlapping or adjacent
+/// Internally backed by a [`SmallVec`] inlining a single `(Range<u32>, ())` pair.
+/// Within the `IdRange` all ranges are sorted by `start`, overlapping or adjacent
 /// ranges are merged together on insert.
-#[repr(transparent)]
-#[derive(Clone, PartialEq, Eq, Hash, Default)]
-pub struct IdRange(SmallVec<[Range<u32>; 2]>);
+pub type IdRange = IdRanges<()>;
 
-impl std::ops::Deref for IdRange {
-    type Target = [Range<u32>];
-    #[inline]
-    fn deref(&self) -> &[Range<u32>] {
-        &self.0
-    }
-}
-
-impl<'a> IntoIterator for &'a IdRange {
-    type Item = &'a Range<u32>;
-    type IntoIter = std::slice::Iter<'a, Range<u32>>;
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
-    }
-}
-
-impl IdRange {
-    pub(crate) fn new(ranges: SmallVec<[Range<u32>; 2]>) -> Self {
-        IdRange(ranges)
-    }
-
-    pub fn with_capacity(capacity: usize) -> Self {
-        IdRange(SmallVec::with_capacity(capacity))
-    }
-
+// ---------------------------------------------------------------------------
+// IdRange-specific methods (only meaningful for T = ())
+// ---------------------------------------------------------------------------
+impl IdRanges<()> {
     /// Inverts current [IdRange], returning another [IdRange] that contains all
     /// "holes" (ranges not included in current range). If current range is a continuous space
     /// starting from the initial clock (eg. [0..5)), then returned range will be empty.
     pub fn invert(&self) -> IdRange {
         let mut inv = SmallVec::new();
         let mut start = 0;
-        for range in self.0.iter() {
+        for (range, _) in self.iter() {
             if range.start > start {
-                inv.push(start..range.start);
+                inv.push((start..range.start, ()));
             }
             start = range.end;
         }
-        IdRange(inv)
-    }
-
-    pub fn find_start(&self, clock: u32) -> Option<usize> {
-        let mut left = 0;
-        let mut right = self.0.len() - 1;
-        while left <= right {
-            let mid_idx = (left + right) / 2;
-            let range = &self.0[mid_idx];
-            if range.start <= clock {
-                if clock < range.end {
-                    return Some(mid_idx);
-                }
-                left = mid_idx + 1;
-            } else {
-                right = mid_idx - 1;
-            }
-        }
-        if left < self.0.len() {
-            Some(left)
-        } else {
-            None
-        }
-    }
-
-    /// Check if given clock exists within current [IdRange].
-    pub fn contains_clock(&self, clock: u32) -> bool {
-        self.0.iter().any(|r| r.contains(&clock))
-    }
-
-    pub fn insert(&mut self, range: Range<u32>) {
-        if range.start >= range.end {
-            return;
-        }
-
-        // tail-fast push - if inserted range >= last element, we don't need binary search
-        if let Some(last) = self.0.last_mut() {
-            if range.start >= last.start {
-                if range.start > last.end {
-                    self.0.push(range);
-                } else {
-                    last.end = last.end.max(range.end); // inserted range is overlapping -> merge to the end
-                }
-                return;
-            }
-        }
-
-        let mut start = range.start;
-        let mut end = range.end;
-        let mut lo = self.0.partition_point(|r| r.start < range.start);
-
-        // Absorb the left neighbour if it touches or overlaps the new range.
-        // `>= start` (not `> start`) so adjacents like [0..3) + [3..5) merge into [0..5).
-        if lo > 0 && self.0[lo - 1].end >= start {
-            lo -= 1;
-            start = self.0[lo].start;
-            end = end.max(self.0[lo].end);
-        }
-
-        // Walk forward absorbing every right neighbour that touches or overlaps.
-        let mut hi = lo;
-        while hi < self.0.len() && self.0[hi].start <= end {
-            end = end.max(self.0[hi].end);
-            hi += 1;
-        }
-
-        // Splice [lo..hi] with the single merged range.
-        if lo == hi {
-            self.0.insert(lo, start..end);
-        } else {
-            self.0[lo] = start..end;
-            if hi - lo > 1 {
-                self.0.drain(lo + 1..hi);
-            }
-        }
-    }
-
-    /// Removes a single clock `range` from the current [IdRange].
-    pub fn remove(&mut self, range: Range<u32>) {
-        if range.start >= range.end || self.0.is_empty() {
-            return;
-        }
-
-        // First index whose entry overlaps or follows `range` (i.e. r.end > range.start).
-        let mut i = self.0.partition_point(|r| r.end <= range.start);
-        if i >= self.0.len() {
-            return; // `range` lies past every entry — no-op.
-        }
-
-        // Special case: a single existing entry strictly contains `range` — split it.
-        if self.0[i].start < range.start && self.0[i].end > range.end {
-            let right = range.end..self.0[i].end;
-            self.0[i].end = range.start;
-            self.0.insert(i + 1, right);
-            return;
-        }
-
-        // Trim the leftmost entry if it straddles `range.start` — keep [r.start..range.start).
-        if self.0[i].start < range.start {
-            self.0[i].end = range.start;
-            i += 1;
-        }
-
-        // Find the slice of entries fully covered by `range`.
-        let mut j = i;
-        while j < self.0.len() && self.0[j].end <= range.end {
-            j += 1;
-        }
-
-        // Trim the trailing entry if it straddles `range.end` — keep [range.end..r.end).
-        if j < self.0.len() && self.0[j].start < range.end {
-            self.0[j].start = range.end;
-        }
-
-        // Drop the fully-covered middle.
-        if j > i {
-            self.0.drain(i..j);
-        }
-    }
-
-    /// Merge `other` ID range into current one. Both inputs are assumed to be in canonical
-    /// form (sorted, non-overlapping, non-adjacent); the result is too. Adjacent and
-    /// overlapping ranges across the two inputs coalesce.
-    pub fn merge(&mut self, other: IdRange) {
-        if other.0.is_empty() {
-            return;
-        }
-        if self.0.is_empty() {
-            self.0 = other.0;
-            return;
-        }
-
-        // Fast path: `other` lies entirely after `self`. Common when accumulating updates
-        // in clock order — avoids the general two-way merge alloc.
-        let last_idx = self.0.len() - 1;
-        let last_end = self.0[last_idx].end;
-        let other_first_start = other.0[0].start;
-        if last_end < other_first_start {
-            self.0.extend(other.0);
-            return;
-        }
-        if last_end == other_first_start {
-            // Adjacent at the boundary — merge first of `other` into last of `self`,
-            // then append the rest.
-            self.0[last_idx].end = last_end.max(other.0[0].end);
-            let mut it = other.0.into_iter();
-            it.next();
-            self.0.extend(it);
-            return;
-        }
-
-        // General two-way merge.
-        let mut result: SmallVec<[Range<u32>; 2]> =
-            SmallVec::with_capacity(self.0.len() + other.0.len());
-        let mut a = std::mem::take(&mut self.0).into_iter().peekable();
-        let mut b = other.0.into_iter().peekable();
-
-        loop {
-            let pick_a = match (a.peek(), b.peek()) {
-                (Some(ra), Some(rb)) => ra.start <= rb.start,
-                (Some(_), None) => true,
-                (None, Some(_)) => false,
-                (None, None) => break,
-            };
-            let next = if pick_a {
-                a.next().unwrap()
-            } else {
-                b.next().unwrap()
-            };
-            match result.last_mut() {
-                Some(last) if last.end >= next.start => {
-                    last.end = last.end.max(next.end);
-                }
-                _ => result.push(next),
-            }
-        }
-
-        self.0 = result;
+        IdRanges::from_raw(inv)
     }
 
     /// Check if current [IdRange] is a subset of `other`. This means that all the elements
     /// described by the current [IdRange] can be found within the bounds of `other` [IdRange].
-    /// If there are some clock values not found within the `other` this method will return false.
     pub fn subset_of(&self, other: &Self) -> bool {
-        for range in self.iter() {
+        for (range, _) in self.iter() {
             if !Self::is_range_covered(range, other) {
                 return false;
             }
@@ -283,141 +77,73 @@ impl IdRange {
 
         let mut current = range.start;
 
-        for other_range in other.iter() {
-            // Skip ranges that end before our current position
+        for (other_range, _) in other.iter() {
             if other_range.end <= current {
                 continue;
             }
-
-            // If there's a gap before this range, we're not fully covered
             if other_range.start > current {
                 return false;
             }
-
-            // This range covers from current to its end
             current = other_range.end;
-
-            // If we've covered the entire range, we're done
             if current >= range.end {
                 return true;
             }
         }
 
-        // Check if we covered the entire range
         current >= range.end
     }
 
-    /// Excludes `other` from the current [IdRange]: every clock covered by `other` is removed
-    /// from `self`, leaving the parts of `self` that lie outside `other`.
-    pub fn exclude(&mut self, other: &Self) {
-        if other.0.is_empty() || self.0.is_empty() {
-            return;
-        }
-
-        let mut result = SmallVec::new();
-        let other = other.0.as_slice();
-        let mut i = 0usize;
-
-        for range in self.0.iter() {
-            let mut start = range.start;
-            let end = range.end;
-
-            // Drop other-ranges entirely to the left of [s..e). Monotone across iterations.
-            while i < other.len() && other[i].end <= start {
-                i += 1;
-            }
-
-            // Cut the other range from [s..e)
-            let mut j = i;
-            while start < end && j < other.len() {
-                let other_range = &other[j];
-                if other_range.start >= end {
-                    break; // remaining other-ranges lie past this self-range
-                }
-                if other_range.start > start {
-                    result.push(start..other_range.start);
-                }
-                start = start.max(other_range.end);
-                if other_range.end < end {
-                    j += 1; // consumed other range; move on
-                } else {
-                    break; // other range extends over the current one — keep it for the next self-range
-                }
-            }
-            if start < end {
-                result.push(start..end);
-            }
-            i = j;
-        }
-
-        *self = IdRange(result);
-    }
-
-    /// Computes the intersection of the current [IdRange] with `other`, modifying the current
-    /// range to contain only elements present in both ranges.
-    pub fn intersect(&mut self, other: &Self) {
-        if self.0.is_empty() || other.0.is_empty() {
-            *self = IdRange::default();
-            return;
-        }
-
-        let mut result = SmallVec::new();
-        let other = other.0.as_slice();
-        let mut i = 0usize;
-
-        for range in self.0.iter() {
-            while i < other.len() && other[i].end <= range.start {
-                i += 1;
-            }
-
-            let mut j = i;
-            while j < other.len() {
-                let other_range = &other[j];
-                if other_range.start >= range.end {
-                    break;
-                }
-                let lo = range.start.max(other_range.start);
-                let hi = range.end.min(other_range.end);
-                if lo < hi {
-                    result.push(lo..hi);
-                }
-                if other_range.end < range.end {
-                    j += 1;
-                } else {
-                    break;
-                }
-            }
-            i = j;
-        }
-
-        *self = IdRange(result);
-    }
-
     fn encode_raw<E: Encoder>(&self, encoder: &mut E) {
-        encoder.write_var(self.0.len() as u32);
-        for range in self.0.iter() {
+        encoder.write_var(self.len() as u32);
+        for (range, _) in self.iter() {
             range.encode(encoder);
         }
     }
 }
 
-impl Encode for IdRange {
+impl Encode for IdRanges<()> {
     #[inline]
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         self.encode_raw(encoder)
     }
 }
 
-impl Decode for IdRange {
+impl Decode for IdRanges<()> {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
         let len: u32 = decoder.read_var()?;
         let mut ranges = SmallVec::with_capacity(len as usize);
         for _ in 0..len {
-            ranges.push(Range::decode(decoder)?);
+            ranges.push((Range::decode(decoder)?, ()));
         }
-        Ok(IdRange(ranges))
+        Ok(IdRanges::from_raw(ranges))
     }
 }
+
+impl Hash for IdRanges<()> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for (range, _) in self.iter() {
+            range.hash(state);
+        }
+    }
+}
+
+impl std::fmt::Display for IdRanges<()> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut i = self.ranges();
+        write!(f, "[")?;
+        if let Some(r) = i.next() {
+            write!(f, "[{}..{})", r.start, r.end)?;
+        }
+        for r in i {
+            write!(f, ", [{}..{})", r.start, r.end)?;
+        }
+        write!(f, "]")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IdSet
+// ---------------------------------------------------------------------------
 
 /// IdSet is a set describing ranges of blocks stored within the document.
 ///
@@ -432,13 +158,78 @@ impl Decode for IdRange {
 /// - [crate::UndoManager] uses notion of stack items as a units of work, which can be undone/redone
 ///   together. Such stack item is a pair of (inserts, deletes), both of which are [IdSet]s.
 #[derive(Default, Clone, PartialEq, Eq)]
-pub struct IdSet(HashMap<ClientID, IdRange, BuildHasherDefault<ClientHasher>>);
+pub struct IdSet(pub(crate) IdMapInner<()>);
 
-pub type Iter<'a> = std::collections::hash_map::Iter<'a, ClientID, IdRange>;
+/// Iterator over `(ClientID, Ranges)` pairs in an [`IdSet`].
+pub struct Iter<'a>(std::collections::btree_map::Iter<'a, ClientID, IdRange>);
 
-//TODO: I'd say we should split IdSet and IdSet into two structures. While IdSet can be
-// implemented in terms of IdSet, it has more specific methods (related to deletion process), while
-// IdSet could contain wider area of use cases.
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a ClientID, Ranges<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(k, v)| (k, Ranges(v)))
+    }
+}
+
+/// A view of the clock ranges for a single client in an [`IdSet`].
+/// Provides iteration over `Range<u32>` values without exposing the
+/// internal value type.
+pub struct Ranges<'a>(&'a IdRange);
+
+impl<'a> Ranges<'a> {
+    /// Iterate over the clock ranges.
+    pub fn iter(&self) -> RangesIter<'a> {
+        RangesIter(self.0.inner().iter())
+    }
+
+    /// Check if a given clock value is covered by any range.
+    pub fn contains_clock(&self, clock: u32) -> bool {
+        self.0.contains_clock(clock)
+    }
+
+    /// Returns the number of disjoint ranges.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if there are no ranges.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'a> IntoIterator for Ranges<'a> {
+    type Item = &'a Range<u32>;
+    type IntoIter = RangesIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RangesIter(self.0.inner().iter())
+    }
+}
+
+/// Iterator over `&Range<u32>` values within a single client's [`Ranges`].
+pub struct RangesIter<'a>(std::slice::Iter<'a, (Range<u32>, ())>);
+
+impl<'a> Iterator for RangesIter<'a> {
+    type Item = &'a Range<u32>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(r, _)| r)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<'a> DoubleEndedIterator for RangesIter<'a> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.next_back().map(|(r, _)| r)
+    }
+}
+
+impl<'a> ExactSizeIterator for RangesIter<'a> {}
+
 impl IdSet {
     pub fn new() -> Self {
         Self::default()
@@ -450,102 +241,90 @@ impl IdSet {
         I2: IntoIterator<Item = Range<u32>>,
     {
         let mut set = Self::new();
-        for (client_id, range) in iter {
-            let range = IdRange(range.into_iter().collect());
-            set.0.insert(client_id, range);
+        for (client_id, ranges) in iter {
+            let range = IdRanges::from_ranges(ranges);
+            set.0.clients_mut().insert(client_id, range);
         }
         set
     }
 
-    /// Returns number of clients stored;
+    /// Returns number of clients stored.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
     pub fn iter(&self) -> Iter<'_> {
-        self.0.iter()
+        Iter(self.0.clients().iter())
     }
 
     pub fn range_mut(&mut self, client_id: ClientID) -> &mut IdRange {
-        self.0.entry(client_id).or_default()
+        self.0.entry_or_default(client_id)
     }
 
     /// Check if current [IdSet] contains given `id`.
     pub fn contains(&self, id: &ID) -> bool {
-        if let Some(ranges) = self.0.get(&id.client) {
-            ranges.contains_clock(id.clock)
-        } else {
-            false
-        }
+        self.0.contains(id)
     }
 
     /// Checks if current ID set contains any data.
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty() || self.0.values().all(|r| r.is_empty())
+        self.0.is_empty()
     }
 
     pub fn insert(&mut self, id: ID, len: u32) {
         self.0
-            .entry(id.client)
-            .or_default()
+            .entry_or_default(id.client)
             .insert(id.clock..(id.clock + len));
     }
 
     /// Inserts a new ID `range` corresponding with a given `client`.
     pub fn insert_range(&mut self, client: ClientID, range: IdRange) {
-        self.0.insert(client, range);
+        match self.0.clients_mut().entry(client) {
+            std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(range),
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(range);
+            }
+        }
     }
 
     /// Merges another ID set into a current one, combining their information about observed ID
     /// ranges. Per-client [IdRange] merge maintains the canonical invariant on its own, so no
     /// trailing squash is needed.
     pub fn merge_with(&mut self, other: Self) {
-        other.0.into_iter().for_each(|(client, range)| {
-            if let Some(r) = self.0.get_mut(&client) {
-                r.merge(range)
-            } else {
-                self.0.insert(client, range);
-            }
-        });
+        self.0.merge_with(&other.0);
     }
 
     /// Removes from `self` every clock range covered by `other`. Per-client [IdRange]s are
     /// excluded individually; clients absent from `other` are left untouched.
     pub fn diff_with(&mut self, other: &Self) {
-        self.0.retain(|client, ranges| {
-            if let Some(other_ranges) = other.0.get(client) {
-                ranges.exclude(other_ranges);
-            }
-            !ranges.is_empty()
-        });
+        self.0.diff_with(&other.0);
     }
 
     /// Replaces `self` with the per-client intersection against `other`. Clients present only
     /// in `self` (or only in `other`) are dropped.
     pub fn intersect_with(&mut self, other: &Self) {
-        self.0.retain(|client, ranges| match other.0.get(client) {
-            Some(other_ranges) => {
-                ranges.intersect(other_ranges);
-                !ranges.is_empty()
-            }
-            None => false,
-        });
+        self.0.intersect_with(&other.0);
     }
 
     /// Remove a given range of elements from the current [IdSet]. If the client's [IdRange]
     /// becomes empty as a result, the client entry is dropped from the set entirely.
     pub fn remove_range(&mut self, range: &BlockRange) {
-        if let Entry::Occupied(mut e) = self.0.entry(range.id.client) {
-            let id_range = e.get_mut();
-            id_range.remove(range.id.clock..(range.id.clock + range.len));
-            if id_range.is_empty() {
-                e.remove();
+        if let Some(r) = self.0.get_mut(&range.id.client) {
+            r.remove(range.id.clock..(range.id.clock + range.len));
+            if r.is_empty() {
+                self.0.clients_mut().remove(&range.id.client);
             }
         }
     }
 
     pub fn get(&self, client_id: &ClientID) -> Option<&IdRange> {
         self.0.get(client_id)
+    }
+
+    /// Direct access to the inner [IdMapInner] (crate-internal).
+    #[inline]
+    pub(crate) fn inner(&self) -> &IdMapInner<()> {
+        &self.0
     }
 }
 
@@ -569,7 +348,7 @@ impl Decode for IdSet {
             decoder.reset_ds_cur_val();
             let client: u64 = decoder.read_var()?;
             let range = IdRange::decode(decoder)?;
-            set.0.insert(ClientID::new(client), range);
+            set.0.clients_mut().insert(ClientID::new(client), range);
             i += 1;
         }
         Ok(set)
@@ -642,31 +421,16 @@ impl std::fmt::Debug for IdSet {
 impl std::fmt::Display for IdSet {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut s = f.debug_struct("");
-        for (k, v) in self.iter() {
+        for (k, v) in self.0.iter() {
             s.field(&k.to_string(), v);
         }
         s.finish()
     }
 }
 
-impl std::fmt::Debug for IdRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
-    }
-}
-impl std::fmt::Display for IdRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut i = self.iter();
-        write!(f, "[")?;
-        if let Some(r) = i.next() {
-            write!(f, "[{}..{})", r.start, r.end)?;
-        }
-        while let Some(r) = i.next() {
-            write!(f, ", [{}..{})", r.start, r.end)?;
-        }
-        write!(f, "]")
-    }
-}
+// ---------------------------------------------------------------------------
+// DeleteSet
+// ---------------------------------------------------------------------------
 
 /// An extension over [IdSet] that defines methods specific to work with block store deletions.
 pub(crate) trait DeleteSet {
@@ -692,7 +456,7 @@ impl DeleteSet for IdSet {
             }
 
             if !deletes.is_empty() {
-                set.0.insert(client, deletes);
+                set.0.clients_mut().insert(client, deletes);
             }
         }
         set
@@ -700,9 +464,9 @@ impl DeleteSet for IdSet {
 
     fn try_squash_with(&mut self, store: &mut Store) {
         // try to merge deleted / gc'd items
-        for (&client, range) in self.iter() {
+        for (&client, range) in self.0.iter() {
             let blocks = store.blocks.get_client_blocks_mut(client);
-            for r in range.iter().rev() {
+            for (r, _) in range.iter().rev() {
                 // start with merging the item next to the last deleted item
                 let mut si =
                     (blocks.len() - 1).min(1 + blocks.find_pivot(r.end - 1).unwrap_or_default());
@@ -730,16 +494,16 @@ impl DeleteSet for IdSet {
 }
 
 pub(crate) struct Blocks<'ds> {
-    ds_iter: Iter<'ds>,
-    current_range: Option<&'ds Range<u32>>,
+    ds_iter: std::collections::btree_map::Iter<'ds, ClientID, IdRange>,
+    current_range: Option<Range<u32>>,
     current_client_id: Option<ClientID>,
-    range_iter: Option<std::slice::Iter<'ds, Range<u32>>>,
+    range_iter: Option<std::slice::Iter<'ds, (Range<u32>, ())>>,
     current_index: Option<usize>,
 }
 
 impl<'ds> Blocks<'ds> {
     pub(crate) fn new(ds: &'ds IdSet) -> Self {
-        let ds_iter = ds.iter();
+        let ds_iter = ds.0.clients().iter();
         Blocks {
             ds_iter,
             current_client_id: None,
@@ -754,7 +518,7 @@ impl<'ds> TxnIterator for Blocks<'ds> {
     type Item = BlockSlice;
 
     fn next<T: ReadTxn>(&mut self, txn: &T) -> Option<Self::Item> {
-        if let Some(r) = self.current_range {
+        if let Some(r) = self.current_range.clone() {
             let mut block = if let Some(idx) = self.current_index.as_mut() {
                 if let Some(block) = txn
                     .store()
@@ -820,22 +584,22 @@ impl<'ds> TxnIterator for Blocks<'ds> {
                 iter
             } else {
                 let (client_id, range) = self.ds_iter.next()?;
-                self.current_client_id = Some(client_id.clone());
+                self.current_client_id = Some(*client_id);
                 self.current_index = None;
-                self.range_iter = Some(range.iter());
+                self.range_iter = Some(range.inner().iter());
                 self.range_iter.as_mut().unwrap()
             };
             self.current_range = match range_iter.next() {
                 None => {
                     let (client_id, range) = self.ds_iter.next()?;
-                    self.current_client_id = Some(client_id.clone());
+                    self.current_client_id = Some(*client_id);
                     self.current_index = None;
-                    let mut iter = range.iter();
-                    let range = iter.next();
+                    let mut iter = range.inner().iter();
+                    let entry = iter.next();
                     self.range_iter = Some(iter);
-                    range
+                    entry.map(|(r, _)| r.clone())
                 }
-                other => other,
+                Some((r, _)) => Some(r.clone()),
             };
             return self.next(txn);
         }
@@ -843,132 +607,117 @@ impl<'ds> TxnIterator for Blocks<'ds> {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use crate::block::{BlockRange, ClientID, ItemContent};
     use crate::id_set::{DeleteSet, IdRange, IdSet};
+    use crate::ids::IdRanges;
     use crate::iter::TxnIterator;
     use crate::slice::BlockSlice;
     use crate::test_utils::exchange_updates;
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::{Encode, Encoder, EncoderV1};
     use crate::{Doc, Options, ReadTxn, Text, Transact, ID};
-    use smallvec::smallvec;
     use std::collections::HashSet;
     use std::fmt::Debug;
 
+    /// Helper to build an IdRange from a list of ranges.
+    fn id_range(ranges: impl IntoIterator<Item = Range<u32>>) -> IdRange {
+        IdRanges::from_ranges(ranges)
+    }
+
+    use std::ops::Range;
+
     #[test]
     fn id_range_merge_continous() {
-        // `b` entirely within `a`
-        let mut a = IdRange(smallvec![0..5]);
-        a.merge(IdRange(smallvec![2..4]));
-        assert_eq!(a, IdRange(smallvec![0..5]));
+        let mut a = id_range([0..5]);
+        a.merge(id_range([2..4]));
+        assert_eq!(a, id_range([0..5]));
 
-        // the tail of `a` crosses the head of `b`
-        let mut a = IdRange(smallvec![0..5]);
-        a.merge(IdRange(smallvec![4..9]));
-        assert_eq!(a, IdRange(smallvec![0..9]));
+        let mut a = id_range([0..5]);
+        a.merge(id_range([4..9]));
+        assert_eq!(a, id_range([0..9]));
 
-        // `b` is immediately adjacent to the end of `a`
-        let mut a = IdRange(smallvec![0..5]);
-        a.merge(IdRange(smallvec![5..9]));
-        assert_eq!(a, IdRange(smallvec![0..9]));
+        let mut a = id_range([0..5]);
+        a.merge(id_range([5..9]));
+        assert_eq!(a, id_range([0..9]));
 
-        // `a` does not intersect with `b`
-        let mut a = IdRange(smallvec![0..4]);
-        a.merge(IdRange(smallvec![6..9]));
-        assert_eq!(a, IdRange(smallvec![0..4, 6..9]));
+        let mut a = id_range([0..4]);
+        a.merge(id_range([6..9]));
+        assert_eq!(a, id_range([0..4, 6..9]));
     }
 
     #[test]
     fn id_range_merge_canonical() {
-        // Empty into non-empty — self unchanged.
-        let mut a = IdRange(smallvec![0..3]);
+        let mut a = id_range([0..3]);
         a.merge(IdRange::default());
-        assert_eq!(a, IdRange(smallvec![0..3]));
+        assert_eq!(a, id_range([0..3]));
 
-        // Non-empty into empty — adopts other.
         let mut a = IdRange::default();
-        a.merge(IdRange(smallvec![1..5]));
-        assert_eq!(a, IdRange(smallvec![1..5]));
+        a.merge(id_range([1..5]));
+        assert_eq!(a, id_range([1..5]));
 
-        // Other has lower start than self — sorted output.
-        let mut a = IdRange(smallvec![5..7]);
-        a.merge(IdRange(smallvec![1..3]));
-        assert_eq!(a, IdRange(smallvec![1..3, 5..7]));
+        let mut a = id_range([5..7]);
+        a.merge(id_range([1..3]));
+        assert_eq!(a, id_range([1..3, 5..7]));
 
-        // Two-way merge with overlapping middles.
-        let mut a = IdRange(smallvec![0..2, 4..6, 10..12]);
-        a.merge(IdRange(smallvec![1..5, 11..15]));
-        // [0..2] + [1..5] -> [0..5], absorbs [4..6] -> [0..6]; [10..12] + [11..15] -> [10..15]
-        assert_eq!(a, IdRange(smallvec![0..6, 10..15]));
+        let mut a = id_range([0..2, 4..6, 10..12]);
+        a.merge(id_range([1..5, 11..15]));
+        assert_eq!(a, id_range([0..6, 10..15]));
 
-        // Cross-source adjacency must merge.
-        let mut a = IdRange(smallvec![0..3, 10..12]);
-        a.merge(IdRange(smallvec![3..5, 12..14]));
-        assert_eq!(a, IdRange(smallvec![0..5, 10..14]));
+        let mut a = id_range([0..3, 10..12]);
+        a.merge(id_range([3..5, 12..14]));
+        assert_eq!(a, id_range([0..5, 10..14]));
 
-        // Interleaved disjoint ranges stay disjoint and sorted.
-        let mut a = IdRange(smallvec![0..2, 6..8]);
-        a.merge(IdRange(smallvec![3..5, 9..11]));
-        assert_eq!(a, IdRange(smallvec![0..2, 3..5, 6..8, 9..11]));
+        let mut a = id_range([0..2, 6..8]);
+        a.merge(id_range([3..5, 9..11]));
+        assert_eq!(a, id_range([0..2, 3..5, 6..8, 9..11]));
     }
 
     #[test]
     fn id_range_compact() {
-        // Same canonical end-state as the old squash-based test, now produced incrementally
-        // by merge-on-insert: adjacent [0..3) + [3..5) collapses, [6..7) stays separate.
         let mut r = IdRange::default();
         r.insert(0..3);
         r.insert(3..5);
         r.insert(6..7);
-        assert_eq!(r, IdRange(smallvec![0..5, 6..7]));
+        assert_eq!(r, id_range([0..5, 6..7]));
     }
 
     #[test]
     fn id_range_invert() {
-        assert!(IdRange(smallvec![0..3]).invert().is_empty());
-
-        assert_eq!(IdRange(smallvec![3..5]).invert(), IdRange(smallvec![0..3]));
-
-        assert_eq!(
-            IdRange(smallvec![0..3, 4..5]).invert(),
-            IdRange(smallvec![3..4])
-        );
-
-        assert_eq!(
-            IdRange(smallvec![3..4, 7..9]).invert(),
-            IdRange(smallvec![0..3, 4..7])
-        );
+        assert!(id_range([0..3]).invert().is_empty());
+        assert_eq!(id_range([3..5]).invert(), id_range([0..3]));
+        assert_eq!(id_range([0..3, 4..5]).invert(), id_range([3..4]));
+        assert_eq!(id_range([3..4, 7..9]).invert(), id_range([0..3, 4..7]));
     }
 
     #[test]
     fn id_range_contains() {
-        assert!(!IdRange(smallvec![1..3]).contains_clock(0));
-        assert!(IdRange(smallvec![1..3]).contains_clock(1));
-        assert!(IdRange(smallvec![1..3]).contains_clock(2));
-        assert!(!IdRange(smallvec![1..3]).contains_clock(3));
+        assert!(!id_range([1..3]).contains_clock(0));
+        assert!(id_range([1..3]).contains_clock(1));
+        assert!(id_range([1..3]).contains_clock(2));
+        assert!(!id_range([1..3]).contains_clock(3));
 
-        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(0));
-        assert!(IdRange(smallvec![1..3, 4..5]).contains_clock(1));
-        assert!(IdRange(smallvec![1..3, 4..5]).contains_clock(2));
-        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(3));
-        assert!(IdRange(smallvec![1..3, 4..5]).contains_clock(4));
-        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(5));
-        assert!(!IdRange(smallvec![1..3, 4..5]).contains_clock(6));
+        assert!(!id_range([1..3, 4..5]).contains_clock(0));
+        assert!(id_range([1..3, 4..5]).contains_clock(1));
+        assert!(id_range([1..3, 4..5]).contains_clock(2));
+        assert!(!id_range([1..3, 4..5]).contains_clock(3));
+        assert!(id_range([1..3, 4..5]).contains_clock(4));
+        assert!(!id_range([1..3, 4..5]).contains_clock(5));
+        assert!(!id_range([1..3, 4..5]).contains_clock(6));
     }
 
     #[test]
     fn id_range_push() {
-        let mut range = IdRange(smallvec![]);
+        let mut range = IdRange::default();
 
         range.insert(0..4);
-        assert_eq!(range, IdRange(smallvec![0..4]));
+        assert_eq!(range, id_range([0..4]));
 
         range.insert(4..6);
-        assert_eq!(range, IdRange(smallvec![0..6]));
+        assert_eq!(range, id_range([0..6]));
 
         range.insert(7..9);
-        assert_eq!(range, IdRange(smallvec![0..6, 7..9]));
+        assert_eq!(range, id_range([0..6, 7..9]));
     }
 
     #[test]
@@ -977,8 +726,7 @@ mod test {
         range.insert(5..7);
         range.insert(1..3);
         range.insert(3..5);
-        // Adjacency-chain: [3..5) bridges [1..3) and [5..7) into a single [1..7).
-        assert_eq!(range, IdRange(smallvec![1..7]));
+        assert_eq!(range, id_range([1..7]));
     }
 
     #[test]
@@ -988,7 +736,7 @@ mod test {
         assert_eq!(range, IdRange::default());
         range.insert(0..3);
         range.insert(7..7);
-        assert_eq!(range, IdRange(smallvec![0..3]));
+        assert_eq!(range, id_range([0..3]));
     }
 
     #[test]
@@ -998,8 +746,7 @@ mod test {
         range.insert(4..6);
         range.insert(8..10);
         range.insert(1..9);
-        // The single push spans three existing ranges — all collapse into one.
-        assert_eq!(range, IdRange(smallvec![0..10]));
+        assert_eq!(range, id_range([0..10]));
     }
 
     #[test]
@@ -1007,8 +754,7 @@ mod test {
         let mut range = IdRange::default();
         range.insert(0..3);
         range.insert(3..5);
-        // Adjacent (touching at 3) — must merge, not stay split.
-        assert_eq!(range, IdRange(smallvec![0..5]));
+        assert_eq!(range, id_range([0..5]));
     }
 
     #[test]
@@ -1016,86 +762,70 @@ mod test {
         let mut range = IdRange::default();
         range.insert(5..7);
         range.insert(1..3);
-        // Front insert preserves order; no adjacency to merge.
-        assert_eq!(range, IdRange(smallvec![1..3, 5..7]));
+        assert_eq!(range, id_range([1..3, 5..7]));
     }
 
     #[test]
     fn id_range_remove() {
-        // No-op: empty input range.
-        let mut r = IdRange(smallvec![0..10]);
+        let mut r = id_range([0..10]);
         r.remove(5..5);
-        assert_eq!(r, IdRange(smallvec![0..10]));
+        assert_eq!(r, id_range([0..10]));
 
-        // No-op: range starts past every entry.
-        let mut r = IdRange(smallvec![0..5]);
+        let mut r = id_range([0..5]);
         r.remove(10..15);
-        assert_eq!(r, IdRange(smallvec![0..5]));
+        assert_eq!(r, id_range([0..5]));
 
-        // No-op: range falls entirely in a gap.
-        let mut r = IdRange(smallvec![0..5, 10..15]);
+        let mut r = id_range([0..5, 10..15]);
         r.remove(5..10);
-        assert_eq!(r, IdRange(smallvec![0..5, 10..15]));
+        assert_eq!(r, id_range([0..5, 10..15]));
 
-        // Split: range strictly inside a single entry.
-        let mut r = IdRange(smallvec![0..10]);
+        let mut r = id_range([0..10]);
         r.remove(3..7);
-        assert_eq!(r, IdRange(smallvec![0..3, 7..10]));
+        assert_eq!(r, id_range([0..3, 7..10]));
 
-        // Trim left edge: removal hits the head of a single entry.
-        let mut r = IdRange(smallvec![0..10]);
+        let mut r = id_range([0..10]);
         r.remove(0..3);
-        assert_eq!(r, IdRange(smallvec![3..10]));
+        assert_eq!(r, id_range([3..10]));
 
-        // Trim right edge: removal hits the tail of a single entry.
-        let mut r = IdRange(smallvec![0..10]);
+        let mut r = id_range([0..10]);
         r.remove(7..10);
-        assert_eq!(r, IdRange(smallvec![0..7]));
+        assert_eq!(r, id_range([0..7]));
 
-        // Exact match: drop the only entry.
-        let mut r = IdRange(smallvec![0..10]);
+        let mut r = id_range([0..10]);
         r.remove(0..10);
         assert_eq!(r, IdRange::default());
 
-        // Spans multiple entries — left trim, drop middle, right trim.
-        let mut r = IdRange(smallvec![0..3, 6..10, 12..15]);
+        let mut r = id_range([0..3, 6..10, 12..15]);
         r.remove(2..13);
-        assert_eq!(r, IdRange(smallvec![0..2, 13..15]));
+        assert_eq!(r, id_range([0..2, 13..15]));
 
-        // Spans multiple entries — drop two adjacent entries entirely.
-        let mut r = IdRange(smallvec![0..3, 6..10, 12..15]);
+        let mut r = id_range([0..3, 6..10, 12..15]);
         r.remove(0..15);
         assert_eq!(r, IdRange::default());
 
-        // Removal that exceeds the rightmost entry on its right side.
-        let mut r = IdRange(smallvec![0..5, 10..15]);
+        let mut r = id_range([0..5, 10..15]);
         r.remove(12..100);
-        assert_eq!(r, IdRange(smallvec![0..5, 10..12]));
+        assert_eq!(r, id_range([0..5, 10..12]));
 
-        // Removal beginning before the first entry.
-        let mut r = IdRange(smallvec![5..10]);
+        let mut r = id_range([5..10]);
         r.remove(0..7);
-        assert_eq!(r, IdRange(smallvec![7..10]));
+        assert_eq!(r, id_range([7..10]));
     }
 
     #[test]
     fn id_set_remove() {
-        // Removing from a client absent from the set is a no-op.
         let mut set = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         set.remove_range(&BlockRange::new(ID::new(ClientID::new(2), 0), 5));
         assert_eq!(set, IdSet::from_iter([(ClientID::new(1), [0..10])]));
 
-        // Partial removal — split.
         let mut set = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         set.remove_range(&BlockRange::new(ID::new(ClientID::new(1), 3), 4));
         assert_eq!(set, IdSet::from_iter([(ClientID::new(1), [0..3, 7..10])]));
 
-        // Removing the entire IdRange drops the client.
         let mut set = IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [0..5])]);
         set.remove_range(&BlockRange::new(ID::new(ClientID::new(1), 0), 10));
         assert_eq!(set, IdSet::from_iter([(ClientID::new(2), [0..5])]));
 
-        // Empty len is a no-op.
         let mut set = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         set.remove_range(&BlockRange::new(ID::new(ClientID::new(1), 5), 0));
         assert_eq!(set, IdSet::from_iter([(ClientID::new(1), [0..10])]));
@@ -1103,147 +833,125 @@ mod test {
 
     #[test]
     fn id_range_push_subset_of_last() {
-        // Tail-fast path must not shrink the last range when the new range is a
-        // subset of it (range.start >= last.start AND range.end <= last.end).
         let mut range = IdRange::default();
         range.insert(0..10);
         range.insert(5..7);
-        assert_eq!(range, IdRange(smallvec![0..10]));
+        assert_eq!(range, id_range([0..10]));
 
-        // Boundary: range.end == last.end — also a subset, must be a no-op.
         let mut range = IdRange::default();
         range.insert(0..10);
         range.insert(3..10);
-        assert_eq!(range, IdRange(smallvec![0..10]));
+        assert_eq!(range, id_range([0..10]));
 
-        // Boundary: identical to last.
         let mut range = IdRange::default();
         range.insert(0..10);
         range.insert(0..10);
-        assert_eq!(range, IdRange(smallvec![0..10]));
+        assert_eq!(range, id_range([0..10]));
     }
 
     #[test]
     fn id_range_subset_of() {
-        assert!(IdRange(smallvec![1..2]).subset_of(&IdRange(smallvec![1..2])));
-        assert!(IdRange(smallvec![1..2]).subset_of(&IdRange(smallvec![0..2])));
-        assert!(IdRange(smallvec![1..2]).subset_of(&IdRange(smallvec![1..3])));
+        assert!(id_range([1..2]).subset_of(&id_range([1..2])));
+        assert!(id_range([1..2]).subset_of(&id_range([0..2])));
+        assert!(id_range([1..2]).subset_of(&id_range([1..3])));
 
-        assert!(IdRange(smallvec![1..2, 3..4]).subset_of(&IdRange(smallvec![1..4])));
-        assert!(IdRange(smallvec![1..2, 3..4, 5..6]).subset_of(&IdRange(smallvec![1..2, 3..6])));
-        assert!(IdRange(smallvec![3..4, 5..6]).subset_of(&IdRange(smallvec![0..1, 3..6])));
-        assert!(IdRange(smallvec![3..4, 5..6]).subset_of(&IdRange(smallvec![3..4, 5..6])));
+        assert!(id_range([1..2, 3..4]).subset_of(&id_range([1..4])));
+        assert!(id_range([1..2, 3..4, 5..6]).subset_of(&id_range([1..2, 3..6])));
+        assert!(id_range([3..4, 5..6]).subset_of(&id_range([0..1, 3..6])));
+        assert!(id_range([3..4, 5..6]).subset_of(&id_range([3..4, 5..6])));
 
-        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![0..2])));
-        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![1..2])));
-        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![2..3])));
-        assert!(!IdRange(smallvec![1..3]).subset_of(&IdRange(smallvec![2..4])));
+        assert!(!id_range([1..3]).subset_of(&id_range([0..2])));
+        assert!(!id_range([1..3]).subset_of(&id_range([1..2])));
+        assert!(!id_range([1..3]).subset_of(&id_range([2..3])));
+        assert!(!id_range([1..3]).subset_of(&id_range([2..4])));
 
-        assert!(!IdRange(smallvec![1..2, 3..4]).subset_of(&IdRange(smallvec![1..3])));
-        assert!(!IdRange(smallvec![1..2, 3..6]).subset_of(&IdRange(smallvec![1..2, 3..5])));
-        assert!(!IdRange(smallvec![1..2, 3..6]).subset_of(&IdRange(smallvec![1..2, 4..7])));
+        assert!(!id_range([1..2, 3..4]).subset_of(&id_range([1..3])));
+        assert!(!id_range([1..2, 3..6]).subset_of(&id_range([1..2, 3..5])));
+        assert!(!id_range([1..2, 3..6]).subset_of(&id_range([1..2, 4..7])));
     }
 
     #[test]
     fn id_range_exclude() {
-        // exclude from the left side
-        let mut a = IdRange(smallvec![0..4]);
-        a.exclude(&IdRange(smallvec![0..2]));
-        assert_eq!(a, IdRange(smallvec![2..4]));
+        let mut a = id_range([0..4]);
+        a.exclude(&id_range([0..2]));
+        assert_eq!(a, id_range([2..4]));
 
-        // exclude from the right side
-        let mut a = IdRange(smallvec![0..4]);
-        a.exclude(&IdRange(smallvec![2..4]));
-        assert_eq!(a, IdRange(smallvec![0..2]));
+        let mut a = id_range([0..4]);
+        a.exclude(&id_range([2..4]));
+        assert_eq!(a, id_range([0..2]));
 
-        // exclude in the middle - splitting the continuous block in two
-        let mut a = IdRange(smallvec![0..4]);
-        a.exclude(&IdRange(smallvec![1..3]));
-        assert_eq!(a, IdRange(smallvec![0..1, 3..4]));
+        let mut a = id_range([0..4]);
+        a.exclude(&id_range([1..3]));
+        assert_eq!(a, id_range([0..1, 3..4]));
 
-        // exclude fragmented block - splitting single range into >2 ranges
-        let mut a = IdRange(smallvec![0..10]);
-        a.exclude(&IdRange(smallvec![1..3, 4..5]));
-        assert_eq!(a, IdRange(smallvec![0..1, 3..4, 5..10]));
+        let mut a = id_range([0..10]);
+        a.exclude(&id_range([1..3, 4..5]));
+        assert_eq!(a, id_range([0..1, 3..4, 5..10]));
 
-        // exclude continuous range overlapping with more than one range
-        let mut a = IdRange(smallvec![0..4, 5..6, 7..10]);
-        a.exclude(&IdRange(smallvec![3..8]));
-        assert_eq!(a, IdRange(smallvec![0..3, 8..10]));
+        let mut a = id_range([0..4, 5..6, 7..10]);
+        a.exclude(&id_range([3..8]));
+        assert_eq!(a, id_range([0..3, 8..10]));
 
-        // exclude two fragmented ranges with partially overlapping boundaries
-        let mut a = IdRange(smallvec![0..4, 7..10]);
-        a.exclude(&IdRange(smallvec![3..5, 6..9]));
-        assert_eq!(a, IdRange(smallvec![0..3, 9..10]));
+        let mut a = id_range([0..4, 7..10]);
+        a.exclude(&id_range([3..5, 6..9]));
+        assert_eq!(a, id_range([0..3, 9..10]));
 
-        // exclude fragmented ranges, when one gets split into 2+, and another overlaps at the end
-        let mut a = IdRange(smallvec![0..4, 7..10]);
-        a.exclude(&IdRange(smallvec![2..3, 5..6, 9..10]));
-        assert_eq!(a, IdRange(smallvec![0..2, 3..4, 7..9]));
+        let mut a = id_range([0..4, 7..10]);
+        a.exclude(&id_range([2..3, 5..6, 9..10]));
+        assert_eq!(a, id_range([0..2, 3..4, 7..9]));
     }
 
     #[test]
     fn id_range_intersect() {
-        // Basic continuous range intersection
-        let mut a = IdRange(smallvec![0..10]);
-        a.intersect(&IdRange(smallvec![5..15]));
-        assert_eq!(a, IdRange(smallvec![5..10]));
+        let mut a = id_range([0..10]);
+        a.intersect(&id_range([5..15]));
+        assert_eq!(a, id_range([5..10]));
 
-        // Fragmented intersecting with continuous
-        let mut a = IdRange(smallvec![0..5, 10..15]);
-        a.intersect(&IdRange(smallvec![3..12]));
-        assert_eq!(a, IdRange(smallvec![3..5, 10..12]));
+        let mut a = id_range([0..5, 10..15]);
+        a.intersect(&id_range([3..12]));
+        assert_eq!(a, id_range([3..5, 10..12]));
 
-        // No overlap - empty result
-        let mut a = IdRange(smallvec![0..5]);
-        a.intersect(&IdRange(smallvec![10..15]));
+        let mut a = id_range([0..5]);
+        a.intersect(&id_range([10..15]));
         assert_eq!(a, IdRange::default());
 
-        // Multiple ranges with multiple intersections
-        let mut a = IdRange(smallvec![1..4, 6..9]);
-        a.intersect(&IdRange(smallvec![2..7]));
-        assert_eq!(a, IdRange(smallvec![2..4, 6..7]));
+        let mut a = id_range([1..4, 6..9]);
+        a.intersect(&id_range([2..7]));
+        assert_eq!(a, id_range([2..4, 6..7]));
 
-        // Complete overlap
-        let mut a = IdRange(smallvec![2..8]);
-        a.intersect(&IdRange(smallvec![0..10]));
-        assert_eq!(a, IdRange(smallvec![2..8]));
+        let mut a = id_range([2..8]);
+        a.intersect(&id_range([0..10]));
+        assert_eq!(a, id_range([2..8]));
 
-        // Partial overlap on both sides
-        let mut a = IdRange(smallvec![5..15]);
-        a.intersect(&IdRange(smallvec![0..10]));
-        assert_eq!(a, IdRange(smallvec![5..10]));
+        let mut a = id_range([5..15]);
+        a.intersect(&id_range([0..10]));
+        assert_eq!(a, id_range([5..10]));
 
-        // Fragmented with fragmented
-        let mut a = IdRange(smallvec![0..5, 10..15, 20..25]);
-        a.intersect(&IdRange(smallvec![3..12, 22..30]));
-        assert_eq!(a, IdRange(smallvec![3..5, 10..12, 22..25]));
+        let mut a = id_range([0..5, 10..15, 20..25]);
+        a.intersect(&id_range([3..12, 22..30]));
+        assert_eq!(a, id_range([3..5, 10..12, 22..25]));
 
-        // Exact match
-        let mut a = IdRange(smallvec![5..10]);
-        a.intersect(&IdRange(smallvec![5..10]));
-        assert_eq!(a, IdRange(smallvec![5..10]));
+        let mut a = id_range([5..10]);
+        a.intersect(&id_range([5..10]));
+        assert_eq!(a, id_range([5..10]));
 
-        // Single element overlap
-        let mut a = IdRange(smallvec![0..5]);
-        a.intersect(&IdRange(smallvec![4..10]));
-        assert_eq!(a, IdRange(smallvec![4..5]));
+        let mut a = id_range([0..5]);
+        a.intersect(&id_range([4..10]));
+        assert_eq!(a, id_range([4..5]));
 
-        // Half-open boundary touch — must not yield an empty range.
-        let mut a = IdRange(smallvec![0..5]);
-        a.intersect(&IdRange(smallvec![5..10]));
+        let mut a = id_range([0..5]);
+        a.intersect(&id_range([5..10]));
         assert_eq!(a, IdRange::default());
     }
 
     #[test]
     fn id_range_encode_decode() {
-        roundtrip(&IdRange(smallvec![0..4]));
-        roundtrip(&IdRange(smallvec![1..4, 5..8]));
+        roundtrip(&id_range([0..4]));
+        roundtrip(&id_range([1..4, 5..8]));
     }
 
     #[test]
     fn id_set_exclude() {
-        // Clients only in `self` are untouched; clients only in `other` are ignored.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [0..5])]);
         let b = IdSet::from_iter([(ClientID::new(2), [0..3]), (ClientID::new(3), [0..100])]);
         a.diff_with(&b);
@@ -1252,19 +960,16 @@ mod test {
             IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [3..5])])
         );
 
-        // Per-client exclude carves the right shape (split into two).
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         let b = IdSet::from_iter([(ClientID::new(1), [3..7])]);
         a.diff_with(&b);
         assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [0..3, 7..10])]));
 
-        // Clients whose ranges become empty are dropped entirely.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..5]), (ClientID::new(2), [0..5])]);
         let b = IdSet::from_iter([(ClientID::new(1), [0..5])]);
         a.diff_with(&b);
         assert_eq!(a, IdSet::from_iter([(ClientID::new(2), [0..5])]));
 
-        // Excluding an empty other is a no-op.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         a.diff_with(&IdSet::new());
         assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [0..10])]));
@@ -1272,25 +977,21 @@ mod test {
 
     #[test]
     fn id_set_intersect() {
-        // Clients present only in `self` are dropped.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..10]), (ClientID::new(2), [0..5])]);
         let b = IdSet::from_iter([(ClientID::new(1), [5..15])]);
         a.intersect_with(&b);
         assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [5..10])]));
 
-        // Clients present only in `other` are ignored.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         let b = IdSet::from_iter([(ClientID::new(1), [3..7]), (ClientID::new(2), [0..100])]);
         a.intersect_with(&b);
         assert_eq!(a, IdSet::from_iter([(ClientID::new(1), [3..7])]));
 
-        // Clients whose intersection is empty (disjoint ranges) are dropped.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..5]), (ClientID::new(2), [0..5])]);
         let b = IdSet::from_iter([(ClientID::new(1), [10..20]), (ClientID::new(2), [1..4])]);
         a.intersect_with(&b);
         assert_eq!(a, IdSet::from_iter([(ClientID::new(2), [1..4])]));
 
-        // Intersecting with an empty other yields empty.
         let mut a = IdSet::from_iter([(ClientID::new(1), [0..10])]);
         a.intersect_with(&IdSet::new());
         assert!(a.is_empty());

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -64,6 +64,10 @@ impl<'a> IntoIterator for &'a IdRange {
 }
 
 impl IdRange {
+    pub(crate) fn new(ranges: SmallVec<[Range<u32>; 2]>) -> Self {
+        IdRange(ranges)
+    }
+
     pub fn with_capacity(capacity: usize) -> Self {
         IdRange(SmallVec::with_capacity(capacity))
     }
@@ -81,6 +85,28 @@ impl IdRange {
             start = range.end;
         }
         IdRange(inv)
+    }
+
+    pub fn find_start(&self, clock: u32) -> Option<usize> {
+        let mut left = 0;
+        let mut right = self.0.len() - 1;
+        while left <= right {
+            let mid_idx = (left + right) / 2;
+            let range = &self.0[mid_idx];
+            if range.start <= clock {
+                if clock < range.end {
+                    return Some(mid_idx);
+                }
+                left = mid_idx + 1;
+            } else {
+                right = mid_idx - 1;
+            }
+        }
+        if left < self.0.len() {
+            Some(left)
+        } else {
+            None
+        }
     }
 
     /// Check if given clock exists within current [IdRange].
@@ -438,6 +464,10 @@ impl IdSet {
 
     pub fn iter(&self) -> Iter<'_> {
         self.0.iter()
+    }
+
+    pub fn range_mut(&mut self, client_id: ClientID) -> &mut IdRange {
+        self.0.entry(client_id).or_default()
     }
 
     /// Check if current [IdSet] contains given `id`.

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -254,7 +254,7 @@ impl IdSet {
     /// Inserts a new ID `range` corresponding with a given `client`.
     pub fn insert_range(&mut self, client: ClientID, range: IdRange) {
         match self.0.clients_mut().entry(client) {
-            std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(range),
+            std::collections::btree_map::Entry::Occupied(mut e) => e.get_mut().merge(&range),
             std::collections::btree_map::Entry::Vacant(e) => {
                 e.insert(range);
             }
@@ -595,46 +595,46 @@ pub(crate) mod test {
     #[test]
     fn id_range_merge_continous() {
         let mut a = id_range([0..5]);
-        a.merge(id_range([2..4]));
+        a.merge(&id_range([2..4]));
         assert_eq!(a, id_range([0..5]));
 
         let mut a = id_range([0..5]);
-        a.merge(id_range([4..9]));
+        a.merge(&id_range([4..9]));
         assert_eq!(a, id_range([0..9]));
 
         let mut a = id_range([0..5]);
-        a.merge(id_range([5..9]));
+        a.merge(&id_range([5..9]));
         assert_eq!(a, id_range([0..9]));
 
         let mut a = id_range([0..4]);
-        a.merge(id_range([6..9]));
+        a.merge(&id_range([6..9]));
         assert_eq!(a, id_range([0..4, 6..9]));
     }
 
     #[test]
     fn id_range_merge_canonical() {
         let mut a = id_range([0..3]);
-        a.merge(IdRange::default());
+        a.merge(&IdRange::default());
         assert_eq!(a, id_range([0..3]));
 
         let mut a = IdRange::default();
-        a.merge(id_range([1..5]));
+        a.merge(&id_range([1..5]));
         assert_eq!(a, id_range([1..5]));
 
         let mut a = id_range([5..7]);
-        a.merge(id_range([1..3]));
+        a.merge(&id_range([1..3]));
         assert_eq!(a, id_range([1..3, 5..7]));
 
         let mut a = id_range([0..2, 4..6, 10..12]);
-        a.merge(id_range([1..5, 11..15]));
+        a.merge(&id_range([1..5, 11..15]));
         assert_eq!(a, id_range([0..6, 10..15]));
 
         let mut a = id_range([0..3, 10..12]);
-        a.merge(id_range([3..5, 12..14]));
+        a.merge(&id_range([3..5, 12..14]));
         assert_eq!(a, id_range([0..5, 10..14]));
 
         let mut a = id_range([0..2, 6..8]);
-        a.merge(id_range([3..5, 9..11]));
+        a.merge(&id_range([3..5, 9..11]));
         assert_eq!(a, id_range([0..2, 3..5, 6..8, 9..11]));
     }
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -268,16 +268,36 @@ impl IdSet {
         self.0.merge_with(&other.0);
     }
 
+    /// Merges another ID set with a current one, returning a new set as a result. Information
+    /// about observed ID ranges will be combined. Per-client [IdRange] merge maintains
+    /// the canonical invariant on its own, so no trailing squash is needed.
+    pub fn merge(&self, other: &Self) -> Self {
+        Self(self.0.merge(&other.0))
+    }
+
     /// Removes from `self` every clock range covered by `other`. Per-client [IdRange]s are
     /// excluded individually; clients absent from `other` are left untouched.
     pub fn diff_with(&mut self, other: &Self) {
         self.0.diff_with(&other.0);
     }
 
+    /// Removes from `self` every clock range covered by `other`, returning new set as a result.
+    /// Per-client [IdRange]s are excluded individually; clients absent from `other`
+    /// are left untouched.
+    pub fn diff(&self, other: &Self) -> Self {
+        Self(self.0.diff(&other.0))
+    }
+
     /// Replaces `self` with the per-client intersection against `other`. Clients present only
     /// in `self` (or only in `other`) are dropped.
     pub fn intersect_with(&mut self, other: &Self) {
         self.0.intersect_with(&other.0);
+    }
+
+    /// Returns a new ID set, which holds [IdRange]s which are present in both current set and
+    /// the other one. Ranges not present in both of the inputs at the same time will be removed.
+    pub fn intersect(&self, other: &Self) -> Self {
+        Self(self.0.intersect(&other.0))
     }
 
     /// Remove a given range of elements from the current [IdSet]. If the client's [IdRange]

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -11,11 +11,10 @@ use crate::ReadTxn;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smallvec::SmallVec;
+use std::collections::btree_map::Entry;
 use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
-// Note: use native Rust [Range](https://doc.rust-lang.org/std/ops/struct.Range.html)
-// as it's left-inclusive/right-exclusive and defines the exact capabilities we care about here.
 
 impl Encode for Range<u32> {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
@@ -40,25 +39,7 @@ impl Decode for Range<u32> {
 /// ranges are merged together on insert.
 pub type IdRange = IdRanges<()>;
 
-// ---------------------------------------------------------------------------
-// IdRange-specific methods (only meaningful for T = ())
-// ---------------------------------------------------------------------------
 impl IdRanges<()> {
-    /// Inverts current [IdRange], returning another [IdRange] that contains all
-    /// "holes" (ranges not included in current range). If current range is a continuous space
-    /// starting from the initial clock (eg. [0..5)), then returned range will be empty.
-    pub fn invert(&self) -> IdRange {
-        let mut inv = SmallVec::new();
-        let mut start = 0;
-        for (range, _) in self.iter() {
-            if range.start > start {
-                inv.push((start..range.start, ()));
-            }
-            start = range.end;
-        }
-        IdRanges::from_raw(inv)
-    }
-
     /// Check if current [IdRange] is a subset of `other`. This means that all the elements
     /// described by the current [IdRange] can be found within the bounds of `other` [IdRange].
     pub fn subset_of(&self, other: &Self) -> bool {
@@ -92,19 +73,15 @@ impl IdRanges<()> {
 
         current >= range.end
     }
-
-    fn encode_raw<E: Encoder>(&self, encoder: &mut E) {
-        encoder.write_var(self.len() as u32);
-        for (range, _) in self.iter() {
-            range.encode(encoder);
-        }
-    }
 }
 
 impl Encode for IdRanges<()> {
     #[inline]
     fn encode<E: Encoder>(&self, encoder: &mut E) {
-        self.encode_raw(encoder)
+        encoder.write_var(self.len() as u32);
+        for (range, _) in self.iter() {
+            range.encode(encoder);
+        }
     }
 }
 
@@ -140,10 +117,6 @@ impl std::fmt::Display for IdRanges<()> {
         write!(f, "]")
     }
 }
-
-// ---------------------------------------------------------------------------
-// IdSet
-// ---------------------------------------------------------------------------
 
 /// IdSet is a set describing ranges of blocks stored within the document.
 ///
@@ -258,7 +231,7 @@ impl IdSet {
     }
 
     pub fn range_mut(&mut self, client_id: ClientID) -> &mut IdRange {
-        self.0.entry_or_default(client_id)
+        self.0.entry(client_id).or_default()
     }
 
     /// Check if current [IdSet] contains given `id`.
@@ -273,7 +246,8 @@ impl IdSet {
 
     pub fn insert(&mut self, id: ID, len: u32) {
         self.0
-            .entry_or_default(id.client)
+            .entry(id.client)
+            .or_default()
             .insert(id.clock..(id.clock + len));
     }
 
@@ -309,22 +283,17 @@ impl IdSet {
     /// Remove a given range of elements from the current [IdSet]. If the client's [IdRange]
     /// becomes empty as a result, the client entry is dropped from the set entirely.
     pub fn remove_range(&mut self, range: &BlockRange) {
-        if let Some(r) = self.0.get_mut(&range.id.client) {
-            r.remove(range.id.clock..(range.id.clock + range.len));
-            if r.is_empty() {
-                self.0.clients_mut().remove(&range.id.client);
+        if let Entry::Occupied(mut e) = self.0.entry(range.id.client) {
+            let ranges = e.get_mut();
+            ranges.remove(range.clock_range());
+            if ranges.is_empty() {
+                e.remove();
             }
         }
     }
 
     pub fn get(&self, client_id: &ClientID) -> Option<&IdRange> {
         self.0.get(client_id)
-    }
-
-    /// Direct access to the inner [IdMapInner] (crate-internal).
-    #[inline]
-    pub(crate) fn inner(&self) -> &IdMapInner<()> {
-        &self.0
     }
 }
 
@@ -428,10 +397,6 @@ impl std::fmt::Display for IdSet {
     }
 }
 
-// ---------------------------------------------------------------------------
-// DeleteSet
-// ---------------------------------------------------------------------------
-
 /// An extension over [IdSet] that defines methods specific to work with block store deletions.
 pub(crate) trait DeleteSet {
     /// Creates a [IdSet] by reading all deleted blocks and including their clock ranges into
@@ -440,7 +405,7 @@ pub(crate) trait DeleteSet {
 
     fn try_squash_with(&mut self, store: &mut Store);
 
-    fn blocks(&self) -> Blocks;
+    fn blocks(&self) -> Blocks<'_>;
 }
 
 impl DeleteSet for IdSet {
@@ -488,7 +453,7 @@ impl DeleteSet for IdSet {
         }
     }
 
-    fn blocks(&self) -> Blocks {
+    fn blocks(&self) -> Blocks<'_> {
         Blocks::new(self)
     }
 }
@@ -680,14 +645,6 @@ pub(crate) mod test {
         r.insert(3..5);
         r.insert(6..7);
         assert_eq!(r, id_range([0..5, 6..7]));
-    }
-
-    #[test]
-    fn id_range_invert() {
-        assert!(id_range([0..3]).invert().is_empty());
-        assert_eq!(id_range([3..5]).invert(), id_range([0..3]));
-        assert_eq!(id_range([0..3, 4..5]).invert(), id_range([3..4]));
-        assert_eq!(id_range([3..4, 7..9]).invert(), id_range([0..3, 4..7]));
     }
 
     #[test]

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -33,6 +33,26 @@ impl<T> Default for IdRanges<T> {
     }
 }
 
+/// Push a `(range, value)` entry onto `vec`, coalescing with the last
+/// entry if they are adjacent/overlapping and have equal values.
+#[inline]
+fn push_coalesced<T: Merge, A: smallvec::Array<Item = (Range<u32>, T)>>(
+    vec: &mut SmallVec<A>,
+    range: Range<u32>,
+    value: T,
+) {
+    if range.start >= range.end {
+        return;
+    }
+    if let Some(last) = vec.last_mut() {
+        if last.0.end >= range.start && last.1 == value {
+            last.0.end = last.0.end.max(range.end);
+            return;
+        }
+    }
+    vec.push((range, value));
+}
+
 impl<T: Merge> IdRanges<T> {
     #[inline]
     pub fn new() -> Self {
@@ -101,6 +121,30 @@ impl<T: Merge> IdRanges<T> {
             return;
         }
 
+        // Tail-fast path: if the new range starts at or after the last entry,
+        // no binary search needed. Common when accumulating updates in clock order.
+        if let Some(last) = self.0.last_mut() {
+            if range.start >= last.0.start {
+                if range.start > last.0.end {
+                    // Disjoint after last — just push
+                    self.0.push((range, value));
+                    return;
+                }
+                // Overlaps or adjacent with last entry
+                if last.1 == value {
+                    // Same value — extend
+                    last.0.end = last.0.end.max(range.end);
+                    return;
+                }
+                if range.start == last.0.end {
+                    // Adjacent but different value — just push (no overlap to merge)
+                    self.0.push((range, value));
+                    return;
+                }
+                // Partial overlap with different value — fall through to general path
+            }
+        }
+
         // Find first potentially overlapping entry
         let mut lo = self.0.partition_point(|e| e.0.start < range.start);
 
@@ -115,17 +159,33 @@ impl<T: Merge> IdRanges<T> {
             hi += 1;
         }
 
-        // No overlap — simple insert, then try to coalesce with neighbors
+        // No overlap — simple insert, then coalesce with neighbors
         if lo == hi {
             self.0.insert(lo, (range, value));
-            self.coalesce_around(lo);
+            // Coalesce with right neighbor
+            if lo + 1 < self.0.len()
+                && self.0[lo].0.end >= self.0[lo + 1].0.start
+                && self.0[lo].1 == self.0[lo + 1].1
+            {
+                self.0[lo].0.end = self.0[lo].0.end.max(self.0[lo + 1].0.end);
+                self.0.remove(lo + 1);
+            }
+            // Coalesce with left neighbor
+            if lo > 0
+                && self.0[lo - 1].0.end >= self.0[lo].0.start
+                && self.0[lo - 1].1 == self.0[lo].1
+            {
+                self.0[lo - 1].0.end = self.0[lo - 1].0.end.max(self.0[lo].0.end);
+                self.0.remove(lo);
+            }
             return;
         }
 
-        // Build replacement entries by walking through overlapping region
-        let mut result: SmallVec<[(Range<u32>, T); 4]> = SmallVec::new();
+        // Build replacement entries by walking through the overlapping region.
         let new_start = range.start;
         let new_end = range.end;
+
+        let mut replacement: SmallVec<[(Range<u32>, T); 4]> = SmallVec::new();
         let mut cursor = self.0[lo].0.start.min(new_start);
 
         for i in lo..hi {
@@ -133,12 +193,12 @@ impl<T: Merge> IdRanges<T> {
 
             // Gap before this entry, covered only by new value
             if cursor >= new_start && cursor < entry_range.start {
-                result.push((cursor..entry_range.start.min(new_end), value.clone()));
+                push_coalesced(&mut replacement, cursor..entry_range.start.min(new_end), value.clone());
             }
 
             // Prefix of existing entry before new range
             if entry_range.start < new_start {
-                result.push((entry_range.start..new_start, entry_value.clone()));
+                push_coalesced(&mut replacement, entry_range.start..new_start, entry_value.clone());
             }
 
             // Overlapping portion — merge values
@@ -147,42 +207,51 @@ impl<T: Merge> IdRanges<T> {
             if overlap_start < overlap_end {
                 let mut merged = entry_value.clone();
                 merged.merge(&value);
-                result.push((overlap_start..overlap_end, merged));
+                push_coalesced(&mut replacement, overlap_start..overlap_end, merged);
             }
 
             // Suffix of existing entry after new range
             if entry_range.end > new_end {
-                result.push((new_end..entry_range.end, entry_value.clone()));
+                push_coalesced(&mut replacement, new_end..entry_range.end, entry_value.clone());
             }
 
             cursor = entry_range.end;
         }
 
-        // Remaining gap after all entries, covered only by new value
+        // Remaining gap after all overlapping entries, covered only by new value
         if cursor < new_end {
-            result.push((cursor..new_end, value));
+            push_coalesced(&mut replacement, cursor..new_end, value);
         }
 
-        // Coalesce adjacent entries with equal values
-        let mut coalesced: SmallVec<[(Range<u32>, T); 4]> = SmallVec::new();
-        for entry in result {
-            if let Some(last) = coalesced.last_mut() {
-                if last.0.end >= entry.0.start && last.1 == entry.1 {
-                    last.0.end = last.0.end.max(entry.0.end);
-                    continue;
-                }
-            }
-            coalesced.push(entry);
-        }
-
-        // Replace self[lo..hi] with the coalesced entries
+        // Splice replacement into self: drain [lo..hi) and insert replacement entries.
+        // For a single replacement entry (common for T=()), this is just a drain + assign.
+        let repl_len = replacement.len();
         self.0.drain(lo..hi);
-        for (i, entry) in coalesced.into_iter().enumerate() {
+        // Reserve and insert
+        self.0.reserve(repl_len);
+        for (i, entry) in replacement.into_iter().enumerate() {
             self.0.insert(lo + i, entry);
         }
 
-        // Coalesce the splice boundary with the surrounding entries.
-        self.coalesce_at_boundary(lo);
+        // Coalesce at splice boundaries
+        let splice_end = lo + repl_len;
+        if splice_end < self.0.len() && splice_end > 0 {
+            let prev = splice_end - 1;
+            if self.0[prev].0.end >= self.0[splice_end].0.start
+                && self.0[prev].1 == self.0[splice_end].1
+            {
+                self.0[prev].0.end = self.0[prev].0.end.max(self.0[splice_end].0.end);
+                self.0.remove(splice_end);
+            }
+        }
+        if lo > 0 && lo < self.0.len() {
+            if self.0[lo - 1].0.end >= self.0[lo].0.start
+                && self.0[lo - 1].1 == self.0[lo].1
+            {
+                self.0[lo - 1].0.end = self.0[lo - 1].0.end.max(self.0[lo].0.end);
+                self.0.remove(lo);
+            }
+        }
     }
 
     /// Remove all clock positions in `range` from this set. Existing entries
@@ -231,21 +300,99 @@ impl<T: Merge> IdRanges<T> {
         }
     }
 
-    /// Merge `other` into `self` (set union). Overlapping portions get their
-    /// values combined via [`Merge::merge`]. Adjacent entries with equal values
-    /// are coalesced.
-    pub fn merge(&mut self, other: IdRanges<T>) {
+    /// Merge `other` into `self` (set union) in O(n+m). Overlapping portions
+    /// get their values combined via [`Merge::merge`]. Adjacent entries with
+    /// equal values are coalesced.
+    pub fn merge(&mut self, other: &Self) {
         if other.0.is_empty() {
             return;
         }
         if self.0.is_empty() {
-            self.0 = other.0;
+            self.0 = other.0.clone();
             return;
         }
 
-        for (range, value) in other.0 {
-            self.insert_with(range, value);
+        let a = std::mem::take(&mut self.0);
+        let b = &other.0;
+        let mut result: SmallVec<[(Range<u32>, T); 1]> =
+            SmallVec::with_capacity(a.len() + b.len());
+
+        let mut ai = 0usize;
+        let mut bi = 0usize;
+        // Effective start positions — tracks partial consumption of current entries.
+        let mut a_cur = a[0].0.start;
+        let mut b_cur = b[0].0.start;
+
+        while ai < a.len() || bi < b.len() {
+            let a_avail = ai < a.len();
+            let b_avail = bi < b.len();
+
+            // Only one side remains — drain it
+            if !b_avail {
+                push_coalesced(&mut result, a_cur..a[ai].0.end, a[ai].1.clone());
+                ai += 1;
+                for i in ai..a.len() {
+                    push_coalesced(&mut result, a[i].0.clone(), a[i].1.clone());
+                }
+                break;
+            }
+            if !a_avail {
+                push_coalesced(&mut result, b_cur..b[bi].0.end, b[bi].1.clone());
+                bi += 1;
+                for i in bi..b.len() {
+                    push_coalesced(&mut result, b[i].0.clone(), b[i].1.clone());
+                }
+                break;
+            }
+
+            let a_end = a[ai].0.end;
+            let b_end = b[bi].0.end;
+
+            // No overlap — emit the one that ends first
+            if a_end <= b_cur {
+                push_coalesced(&mut result, a_cur..a_end, a[ai].1.clone());
+                ai += 1;
+                a_cur = if ai < a.len() { a[ai].0.start } else { 0 };
+                continue;
+            }
+            if b_end <= a_cur {
+                push_coalesced(&mut result, b_cur..b_end, b[bi].1.clone());
+                bi += 1;
+                b_cur = if bi < b.len() { b[bi].0.start } else { 0 };
+                continue;
+            }
+
+            // Overlap exists — emit prefix, overlap, then advance the shorter one
+            if a_cur < b_cur {
+                push_coalesced(&mut result, a_cur..b_cur, a[ai].1.clone());
+            } else if b_cur < a_cur {
+                push_coalesced(&mut result, b_cur..a_cur, b[bi].1.clone());
+            }
+
+            let overlap_start = a_cur.max(b_cur);
+            let overlap_end = a_end.min(b_end);
+            let mut merged = a[ai].1.clone();
+            merged.merge(&b[bi].1);
+            push_coalesced(&mut result, overlap_start..overlap_end, merged);
+
+            // Advance the entry that ends first; partially consume the other
+            if a_end < b_end {
+                ai += 1;
+                a_cur = if ai < a.len() { a[ai].0.start } else { 0 };
+                b_cur = overlap_end;
+            } else if b_end < a_end {
+                bi += 1;
+                b_cur = if bi < b.len() { b[bi].0.start } else { 0 };
+                a_cur = overlap_end;
+            } else {
+                ai += 1;
+                bi += 1;
+                a_cur = if ai < a.len() { a[ai].0.start } else { 0 };
+                b_cur = if bi < b.len() { b[bi].0.start } else { 0 };
+            }
         }
+
+        self.0 = result;
     }
 
     /// Remove from `self` every clock position covered by `other`.
@@ -347,39 +494,6 @@ impl<T: Merge> IdRanges<T> {
         self.0 = result;
     }
 
-    /// Try to coalesce the entry at `idx` with its immediate neighbors.
-    fn coalesce_around(&mut self, idx: usize) {
-        // Coalesce with right neighbor
-        if idx + 1 < self.0.len()
-            && self.0[idx].0.end >= self.0[idx + 1].0.start
-            && self.0[idx].1 == self.0[idx + 1].1
-        {
-            self.0[idx].0.end = self.0[idx].0.end.max(self.0[idx + 1].0.end);
-            self.0.remove(idx + 1);
-        }
-        // Coalesce with left neighbor
-        if idx > 0
-            && self.0[idx - 1].0.end >= self.0[idx].0.start
-            && self.0[idx - 1].1 == self.0[idx].1
-        {
-            self.0[idx - 1].0.end = self.0[idx - 1].0.end.max(self.0[idx].0.end);
-            self.0.remove(idx);
-        }
-    }
-
-    /// After a splice at `lo`, coalesce the boundary between the
-    /// splice region and surrounding entries.
-    fn coalesce_at_boundary(&mut self, lo: usize) {
-        // Find the end of the spliced region — we don't know exactly how many
-        // entries were inserted, but we can check the right boundary by looking
-        // at the current state. Just coalesce lo with lo-1 if possible.
-        if lo > 0 && self.0[lo - 1].0.end >= self.0[lo].0.start && self.0[lo - 1].1 == self.0[lo].1
-        {
-            self.0[lo - 1].0.end = self.0[lo - 1].0.end.max(self.0[lo].0.end);
-            self.0.remove(lo);
-        }
-    }
-
     /// Returns iterator over `(Range<u32>, &T)` pairs.
     pub fn iter(&self) -> std::slice::Iter<'_, (Range<u32>, T)> {
         self.0.iter()
@@ -472,9 +586,13 @@ impl<T: Merge> IdMapInner<T> {
         Self::default()
     }
 
+    /// Returns `true` if the map contains no clock ranges.
+    ///
+    /// Invariant: empty [`IdRanges`] entries are never stored in the map,
+    /// so this is a simple check on the map length.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty() || self.0.values().all(|r| r.is_empty())
+        self.0.is_empty()
     }
 
     #[inline]
@@ -518,7 +636,7 @@ impl<T: Merge> IdMapInner<T> {
     pub fn merge_with(&mut self, other: &Self) {
         for (client, other_ranges) in &other.0 {
             match self.0.entry(*client) {
-                Entry::Occupied(mut e) => e.get_mut().merge(other_ranges.clone()),
+                Entry::Occupied(mut e) => e.get_mut().merge(other_ranges),
                 Entry::Vacant(e) => {
                     e.insert(other_ranges.clone());
                 }
@@ -699,7 +817,7 @@ mod test {
         let mut b = IdRanges::<()>::new();
         b.insert(2..8);
 
-        a.merge(b);
+        a.merge(&b);
         assert_eq!(a.as_slice(), &[(0..10, ())]);
     }
 

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -193,12 +193,20 @@ impl<T: Merge> IdRanges<T> {
 
             // Gap before this entry, covered only by new value
             if cursor >= new_start && cursor < entry_range.start {
-                push_coalesced(&mut replacement, cursor..entry_range.start.min(new_end), value.clone());
+                push_coalesced(
+                    &mut replacement,
+                    cursor..entry_range.start.min(new_end),
+                    value.clone(),
+                );
             }
 
             // Prefix of existing entry before new range
             if entry_range.start < new_start {
-                push_coalesced(&mut replacement, entry_range.start..new_start, entry_value.clone());
+                push_coalesced(
+                    &mut replacement,
+                    entry_range.start..new_start,
+                    entry_value.clone(),
+                );
             }
 
             // Overlapping portion — merge values
@@ -212,7 +220,11 @@ impl<T: Merge> IdRanges<T> {
 
             // Suffix of existing entry after new range
             if entry_range.end > new_end {
-                push_coalesced(&mut replacement, new_end..entry_range.end, entry_value.clone());
+                push_coalesced(
+                    &mut replacement,
+                    new_end..entry_range.end,
+                    entry_value.clone(),
+                );
             }
 
             cursor = entry_range.end;
@@ -245,9 +257,7 @@ impl<T: Merge> IdRanges<T> {
             }
         }
         if lo > 0 && lo < self.0.len() {
-            if self.0[lo - 1].0.end >= self.0[lo].0.start
-                && self.0[lo - 1].1 == self.0[lo].1
-            {
+            if self.0[lo - 1].0.end >= self.0[lo].0.start && self.0[lo - 1].1 == self.0[lo].1 {
                 self.0[lo - 1].0.end = self.0[lo - 1].0.end.max(self.0[lo].0.end);
                 self.0.remove(lo);
             }
@@ -314,8 +324,7 @@ impl<T: Merge> IdRanges<T> {
 
         let a = std::mem::take(&mut self.0);
         let b = &other.0;
-        let mut result: SmallVec<[(Range<u32>, T); 1]> =
-            SmallVec::with_capacity(a.len() + b.len());
+        let mut result: SmallVec<[(Range<u32>, T); 1]> = SmallVec::with_capacity(a.len() + b.len());
 
         let mut ai = 0usize;
         let mut bi = 0usize;
@@ -686,6 +695,25 @@ impl<T: Merge> IdMapInner<T> {
     pub fn intersect(&self, other: &Self) -> Self {
         let mut result = self.clone();
         result.intersect_with(other);
+        result
+    }
+
+    /// Maps values inside a current ID map using provided function, creating a new ID map as
+    /// a result. New values are remapped and squashed together into continuous ID range if possible.
+    pub fn map<F, U>(&self, f: F) -> IdMapInner<U>
+    where
+        F: Fn(&T) -> U,
+        U: Merge,
+    {
+        let mut result = IdMapInner::new();
+        for (client, ranges) in self.0.iter() {
+            let mut new_ranges: IdRanges<U> = IdRanges::with_capacity(ranges.len());
+            for (range, value) in ranges.iter() {
+                new_ranges.insert_with(range.clone(), f(value));
+            }
+            result.0.insert(*client, new_ranges);
+        }
+
         result
     }
 

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -1,0 +1,936 @@
+use crate::block::{ClientID, ID};
+use smallvec::SmallVec;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::ops::Range;
+
+/// Trait for per-range values that can be merged when ranges overlap.
+/// Used to parameterize `IdRanges<T>` and `IdMapInner<T>` over different
+/// value types (e.g. `()` for sets, `ContentAttributes<A>` for attributed maps).
+pub trait Merge: Clone + PartialEq {
+    /// Combine another value into this one. Called when two ranges overlap
+    /// during merge (union) or intersect operations.
+    fn merge(&mut self, other: &Self);
+}
+
+impl Merge for () {
+    #[inline(always)]
+    fn merge(&mut self, _other: &Self) {}
+}
+
+/// Per-client sorted, non-overlapping clock ranges with attached values.
+///
+/// Internally backed by a [`SmallVec`] of `(Range<u32>, T)` tuples.
+/// Ranges are maintained sorted by start position; overlapping or adjacent
+/// ranges with equal values are coalesced on insert.
+#[derive(Clone, PartialEq, Eq)]
+pub struct IdRanges<T>(SmallVec<[(Range<u32>, T); 1]>);
+
+impl<T> Default for IdRanges<T> {
+    #[inline]
+    fn default() -> Self {
+        IdRanges(SmallVec::new())
+    }
+}
+
+impl<T: Merge> IdRanges<T> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        IdRanges(SmallVec::with_capacity(capacity))
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Check if a given clock value is covered by any range in this set.
+    pub fn contains_clock(&self, clock: u32) -> bool {
+        let idx = self.0.partition_point(|e| e.0.start <= clock);
+        idx > 0 && self.0[idx - 1].0.end > clock
+    }
+
+    /// Find the index of the first entry whose range contains `clock`,
+    /// or the first entry whose range starts after `clock`.
+    /// Returns `None` if no such entry exists.
+    pub fn find_start(&self, clock: u32) -> Option<usize> {
+        if self.0.is_empty() {
+            return None;
+        }
+        let mut left = 0;
+        let mut right = self.0.len() - 1;
+        while left <= right {
+            let mid = (left + right) / 2;
+            let range = &self.0[mid].0;
+            if range.start <= clock {
+                if clock < range.end {
+                    return Some(mid);
+                }
+                left = mid + 1;
+            } else {
+                if mid == 0 {
+                    break;
+                }
+                right = mid - 1;
+            }
+        }
+        if left < self.0.len() {
+            Some(left)
+        } else {
+            None
+        }
+    }
+
+    /// Insert a `(range, value)` entry. Overlapping existing entries are split
+    /// at boundaries and their values merged via [`Merge::merge`]. Adjacent
+    /// entries with equal values are coalesced.
+    ///
+    /// For `IdRanges<()>` (i.e. `IdRange`), prefer the convenience method
+    /// [`IdRanges::insert`] which omits the unit value.
+    pub fn insert_with(&mut self, range: Range<u32>, value: T) {
+        if range.start >= range.end {
+            return;
+        }
+
+        // Find first potentially overlapping entry
+        let mut lo = self.0.partition_point(|e| e.0.start < range.start);
+
+        // Check if the previous entry extends into our range
+        if lo > 0 && self.0[lo - 1].0.end >= range.start {
+            lo -= 1;
+        }
+
+        // Find the end of overlapping entries
+        let mut hi = lo;
+        while hi < self.0.len() && self.0[hi].0.start <= range.end {
+            hi += 1;
+        }
+
+        // No overlap — simple insert, then try to coalesce with neighbors
+        if lo == hi {
+            self.0.insert(lo, (range, value));
+            self.coalesce_around(lo);
+            return;
+        }
+
+        // Build replacement entries by walking through overlapping region
+        let mut result: SmallVec<[(Range<u32>, T); 4]> = SmallVec::new();
+        let new_start = range.start;
+        let new_end = range.end;
+        let mut cursor = self.0[lo].0.start.min(new_start);
+
+        for i in lo..hi {
+            let (ref entry_range, ref entry_value) = self.0[i];
+
+            // Gap before this entry, covered only by new value
+            if cursor >= new_start && cursor < entry_range.start {
+                result.push((cursor..entry_range.start.min(new_end), value.clone()));
+            }
+
+            // Prefix of existing entry before new range
+            if entry_range.start < new_start {
+                result.push((entry_range.start..new_start, entry_value.clone()));
+            }
+
+            // Overlapping portion — merge values
+            let overlap_start = entry_range.start.max(new_start);
+            let overlap_end = entry_range.end.min(new_end);
+            if overlap_start < overlap_end {
+                let mut merged = entry_value.clone();
+                merged.merge(&value);
+                result.push((overlap_start..overlap_end, merged));
+            }
+
+            // Suffix of existing entry after new range
+            if entry_range.end > new_end {
+                result.push((new_end..entry_range.end, entry_value.clone()));
+            }
+
+            cursor = entry_range.end;
+        }
+
+        // Remaining gap after all entries, covered only by new value
+        if cursor < new_end {
+            result.push((cursor..new_end, value));
+        }
+
+        // Coalesce adjacent entries with equal values
+        let mut coalesced: SmallVec<[(Range<u32>, T); 4]> = SmallVec::new();
+        for entry in result {
+            if let Some(last) = coalesced.last_mut() {
+                if last.0.end >= entry.0.start && last.1 == entry.1 {
+                    last.0.end = last.0.end.max(entry.0.end);
+                    continue;
+                }
+            }
+            coalesced.push(entry);
+        }
+
+        // Replace self[lo..hi] with the coalesced entries
+        self.0.drain(lo..hi);
+        for (i, entry) in coalesced.into_iter().enumerate() {
+            self.0.insert(lo + i, entry);
+        }
+
+        // Coalesce the splice boundary with the surrounding entries.
+        self.coalesce_at_boundary(lo);
+    }
+
+    /// Remove all clock positions in `range` from this set. Existing entries
+    /// that partially overlap are trimmed; fully covered entries are removed.
+    /// Values on surviving pieces are preserved (cloned when split).
+    pub fn remove(&mut self, range: Range<u32>) {
+        if range.start >= range.end || self.0.is_empty() {
+            return;
+        }
+
+        // First entry whose range overlaps (i.e. entry.end > range.start)
+        let mut i = self.0.partition_point(|e| e.0.end <= range.start);
+        if i >= self.0.len() {
+            return;
+        }
+
+        // Special case: a single existing entry strictly contains `range` — split it
+        if self.0[i].0.start < range.start && self.0[i].0.end > range.end {
+            let right_range = range.end..self.0[i].0.end;
+            let right_value = self.0[i].1.clone();
+            self.0[i].0.end = range.start;
+            self.0.insert(i + 1, (right_range, right_value));
+            return;
+        }
+
+        // Trim leftmost entry if it straddles range.start
+        if self.0[i].0.start < range.start {
+            self.0[i].0.end = range.start;
+            i += 1;
+        }
+
+        // Find entries fully covered
+        let mut j = i;
+        while j < self.0.len() && self.0[j].0.end <= range.end {
+            j += 1;
+        }
+
+        // Trim trailing entry if it straddles range.end
+        if j < self.0.len() && self.0[j].0.start < range.end {
+            self.0[j].0.start = range.end;
+        }
+
+        // Drop fully-covered entries
+        if j > i {
+            self.0.drain(i..j);
+        }
+    }
+
+    /// Merge `other` into `self` (set union). Overlapping portions get their
+    /// values combined via [`Merge::merge`]. Adjacent entries with equal values
+    /// are coalesced.
+    pub fn merge(&mut self, other: IdRanges<T>) {
+        if other.0.is_empty() {
+            return;
+        }
+        if self.0.is_empty() {
+            self.0 = other.0;
+            return;
+        }
+
+        for (range, value) in other.0 {
+            self.insert_with(range, value);
+        }
+    }
+
+    /// Remove from `self` every clock position covered by `other`.
+    /// Values from `other` are ignored — only clock positions matter.
+    /// Values on surviving pieces of `self` are preserved.
+    pub fn exclude<U: Merge>(&mut self, other: &IdRanges<U>) {
+        if other.0.is_empty() || self.0.is_empty() {
+            return;
+        }
+
+        let mut result: SmallVec<[(Range<u32>, T); 1]> = SmallVec::new();
+        let other = other.0.as_slice();
+        let mut i = 0usize;
+
+        for (ref range, ref value) in self.0.iter() {
+            let mut start = range.start;
+            let end = range.end;
+
+            // Skip other-entries entirely to the left
+            while i < other.len() && other[i].0.end <= start {
+                i += 1;
+            }
+
+            // Cut other ranges from [start..end)
+            let mut j = i;
+            while start < end && j < other.len() {
+                let other_range = &other[j].0;
+                if other_range.start >= end {
+                    break;
+                }
+                if other_range.start > start {
+                    result.push((start..other_range.start, value.clone()));
+                }
+                start = start.max(other_range.end);
+                if other_range.end < end {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            if start < end {
+                result.push((start..end, value.clone()));
+            }
+            i = j;
+        }
+
+        self.0 = result;
+    }
+
+    /// Replace `self` with the intersection against `other`. Only clock
+    /// positions present in both are kept. Values are combined via
+    /// [`Merge::merge`].
+    pub fn intersect(&mut self, other: &Self) {
+        if self.0.is_empty() || other.0.is_empty() {
+            self.0 = SmallVec::new();
+            return;
+        }
+
+        let mut result: SmallVec<[(Range<u32>, T); 1]> = SmallVec::new();
+        let other = other.0.as_slice();
+        let mut i = 0usize;
+
+        for (ref range, ref value) in self.0.iter() {
+            while i < other.len() && other[i].0.end <= range.start {
+                i += 1;
+            }
+
+            let mut j = i;
+            while j < other.len() {
+                let (ref other_range, ref other_value) = other[j];
+                if other_range.start >= range.end {
+                    break;
+                }
+                let lo = range.start.max(other_range.start);
+                let hi = range.end.min(other_range.end);
+                if lo < hi {
+                    let mut merged = value.clone();
+                    merged.merge(other_value);
+                    // Coalesce with last result entry if adjacent and equal
+                    if let Some(last) = result.last_mut() {
+                        if last.0.end == lo && last.1 == merged {
+                            last.0.end = hi;
+                        } else {
+                            result.push((lo..hi, merged));
+                        }
+                    } else {
+                        result.push((lo..hi, merged));
+                    }
+                }
+                if other_range.end < range.end {
+                    j += 1;
+                } else {
+                    break;
+                }
+            }
+            i = j;
+        }
+
+        self.0 = result;
+    }
+
+    /// Try to coalesce the entry at `idx` with its immediate neighbors.
+    fn coalesce_around(&mut self, idx: usize) {
+        // Coalesce with right neighbor
+        if idx + 1 < self.0.len()
+            && self.0[idx].0.end >= self.0[idx + 1].0.start
+            && self.0[idx].1 == self.0[idx + 1].1
+        {
+            self.0[idx].0.end = self.0[idx].0.end.max(self.0[idx + 1].0.end);
+            self.0.remove(idx + 1);
+        }
+        // Coalesce with left neighbor
+        if idx > 0
+            && self.0[idx - 1].0.end >= self.0[idx].0.start
+            && self.0[idx - 1].1 == self.0[idx].1
+        {
+            self.0[idx - 1].0.end = self.0[idx - 1].0.end.max(self.0[idx].0.end);
+            self.0.remove(idx);
+        }
+    }
+
+    /// After a splice at `lo`, coalesce the boundary between the
+    /// splice region and surrounding entries.
+    fn coalesce_at_boundary(&mut self, lo: usize) {
+        // Find the end of the spliced region — we don't know exactly how many
+        // entries were inserted, but we can check the right boundary by looking
+        // at the current state. Just coalesce lo with lo-1 if possible.
+        if lo > 0 && self.0[lo - 1].0.end >= self.0[lo].0.start && self.0[lo - 1].1 == self.0[lo].1
+        {
+            self.0[lo - 1].0.end = self.0[lo - 1].0.end.max(self.0[lo].0.end);
+            self.0.remove(lo);
+        }
+    }
+
+    /// Returns iterator over `(Range<u32>, &T)` pairs.
+    pub fn iter(&self) -> std::slice::Iter<'_, (Range<u32>, T)> {
+        self.0.iter()
+    }
+
+    /// Returns an iterator over clock ranges only (ignoring values).
+    pub fn ranges(&self) -> impl Iterator<Item = &Range<u32>> {
+        self.0.iter().map(|e| &e.0)
+    }
+
+    /// Returns a reference to the entry at `idx`.
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<&(Range<u32>, T)> {
+        self.0.get(idx)
+    }
+
+    /// Access inner entries as a slice.
+    #[inline]
+    pub fn as_slice(&self) -> &[(Range<u32>, T)] {
+        &self.0
+    }
+
+    /// Direct access to the inner SmallVec (crate-internal).
+    #[inline]
+    pub(crate) fn inner(&self) -> &SmallVec<[(Range<u32>, T); 1]> {
+        &self.0
+    }
+
+    /// Direct mutable access to the inner SmallVec (crate-internal).
+    #[inline]
+    pub(crate) fn inner_mut(&mut self) -> &mut SmallVec<[(Range<u32>, T); 1]> {
+        &mut self.0
+    }
+
+    /// Construct from raw SmallVec (crate-internal, assumes sorted/non-overlapping).
+    #[inline]
+    pub(crate) fn from_raw(raw: SmallVec<[(Range<u32>, T); 1]>) -> Self {
+        IdRanges(raw)
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for IdRanges<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[")?;
+        let mut first = true;
+        for (range, value) in &self.0 {
+            if !first {
+                write!(f, ", ")?;
+            }
+            write!(f, "[{}..{}, {:?}]", range.start, range.end, value)?;
+            first = false;
+        }
+        write!(f, "]")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IdRanges<()> convenience methods (used as `IdRange` in id_set)
+// ---------------------------------------------------------------------------
+
+impl IdRanges<()> {
+    /// Convenience: insert a bare clock range (no value needed for `T = ()`).
+    pub fn insert(&mut self, range: Range<u32>) {
+        self.insert_with(range, ());
+    }
+
+    /// Construct from an iterator of `Range<u32>` values.
+    /// Each range is inserted individually, so overlapping / adjacent ranges
+    /// are coalesced automatically.
+    pub fn from_ranges(ranges: impl IntoIterator<Item = Range<u32>>) -> Self {
+        let mut r = IdRanges::new();
+        for range in ranges {
+            r.insert(range);
+        }
+        r
+    }
+}
+
+// ---------------------------------------------------------------------------
+// IdMapInner<T>
+// ---------------------------------------------------------------------------
+
+/// Generic map from [`ClientID`] to [`IdRanges<T>`], using a [`BTreeMap`] for
+/// sorted client iteration. This is the shared core of [`IdSet`] and `IdMap<A>`.
+#[derive(Clone, PartialEq, Eq)]
+pub struct IdMapInner<T: Merge>(BTreeMap<ClientID, IdRanges<T>>);
+
+impl<T: Merge> Default for IdMapInner<T> {
+    #[inline]
+    fn default() -> Self {
+        IdMapInner(BTreeMap::new())
+    }
+}
+
+impl<T: Merge> IdMapInner<T> {
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty() || self.0.values().all(|r| r.is_empty())
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&ClientID, &IdRanges<T>)> {
+        self.0.iter()
+    }
+
+    pub fn get(&self, client_id: &ClientID) -> Option<&IdRanges<T>> {
+        self.0.get(client_id)
+    }
+
+    pub fn get_mut(&mut self, client_id: &ClientID) -> Option<&mut IdRanges<T>> {
+        self.0.get_mut(client_id)
+    }
+
+    pub fn contains(&self, id: &ID) -> bool {
+        if let Some(ranges) = self.0.get(&id.client) {
+            ranges.contains_clock(id.clock)
+        } else {
+            false
+        }
+    }
+
+    /// Get or create a mutable reference to the ranges for a given client.
+    pub fn entry_or_default(&mut self, client_id: ClientID) -> &mut IdRanges<T> {
+        self.0.entry(client_id).or_default()
+    }
+
+    /// Insert a range with a value for a given client.
+    pub fn insert_range(&mut self, client_id: ClientID, range: Range<u32>, value: T) {
+        self.0
+            .entry(client_id)
+            .or_default()
+            .insert_with(range, value);
+    }
+
+    /// Merge another map into this one (set union). Per-client ranges are
+    /// merged via [`IdRanges::merge`].
+    pub fn merge_with(&mut self, other: &Self) {
+        for (client, other_ranges) in &other.0 {
+            match self.0.entry(*client) {
+                Entry::Occupied(mut e) => e.get_mut().merge(other_ranges.clone()),
+                Entry::Vacant(e) => {
+                    e.insert(other_ranges.clone());
+                }
+            }
+        }
+    }
+
+    /// Return a new map that is the union of `self` and `other`.
+    pub fn merge(&self, other: &Self) -> Self {
+        let mut result = self.clone();
+        result.merge_with(other);
+        result
+    }
+
+    /// Remove from `self` every clock position covered by `other`.
+    /// The value type `U` of `other` is ignored — only clock positions matter.
+    pub fn diff_with<U: Merge>(&mut self, other: &IdMapInner<U>) {
+        self.0.retain(|client, ranges| {
+            if let Some(other_ranges) = other.0.get(client) {
+                ranges.exclude(other_ranges);
+            }
+            !ranges.is_empty()
+        });
+    }
+
+    /// Return a new map with clock positions from `self` that are not in `other`.
+    pub fn diff<U: Merge>(&self, other: &IdMapInner<U>) -> Self {
+        let mut result = self.clone();
+        result.diff_with(other);
+        result
+    }
+
+    /// Replace `self` with the per-client intersection against `other`.
+    /// Clients present only in one side are dropped. Values are merged
+    /// via [`Merge::merge`].
+    pub fn intersect_with(&mut self, other: &Self) {
+        self.0.retain(|client, ranges| match other.0.get(client) {
+            Some(other_ranges) => {
+                ranges.intersect(other_ranges);
+                !ranges.is_empty()
+            }
+            None => false,
+        });
+    }
+
+    /// Return a new map with only clock positions present in both.
+    pub fn intersect(&self, other: &Self) -> Self {
+        let mut result = self.clone();
+        result.intersect_with(other);
+        result
+    }
+
+    /// Direct access to the inner BTreeMap (crate-internal).
+    #[inline]
+    pub(crate) fn clients(&self) -> &BTreeMap<ClientID, IdRanges<T>> {
+        &self.0
+    }
+
+    /// Direct mutable access to the inner BTreeMap (crate-internal).
+    #[inline]
+    pub(crate) fn clients_mut(&mut self) -> &mut BTreeMap<ClientID, IdRanges<T>> {
+        &mut self.0
+    }
+}
+
+impl<T: Merge + std::fmt::Debug> std::fmt::Debug for IdMapInner<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("IdMapInner");
+        for (client, ranges) in &self.0 {
+            s.field(&client.to_string(), ranges);
+        }
+        s.finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // ---- IdRanges<()> tests (equivalent to old IdRange) ----
+
+    #[test]
+    fn insert_non_overlapping() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(5..8);
+        r.insert(0..3);
+        r.insert(10..12);
+        assert_eq!(r.as_slice(), &[(0..3, ()), (5..8, ()), (10..12, ())]);
+    }
+
+    #[test]
+    fn insert_adjacent_coalesces() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..3);
+        r.insert(3..5);
+        assert_eq!(r.as_slice(), &[(0..5, ())]);
+    }
+
+    #[test]
+    fn insert_overlapping_coalesces() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..5);
+        r.insert(3..8);
+        assert_eq!(r.as_slice(), &[(0..8, ())]);
+    }
+
+    #[test]
+    fn insert_contained_coalesces() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..10);
+        r.insert(3..7);
+        assert_eq!(r.as_slice(), &[(0..10, ())]);
+    }
+
+    #[test]
+    fn insert_spanning_multiple_coalesces() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..3);
+        r.insert(5..8);
+        r.insert(10..12);
+        r.insert(2..11);
+        assert_eq!(r.as_slice(), &[(0..12, ())]);
+    }
+
+    #[test]
+    fn insert_empty_range_noop() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(5..5);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn remove_middle_splits() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..10);
+        r.remove(3..7);
+        assert_eq!(r.as_slice(), &[(0..3, ()), (7..10, ())]);
+    }
+
+    #[test]
+    fn remove_prefix() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..10);
+        r.remove(0..5);
+        assert_eq!(r.as_slice(), &[(5..10, ())]);
+    }
+
+    #[test]
+    fn remove_suffix() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..10);
+        r.remove(5..10);
+        assert_eq!(r.as_slice(), &[(0..5, ())]);
+    }
+
+    #[test]
+    fn remove_entire() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..10);
+        r.remove(0..10);
+        assert!(r.is_empty());
+    }
+
+    #[test]
+    fn remove_beyond() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..5);
+        r.remove(10..15);
+        assert_eq!(r.as_slice(), &[(0..5, ())]);
+    }
+
+    #[test]
+    fn merge_two_ranges() {
+        let mut a = IdRanges::<()>::new();
+        a.insert(0..3);
+        a.insert(7..10);
+
+        let mut b = IdRanges::<()>::new();
+        b.insert(2..8);
+
+        a.merge(b);
+        assert_eq!(a.as_slice(), &[(0..10, ())]);
+    }
+
+    #[test]
+    fn exclude_partial() {
+        let mut a = IdRanges::<()>::new();
+        a.insert(0..10);
+
+        let mut b = IdRanges::<()>::new();
+        b.insert(3..7);
+
+        a.exclude(&b);
+        assert_eq!(a.as_slice(), &[(0..3, ()), (7..10, ())]);
+    }
+
+    #[test]
+    fn intersect_partial() {
+        let mut a = IdRanges::<()>::new();
+        a.insert(0..10);
+
+        let mut b = IdRanges::<()>::new();
+        b.insert(3..15);
+
+        a.intersect(&b);
+        assert_eq!(a.as_slice(), &[(3..10, ())]);
+    }
+
+    #[test]
+    fn intersect_no_overlap() {
+        let mut a = IdRanges::<()>::new();
+        a.insert(0..3);
+
+        let mut b = IdRanges::<()>::new();
+        b.insert(5..8);
+
+        a.intersect(&b);
+        assert!(a.is_empty());
+    }
+
+    #[test]
+    fn contains_clock_basic() {
+        let mut r = IdRanges::<()>::new();
+        r.insert(0..5);
+        r.insert(10..15);
+        assert!(r.contains_clock(0));
+        assert!(r.contains_clock(4));
+        assert!(!r.contains_clock(5));
+        assert!(!r.contains_clock(7));
+        assert!(r.contains_clock(10));
+        assert!(r.contains_clock(14));
+        assert!(!r.contains_clock(15));
+    }
+
+    // ---- Attributed IdRanges tests ----
+
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    struct Attrs(Vec<&'static str>);
+
+    impl Merge for Attrs {
+        fn merge(&mut self, other: &Self) {
+            for a in &other.0 {
+                if !self.0.contains(a) {
+                    self.0.push(a);
+                    self.0.sort();
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn insert_attributed_overlapping_splits() {
+        let mut r = IdRanges::<Attrs>::new();
+        r.insert_with(0..5, Attrs(vec!["a"]));
+        r.insert_with(3..8, Attrs(vec!["b"]));
+        assert_eq!(
+            r.as_slice(),
+            &[
+                (0..3, Attrs(vec!["a"])),
+                (3..5, Attrs(vec!["a", "b"])),
+                (5..8, Attrs(vec!["b"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn insert_attributed_same_attrs_coalesces() {
+        let mut r = IdRanges::<Attrs>::new();
+        r.insert_with(0..5, Attrs(vec!["a"]));
+        r.insert_with(3..8, Attrs(vec!["a"]));
+        assert_eq!(r.as_slice(), &[(0..8, Attrs(vec!["a"]))]);
+    }
+
+    #[test]
+    fn insert_attributed_contained() {
+        let mut r = IdRanges::<Attrs>::new();
+        r.insert_with(0..10, Attrs(vec!["a"]));
+        r.insert_with(3..7, Attrs(vec!["b"]));
+        assert_eq!(
+            r.as_slice(),
+            &[
+                (0..3, Attrs(vec!["a"])),
+                (3..7, Attrs(vec!["a", "b"])),
+                (7..10, Attrs(vec!["a"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn insert_attributed_spanning_gap() {
+        let mut r = IdRanges::<Attrs>::new();
+        r.insert_with(2..4, Attrs(vec!["a"]));
+        r.insert_with(6..8, Attrs(vec!["b"]));
+        r.insert_with(3..7, Attrs(vec!["c"]));
+        assert_eq!(
+            r.as_slice(),
+            &[
+                (2..3, Attrs(vec!["a"])),
+                (3..4, Attrs(vec!["a", "c"])),
+                (4..6, Attrs(vec!["c"])),
+                (6..7, Attrs(vec!["b", "c"])),
+                (7..8, Attrs(vec!["b"])),
+            ]
+        );
+    }
+
+    #[test]
+    fn remove_attributed_splits() {
+        let mut r = IdRanges::<Attrs>::new();
+        r.insert_with(0..10, Attrs(vec!["a"]));
+        r.remove(3..7);
+        assert_eq!(
+            r.as_slice(),
+            &[(0..3, Attrs(vec!["a"])), (7..10, Attrs(vec!["a"])),]
+        );
+    }
+
+    #[test]
+    fn exclude_attributed() {
+        let mut a = IdRanges::<Attrs>::new();
+        a.insert_with(0..10, Attrs(vec!["a"]));
+
+        let mut b = IdRanges::<Attrs>::new();
+        b.insert_with(3..7, Attrs(vec!["ignored"]));
+
+        a.exclude(&b);
+        assert_eq!(
+            a.as_slice(),
+            &[(0..3, Attrs(vec!["a"])), (7..10, Attrs(vec!["a"])),]
+        );
+    }
+
+    #[test]
+    fn intersect_attributed() {
+        let mut a = IdRanges::<Attrs>::new();
+        a.insert_with(0..10, Attrs(vec!["a"]));
+
+        let mut b = IdRanges::<Attrs>::new();
+        b.insert_with(3..15, Attrs(vec!["b"]));
+
+        a.intersect(&b);
+        assert_eq!(a.as_slice(), &[(3..10, Attrs(vec!["a", "b"]))]);
+    }
+
+    // ---- IdMapInner tests ----
+
+    #[test]
+    fn id_map_inner_merge() {
+        let mut a = IdMapInner::<()>::new();
+        a.insert_range(ClientID::new(1), 0..5, ());
+        a.insert_range(ClientID::new(2), 0..3, ());
+
+        let mut b = IdMapInner::<()>::new();
+        b.insert_range(ClientID::new(1), 3..8, ());
+        b.insert_range(ClientID::new(3), 0..4, ());
+
+        a.merge_with(&b);
+        assert!(a.contains(&ID::new(ClientID::new(1), 7)));
+        assert!(a.contains(&ID::new(ClientID::new(2), 2)));
+        assert!(a.contains(&ID::new(ClientID::new(3), 3)));
+    }
+
+    #[test]
+    fn id_map_inner_diff() {
+        let mut a = IdMapInner::<()>::new();
+        a.insert_range(ClientID::new(1), 0..10, ());
+
+        let mut b = IdMapInner::<()>::new();
+        b.insert_range(ClientID::new(1), 3..7, ());
+
+        a.diff_with(&b);
+        assert!(a.contains(&ID::new(ClientID::new(1), 2)));
+        assert!(!a.contains(&ID::new(ClientID::new(1), 5)));
+        assert!(a.contains(&ID::new(ClientID::new(1), 8)));
+    }
+
+    #[test]
+    fn id_map_inner_intersect() {
+        let mut a = IdMapInner::<()>::new();
+        a.insert_range(ClientID::new(1), 0..10, ());
+        a.insert_range(ClientID::new(2), 0..5, ());
+
+        let mut b = IdMapInner::<()>::new();
+        b.insert_range(ClientID::new(1), 5..15, ());
+
+        a.intersect_with(&b);
+        assert!(!a.contains(&ID::new(ClientID::new(1), 3)));
+        assert!(a.contains(&ID::new(ClientID::new(1), 7)));
+        assert!(!a.contains(&ID::new(ClientID::new(2), 2)));
+    }
+
+    #[test]
+    fn id_map_inner_diff_generic_u() {
+        let mut a = IdMapInner::<Attrs>::new();
+        a.insert_range(ClientID::new(1), 0..10, Attrs(vec!["a"]));
+
+        let mut b = IdMapInner::<()>::new();
+        b.insert_range(ClientID::new(1), 3..7, ());
+
+        a.diff_with(&b);
+        assert!(a.contains(&ID::new(ClientID::new(1), 2)));
+        assert!(!a.contains(&ID::new(ClientID::new(1), 5)));
+        assert!(a.contains(&ID::new(ClientID::new(1), 8)));
+    }
+}

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -251,7 +251,7 @@ impl<T: Merge> IdRanges<T> {
     /// Remove from `self` every clock position covered by `other`.
     /// Values from `other` are ignored — only clock positions matter.
     /// Values on surviving pieces of `self` are preserved.
-    pub fn exclude<U: Merge>(&mut self, other: &IdRanges<U>) {
+    pub fn exclude<U>(&mut self, other: &IdRanges<U>) {
         if other.0.is_empty() || self.0.is_empty() {
             return;
         }
@@ -436,10 +436,6 @@ impl<T: std::fmt::Debug> std::fmt::Debug for IdRanges<T> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// IdRanges<()> convenience methods (used as `IdRange` in id_set)
-// ---------------------------------------------------------------------------
-
 impl IdRanges<()> {
     /// Convenience: insert a bare clock range (no value needed for `T = ()`).
     pub fn insert(&mut self, range: Range<u32>) {
@@ -458,14 +454,10 @@ impl IdRanges<()> {
     }
 }
 
-// ---------------------------------------------------------------------------
-// IdMapInner<T>
-// ---------------------------------------------------------------------------
-
 /// Generic map from [`ClientID`] to [`IdRanges<T>`], using a [`BTreeMap`] for
 /// sorted client iteration. This is the shared core of [`IdSet`] and `IdMap<A>`.
 #[derive(Clone, PartialEq, Eq)]
-pub struct IdMapInner<T: Merge>(BTreeMap<ClientID, IdRanges<T>>);
+pub(crate) struct IdMapInner<T: Merge>(BTreeMap<ClientID, IdRanges<T>>);
 
 impl<T: Merge> Default for IdMapInner<T> {
     #[inline]
@@ -498,8 +490,11 @@ impl<T: Merge> IdMapInner<T> {
         self.0.get(client_id)
     }
 
-    pub fn get_mut(&mut self, client_id: &ClientID) -> Option<&mut IdRanges<T>> {
-        self.0.get_mut(client_id)
+    pub(crate) fn entry(
+        &mut self,
+        client_id: ClientID,
+    ) -> std::collections::btree_map::Entry<'_, ClientID, IdRanges<T>> {
+        self.0.entry(client_id)
     }
 
     pub fn contains(&self, id: &ID) -> bool {
@@ -508,11 +503,6 @@ impl<T: Merge> IdMapInner<T> {
         } else {
             false
         }
-    }
-
-    /// Get or create a mutable reference to the ranges for a given client.
-    pub fn entry_or_default(&mut self, client_id: ClientID) -> &mut IdRanges<T> {
-        self.0.entry(client_id).or_default()
     }
 
     /// Insert a range with a value for a given client.

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -616,6 +616,7 @@ pub mod block;
 mod block_store;
 pub mod doc;
 mod event;
+mod id_map;
 mod id_set;
 mod store;
 mod transaction;

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -632,6 +632,7 @@ pub mod branch;
 pub mod encoding;
 pub mod error;
 mod gc;
+mod ids;
 mod input;
 pub mod iter;
 pub mod json_path;


### PR DESCRIPTION
This PR adds support to yjs v14 `IdMap` type. It's similar to `IdSet` (hence the common part of `IdMapInner` has been extracted), but it allows to extend individual block ranges with additional metadata.