### PR TITLE
Upgrade transaction logic to match yjs v14

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -222,6 +222,32 @@ typedef struct YSubscription {} YSubscription;
 #define Y_OFFSET_UTF16 1
 
 /**
+ * Boolean flag used to determine if deleted blocks should be garbage collected or not
+ * during the transaction commits. Setting this value to 0 means GC will be performed.
+ */
+#define Y_SKIP_GC (1 << 1)
+
+/**
+ * Boolean flag used to determine if subdocument should be loaded automatically.
+ * If this is a subdocument, remote peers will load the document as well automatically.
+ */
+#define Y_AUTO_LOAD (1 << 2)
+
+/**
+ * Boolean flag used to determine whether the document should be synced by the provider now.
+ */
+#define Y_SHOULD_LOAD (1 << 3)
+
+/**
+ * Whenever we receive an update that might remove piece of text, it might turn out that it was
+ * surrounded by the formatting attributes, that now are effectively dead and unrenderable, but
+ * still are considered alive blocks.
+ *
+ * This flag orders cleanup of dangling formatting attributes.
+ */
+#define Y_CLEANUP_FMT (1 << 4)
+
+/**
  * Error code: couldn't read data from input stream.
  */
 #define ERR_CODE_IO 1
@@ -353,27 +379,15 @@ typedef struct YOptions {
    */
   const char *collection_id;
   /**
-   * Encoding used by text editing operations on this document. It's used to compute
-   * `YText`/`YXmlText` insertion offsets and text lengths. Either:
-   *
-   * - `Y_OFFSET_BYTES`
-   * - `Y_OFFSET_UTF16`
+   * Boolean flags used to configure document options:
+   * - `Y_OFFSET_BYTES`: use UTF-8 byte length for text indexes and offsets.
+   * - `Y_OFFSET_UTF16`: use UTF-16 code points for text indexes and offsets.
+   * - `Y_SKIP_GC`: skip automatic garbage collection at transaction commit (useful for snapshots and keeping historical traces).
+   * - `Y_AUTO_LOAD`: all subdocuments should be loaded automatically.
+   * - `Y_SHOULD_LOAD`: should current document be synced with its provider immediatelly?
+   * - `Y_CLEANUP_TEXT_FMT`: automatically remove dangling formatting attributes.
    */
-  uint8_t encoding;
-  /**
-   * Boolean flag used to determine if deleted blocks should be garbage collected or not
-   * during the transaction commits. Setting this value to 0 means GC will be performed.
-   */
-  uint8_t skip_gc;
-  /**
-   * Boolean flag used to determine if subdocument should be loaded automatically.
-   * If this is a subdocument, remote peers will load the document as well automatically.
-   */
-  uint8_t auto_load;
-  /**
-   * Boolean flag used to determine whether the document should be synced by the provider now.
-   */
-  uint8_t should_load;
+  uint8_t flags;
 } YOptions;
 
 /**

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -10,9 +10,8 @@ extern "C" {
 
 YDoc *ydoc_new_with_id(uint64_t id) {
     YOptions o = yoptions();
-    o.encoding = Y_OFFSET_UTF16;
+    o.flags = Y_OFFSET_UTF16;
     o.id = id;
-    o.skip_gc = 0;
 
     return ydoc_new_with_options(o);
 }
@@ -1486,9 +1485,8 @@ TEST_CASE("YDoc observe after transaction") {
 
 TEST_CASE("YDoc snapshots") {
     YOptions o = yoptions();
-    o.encoding = Y_OFFSET_UTF16;
+    o.flags = Y_OFFSET_UTF16 | Y_SKIP_GC;
     o.id = 1;
-    o.skip_gc = 1;
 
     YDoc *doc = ydoc_new_with_options(o);
     Branch *txt = ytext(doc, "test");
@@ -1568,7 +1566,7 @@ TEST_CASE("YDoc observe subdocs") {
     YOptions options = yoptions();
     options.guid = "a";
     options.id = 1;
-    options.should_load = Y_TRUE;
+    options.flags |= Y_SHOULD_LOAD;
     YDoc *docA = ydoc_new_with_options(options);
 
     YTransaction *txn = ydoc_write_transaction(doc1, 0, NULL);
@@ -1616,7 +1614,7 @@ TEST_CASE("YDoc observe subdocs") {
     YOptions optionsB = yoptions();
     optionsB.guid = "a";
     optionsB.id = 2;
-    optionsB.should_load = Y_FALSE;
+    optionsB.flags = Y_SHOULD_LOAD;
     YDoc *docB = ydoc_new_with_options(optionsB);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);
@@ -1640,7 +1638,7 @@ TEST_CASE("YDoc observe subdocs") {
     YOptions optionsC = yoptions();
     optionsC.guid = "c";
     optionsC.id = 3;
-    optionsC.should_load = Y_TRUE;
+    optionsC.flags = Y_SHOULD_LOAD;
     YDoc *docC = ydoc_new_with_options(optionsC);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);
@@ -1996,7 +1994,7 @@ TEST_CASE("Logical branch pointers") {
 
 TEST_CASE("Unicode support") {
     YOptions o = yoptions();
-    o.encoding = Y_OFFSET_UTF16;
+    o.flags |= Y_OFFSET_UTF16;
     YDoc *doc = ydoc_new_with_options(o);
     Branch *txt = ytext(doc, "quill");
     YTransaction *txn = ydoc_write_transaction(doc, 0, NULL);

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1432,7 +1432,11 @@ TEST_CASE("YDoc observe after transaction") {
     AfterTransactionTest t;
     t.calls = 0;
     t.delete_set.entries_count = 0;
-    t.before_state.entries_count = 0;
+
+    t.before_state.entries_count = 1;
+    t.before_state.client_ids = &CLIENT_ID;
+    uint32_t CLOCK = 0;
+    t.before_state.clocks = &CLOCK;
 
     t.after_state.entries_count = 1;
     t.after_state.client_ids = &CLIENT_ID;

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1614,7 +1614,7 @@ TEST_CASE("YDoc observe subdocs") {
     YOptions optionsB = yoptions();
     optionsB.guid = "a";
     optionsB.id = 2;
-    optionsB.flags = Y_SHOULD_LOAD;
+    optionsB.flags &= ~Y_SHOULD_LOAD;
     YDoc *docB = ydoc_new_with_options(optionsB);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);
@@ -1638,7 +1638,7 @@ TEST_CASE("YDoc observe subdocs") {
     YOptions optionsC = yoptions();
     optionsC.guid = "c";
     optionsC.id = 3;
-    optionsC.flags = Y_SHOULD_LOAD;
+    optionsC.flags |= Y_SHOULD_LOAD;
     YDoc *docC = ydoc_new_with_options(optionsC);
 
     txn = ydoc_write_transaction(doc1, 0, NULL);

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1435,13 +1435,13 @@ TEST_CASE("YDoc observe after transaction") {
 
     t.before_state.entries_count = 1;
     t.before_state.client_ids = &CLIENT_ID;
-    uint32_t CLOCK = 0;
-    t.before_state.clocks = &CLOCK;
+    uint32_t CLOCK_START = 0;
+    t.before_state.clocks = &CLOCK_START;
 
     t.after_state.entries_count = 1;
     t.after_state.client_ids = &CLIENT_ID;
-    uint32_t CLOCK = 11;
-    t.after_state.clocks = &CLOCK;
+    uint32_t CLOCK_END = 11;
+    t.after_state.clocks = &CLOCK_END;
 
     YDoc *doc1 = ydoc_new_with_id(CLIENT_ID);
     Branch *txt1 = ytext(doc1, "test");

--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -89,9 +89,8 @@ export const testOnAfterTransaction = tc => {
 
     text.insert(0, 'hello world')
 
-    t.compare(event.beforeState, new Map());
-    let state = new Map()
-    state.set(1, 11)
+    t.compare(event.beforeState, new Map([[1, 0]]));
+    let state = new Map([[1, 11]])
     t.compare(event.afterState, state);
     t.compare(event.deleteSet, new Map());
 

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -98,14 +98,6 @@ pub const Y_TRUE: u8 = 1;
 /// Flag used to mark a falsy boolean numbers.
 pub const Y_FALSE: u8 = 0;
 
-/// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
-/// the byte number of UTF8-encoded string.
-pub const Y_OFFSET_BYTES: u8 = 0;
-
-/// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
-/// UTF-16 chars of encoded string.
-pub const Y_OFFSET_UTF16: u8 = 1;
-
 /* pub types below are used by cbindgen for c header generation */
 
 /// A Yrs document type. Documents are the most important units of collaborative resources management.
@@ -279,32 +271,52 @@ pub struct YOptions {
     /// belongs to. It's used only by providers.
     pub collection_id: *const c_char,
 
-    /// Encoding used by text editing operations on this document. It's used to compute
-    /// `YText`/`YXmlText` insertion offsets and text lengths. Either:
-    ///
-    /// - `Y_OFFSET_BYTES`
-    /// - `Y_OFFSET_UTF16`
-    pub encoding: u8,
-
-    /// Boolean flag used to determine if deleted blocks should be garbage collected or not
-    /// during the transaction commits. Setting this value to 0 means GC will be performed.
-    pub skip_gc: u8,
-
-    /// Boolean flag used to determine if subdocument should be loaded automatically.
-    /// If this is a subdocument, remote peers will load the document as well automatically.
-    pub auto_load: u8,
-
-    /// Boolean flag used to determine whether the document should be synced by the provider now.
-    pub should_load: u8,
+    /// Boolean flags used to configure document options:
+    /// - `Y_OFFSET_BYTES`: use UTF-8 byte length for text indexes and offsets.
+    /// - `Y_OFFSET_UTF16`: use UTF-16 code points for text indexes and offsets.
+    /// - `Y_SKIP_GC`: skip automatic garbage collection at transaction commit (useful for snapshots and keeping historical traces).
+    /// - `Y_AUTO_LOAD`: all subdocuments should be loaded automatically.
+    /// - `Y_SHOULD_LOAD`: should current document be synced with its provider immediatelly?
+    /// - `Y_CLEANUP_TEXT_FMT`: automatically remove dangling formatting attributes.
+    pub flags: u8,
 }
+
+/// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
+/// the byte number of UTF8-encoded string.
+pub const Y_OFFSET_BYTES: u8 = 0;
+
+/// Flag used by `YOptions` to determine, that text operations offsets and length will be counted by
+/// UTF-16 chars of encoded string.
+pub const Y_OFFSET_UTF16: u8 = 1;
+
+/// Boolean flag used to determine if deleted blocks should be garbage collected or not
+/// during the transaction commits. Setting this value to 0 means GC will be performed.
+pub const Y_SKIP_GC: u8 = 1 << 1;
+
+/// Boolean flag used to determine if subdocument should be loaded automatically.
+/// If this is a subdocument, remote peers will load the document as well automatically.
+pub const Y_AUTO_LOAD: u8 = 1 << 2;
+
+/// Boolean flag used to determine whether the document should be synced by the provider now.
+pub const Y_SHOULD_LOAD: u8 = 1 << 3;
+
+/// Whenever we receive an update that might remove piece of text, it might turn out that it was
+/// surrounded by the formatting attributes, that now are effectively dead and unrenderable, but
+/// still are considered alive blocks.
+///
+/// This flag orders cleanup of dangling formatting attributes.
+pub const Y_CLEANUP_FMT: u8 = 1 << 4;
 
 impl Into<Options> for YOptions {
     fn into(self) -> Options {
-        let encoding = match self.encoding {
-            Y_OFFSET_BYTES => OffsetKind::Bytes,
-            Y_OFFSET_UTF16 => OffsetKind::Utf16,
-            _ => panic!("Unrecognized YOptions.encoding type"),
-        };
+        let mut offset_kind = OffsetKind::Bytes;
+        if self.flags & Y_OFFSET_UTF16 != 0 {
+            offset_kind = OffsetKind::Utf16;
+        }
+        let skip_gc = self.flags & Y_SKIP_GC != 0;
+        let auto_load = self.flags & Y_AUTO_LOAD != 0;
+        let should_load = self.flags & Y_SHOULD_LOAD != 0;
+        let cleanup_formatting = self.flags & Y_CLEANUP_FMT != 0;
         let guid = if self.guid.is_null() {
             uuid_v4()
         } else {
@@ -323,16 +335,34 @@ impl Into<Options> for YOptions {
             client_id: ClientID::new(self.id),
             guid,
             collection_id,
-            skip_gc: if self.skip_gc == 0 { false } else { true },
-            auto_load: if self.auto_load == 0 { false } else { true },
-            should_load: if self.should_load == 0 { false } else { true },
-            offset_kind: encoding,
+            skip_gc,
+            auto_load,
+            should_load,
+            offset_kind,
+            cleanup_formatting,
         }
     }
 }
 
 impl From<Options> for YOptions {
     fn from(o: Options) -> Self {
+        let mut flags = 0;
+        if o.offset_kind == OffsetKind::Utf16 {
+            flags |= Y_OFFSET_UTF16;
+        }
+        if o.skip_gc {
+            flags |= Y_SKIP_GC;
+        }
+        if o.auto_load {
+            flags |= Y_AUTO_LOAD;
+        }
+        if o.should_load {
+            flags |= Y_SHOULD_LOAD;
+        }
+        if o.cleanup_formatting {
+            flags |= Y_CLEANUP_FMT;
+        }
+
         YOptions {
             id: o.client_id.get(),
             guid: CString::new(o.guid.as_ref()).unwrap().into_raw(),
@@ -341,13 +371,7 @@ impl From<Options> for YOptions {
             } else {
                 null_mut()
             },
-            encoding: match o.offset_kind {
-                OffsetKind::Bytes => Y_OFFSET_BYTES,
-                OffsetKind::Utf16 => Y_OFFSET_UTF16,
-            },
-            skip_gc: if o.skip_gc { 1 } else { 0 },
-            auto_load: if o.auto_load { 1 } else { 0 },
-            should_load: if o.should_load { 1 } else { 0 },
+            flags,
         }
     }
 }

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -879,6 +879,8 @@ impl Item {
             ItemContent::Format(_, _) => {
                 // @todo searchmarker are currently unsupported for rich text documents
                 // /** @type {AbstractType<any>} */ (item.parent)._searchMarker = null
+                let mut parent = *self.parent.as_branch().unwrap();
+                parent.has_formatting = true;
             }
             ItemContent::Type(branch) => {
                 let ptr = BranchPtr::from(branch);

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -287,7 +287,7 @@ impl GC {
 
 impl From<BlockRange> for GC {
     fn from(value: BlockRange) -> Self {
-        let start = value.id.clock;
+        let start = value.clock;
         let end = start + value.len - 1;
         GC { start, end }
     }
@@ -1173,27 +1173,34 @@ pub struct Item {
 }
 
 /// Describes a consecutive range of updates (identified by their [ID]s).
-#[derive(PartialEq, Eq, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct BlockRange {
-    /// [ID] of the first update stored within current [BlockRange] bounds.
-    pub id: ID,
-    /// Number of splittable updates stored within this [BlockRange].
+    pub client: ClientID,
+    pub clock: u32,
     pub len: u32,
 }
 
 impl BlockRange {
     pub fn new(id: ID, len: u32) -> Self {
-        BlockRange { id, len }
+        BlockRange {
+            client: id.client,
+            clock: id.clock,
+            len,
+        }
+    }
+
+    pub fn id(&self) -> ID {
+        ID::new(self.client, self.clock)
     }
 
     /// Returns an [ID] of the last update fitting into the bounds of current [BlockRange]
     pub fn last_id(&self) -> ID {
-        ID::new(self.id.client, self.id.clock + self.len)
+        ID::new(self.client, self.clock + self.len)
     }
 
     /// Returns a range describing the clocks covered by this [BlockRange].
     pub fn clock_range(&self) -> Range<u32> {
-        self.id.clock..(self.id.clock + self.len)
+        self.clock..(self.clock + self.len)
     }
 
     /// Returns a slice of a current [BlockRange], which starts at a given offset (relative to
@@ -1212,14 +1219,14 @@ impl BlockRange {
     /// ```
     pub fn slice(&self, offset: u32) -> Self {
         let mut next = self.clone();
-        next.id.clock += offset;
+        next.clock += offset;
         next.len -= offset;
         next
     }
 
     pub(crate) fn integrate(&mut self, pivot: u32) -> bool {
         if pivot > 0 {
-            self.id.clock += pivot;
+            self.clock += pivot;
             self.len -= pivot;
         }
 
@@ -1233,9 +1240,7 @@ impl BlockRange {
 
     /// Checks if provided `id` fits inside of boundaries defined by current [BlockRange].
     pub fn contains(&self, id: &ID) -> bool {
-        self.id.client == id.client
-            && id.clock >= self.id.clock
-            && id.clock < self.id.clock + self.len
+        self.client == id.client && id.clock >= self.clock && id.clock < self.clock + self.len
     }
 }
 
@@ -1247,7 +1252,13 @@ impl std::fmt::Debug for BlockRange {
 
 impl std::fmt::Display for BlockRange {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "({}-{})", self.id, self.len)
+        write!(
+            f,
+            "({}:{}..{})",
+            self.client,
+            self.clock,
+            self.clock + self.len
+        )
     }
 }
 

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -1,7 +1,7 @@
+use crate::block_store::BlockStore;
 use crate::branch::{Branch, BranchPtr};
 use crate::doc::{DocAddr, OffsetKind};
 use crate::encoding::read::Error;
-use crate::error::UpdateError;
 use crate::gc::GCCollector;
 use crate::slice::{BlockSlice, ItemSlice};
 use crate::store::Store;
@@ -371,31 +371,6 @@ impl Block {
         }
     }
 
-    pub(crate) fn integrate(&mut self, txn: &mut TransactionMut<'_>, offset: u32) -> bool {
-        match self {
-            Block::Item(item) => ItemPtr::from(item).integrate(txn, offset),
-            Block::GC(gc) => {
-                if offset > 0 {
-                    gc.clock += offset;
-                    gc.len -= offset;
-                }
-                txn.delete_set.insert(gc.id(), gc.len);
-                txn.insert_set.insert(gc.id(), gc.len);
-                txn.store.blocks.push(Block::GC(*gc));
-                false
-            }
-            Block::Skip(skip) => {
-                if offset > 0 {
-                    skip.clock += offset;
-                    skip.len -= offset;
-                }
-                txn.store.skips.insert(skip.id(), skip.len);
-                txn.store.blocks.push(Block::Skip(*skip));
-                false
-            }
-        }
-    }
-
     pub fn encode_with_offset<E: Encoder>(&self, encoder: &mut E, offset: u32) {
         match self {
             Block::Item(x) => {
@@ -635,12 +610,7 @@ impl ItemPtr {
         )?;
         item.redone = Some(*redone_item.id());
         redone_item.info.set_keep();
-        let mut block_ptr = ItemPtr::from(&mut redone_item);
-
-        block_ptr.integrate(txn, 0);
-
-        txn.store_mut().blocks.push(Block::Item(redone_item));
-        Some(block_ptr)
+        txn.integrate_item(redone_item, 0)
     }
 
     pub(crate) fn keep(&self, keep: bool) {
@@ -708,264 +678,6 @@ impl ItemPtr {
             item.right = Some(new_ptr);
 
             Some(new)
-        }
-    }
-
-    /// Integrates current block into block store.
-    /// If it returns true, it means that the block should be deleted after being added to a block store.
-    pub(crate) fn integrate(&mut self, txn: &mut TransactionMut, offset: u32) -> bool {
-        let self_ptr = self.clone();
-        let this = self.deref_mut();
-        let store = txn.store_mut();
-        let encoding = store.offset_kind;
-        if offset > 0 {
-            // offset could be > 0 only in context of Update::integrate,
-            // is such case offset kind in use always means Yjs-compatible offset (utf-16)
-            this.id.clock += offset;
-            this.left = store
-                .blocks
-                .get_item_clean_end(&ID::new(this.id.client, this.id.clock - 1))
-                .map(|slice| store.materialize(slice));
-            this.origin = this.left.as_deref().map(|b: &Item| b.last_id());
-            this.content = this
-                .content
-                .splice(offset as usize, OffsetKind::Utf16)
-                .unwrap();
-            this.len -= offset;
-        }
-
-        let parent = match &this.parent {
-            TypePtr::Branch(branch) => Some(*branch),
-            TypePtr::Named(name) => {
-                let branch = store.get_or_create_type(name.clone(), TypeRef::Undefined);
-                this.parent = TypePtr::Branch(branch);
-                Some(branch)
-            }
-            TypePtr::ID(id) => {
-                if let Some(item) = store.blocks.get_item(id) {
-                    if let Some(branch) = item.as_branch() {
-                        this.parent = TypePtr::Branch(branch);
-                        Some(branch)
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            }
-            TypePtr::Unknown => return true,
-        };
-
-        let left: Option<&Item> = this.left.as_deref();
-        let right: Option<&Item> = this.right.as_deref();
-
-        let right_is_null_or_has_left = match right {
-            None => true,
-            Some(i) => i.left.is_some(),
-        };
-        let left_has_other_right_than_self = match left {
-            Some(i) => i.right != this.right,
-            _ => false,
-        };
-
-        if let Some(mut parent_ref) = parent {
-            if (left.is_none() && right_is_null_or_has_left) || left_has_other_right_than_self {
-                // set the first conflicting item
-                let mut o = if let Some(left) = left {
-                    left.right
-                } else if let Some(sub) = &this.parent_sub {
-                    let mut o = parent_ref.map.get(sub).cloned();
-                    while let Some(item) = o.as_deref() {
-                        if item.left.is_some() {
-                            o = item.left.clone();
-                            continue;
-                        }
-                        break;
-                    }
-                    o.clone()
-                } else {
-                    parent_ref.start
-                };
-
-                let mut left = this.left.clone();
-                let mut conflicting_items = HashSet::new();
-                let mut items_before_origin = HashSet::new();
-
-                // Let c in conflicting_items, b in items_before_origin
-                // ***{origin}bbbb{this}{c,b}{c,b}{o}***
-                // Note that conflicting_items is a subset of items_before_origin
-                while let Some(item) = o {
-                    if Some(item) == this.right {
-                        break;
-                    }
-
-                    items_before_origin.insert(item);
-                    conflicting_items.insert(item);
-                    if this.origin == item.origin {
-                        // case 1
-                        if item.id.client < this.id.client {
-                            left = Some(item.clone());
-                            conflicting_items.clear();
-                        } else if this.right_origin == item.right_origin {
-                            // `self` and `item` are conflicting and point to the same integration
-                            // points. The id decides which item comes first. Since `self` is to
-                            // the left of `item`, we can break here.
-                            break;
-                        }
-                    } else {
-                        if let Some(origin_ptr) = item
-                            .origin
-                            .as_ref()
-                            .and_then(|id| store.blocks.get_item(id))
-                        {
-                            if items_before_origin.contains(&origin_ptr) {
-                                if !conflicting_items.contains(&origin_ptr) {
-                                    left = Some(item.clone());
-                                    conflicting_items.clear();
-                                }
-                            } else {
-                                break;
-                            }
-                        } else {
-                            break;
-                        }
-                    }
-                    o = item.right.clone();
-                }
-                this.left = left;
-            }
-
-            if this.parent_sub.is_none() {
-                if let Some(item) = this.left.as_deref() {
-                    if item.parent_sub.is_some() {
-                        this.parent_sub = item.parent_sub.clone();
-                    } else if let Some(item) = this.right.as_deref() {
-                        this.parent_sub = item.parent_sub.clone();
-                    }
-                }
-            }
-
-            // reconnect left/right
-            if let Some(left) = this.left.as_deref_mut() {
-                this.right = left.right.replace(self_ptr);
-            } else {
-                let r = if let Some(parent_sub) = &this.parent_sub {
-                    // update parent map/start if necessary
-                    let mut r = parent_ref.map.get(parent_sub).cloned();
-                    while let Some(item) = r {
-                        if item.left.is_some() {
-                            r = item.left;
-                        } else {
-                            break;
-                        }
-                    }
-                    r
-                } else {
-                    let start = parent_ref.start.replace(self_ptr);
-                    start
-                };
-                this.right = r;
-            }
-
-            if let Some(right) = this.right.as_deref_mut() {
-                right.left = Some(self_ptr);
-            } else if let Some(parent_sub) = &this.parent_sub {
-                // set as current parent value if right === null and this is parentSub
-                parent_ref.map.insert(parent_sub.clone(), self_ptr);
-                if let Some(mut left) = this.left {
-                    #[cfg(feature = "weak")]
-                    {
-                        if left.info.is_linked() {
-                            // inherit links from the block we're overriding
-                            left.info.clear_linked();
-                            this.info.set_linked();
-                            let all_links = &mut txn.store.linked_by;
-                            if let Some(linked_by) = all_links.remove(&left) {
-                                all_links.insert(self_ptr, linked_by);
-                                // since left is being deleted, it will remove
-                                // its links from store.linkedBy anyway
-                            }
-                        }
-                    }
-                    // this is the current attribute value of parent. delete right
-                    txn.delete(left);
-                }
-            }
-
-            // adjust length of parent
-            if this.parent_sub.is_none() && !this.is_deleted() {
-                if this.is_countable() {
-                    // adjust length of parent
-                    parent_ref.block_len += this.len;
-                    parent_ref.content_len += this.content_len(encoding);
-                }
-                #[cfg(feature = "weak")]
-                match (this.left, this.right) {
-                    (Some(l), Some(r)) if l.info.is_linked() || r.info.is_linked() => {
-                        crate::types::weak::join_linked_range(self_ptr, txn)
-                    }
-                    _ => {}
-                }
-            }
-
-            match &mut this.content {
-                ItemContent::Deleted(len) => {
-                    txn.delete_set.insert(this.id, *len);
-                    this.mark_as_deleted();
-                }
-                ItemContent::Doc(parent_doc, doc) => {
-                    *parent_doc = Some(txn.doc().clone());
-                    {
-                        let mut child_txn = doc.transact_mut();
-                        child_txn.store.parent = Some(self_ptr);
-                    }
-                    let subdocs = txn.subdocs.get_or_init();
-                    subdocs.added.insert(DocAddr::new(doc), doc.clone());
-                    if doc.should_load() {
-                        subdocs.loaded.insert(doc.addr(), doc.clone());
-                    }
-                }
-                ItemContent::Format(_, _) => {
-                    // @todo searchmarker are currently unsupported for rich text documents
-                    // /** @type {AbstractType<any>} */ (item.parent)._searchMarker = null
-                }
-                ItemContent::Type(branch) => {
-                    let ptr = BranchPtr::from(branch);
-                    #[cfg(feature = "weak")]
-                    if let TypeRef::WeakLink(source) = &ptr.type_ref {
-                        source.materialize(txn, ptr);
-                    }
-                }
-                _ => {
-                    // other types don't define integration-specific actions
-                }
-            }
-            txn.add_changed_type(parent_ref, this.parent_sub.clone());
-            if this.info.is_linked() {
-                if let Some(links) = txn.store.linked_by.get(&self_ptr).cloned() {
-                    // notify links about changes
-                    for link in links.iter() {
-                        txn.add_changed_type(*link, this.parent_sub.clone());
-                    }
-                }
-            }
-            let parent_deleted = if let TypePtr::Branch(ptr) = &this.parent {
-                if let Some(block) = ptr.item {
-                    block.is_deleted()
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
-            if parent_deleted || (this.parent_sub.is_some() && this.right.is_some()) {
-                // delete if parent is deleted or if this is not the current attribute value of parent
-                true
-            } else {
-                false
-            }
-        } else {
-            true
         }
     }
 
@@ -1110,6 +822,306 @@ impl Item {
     /// Returns a unique identifier of a first update contained by a current [Item].
     pub fn id(&self) -> &ID {
         &self.id
+    }
+
+    #[inline]
+    pub fn range(&self) -> BlockRange {
+        BlockRange::new(self.id, self.len)
+    }
+
+    fn trim(&mut self, offset: u32, store: &mut Store) {
+        // offset could be > 0 only in context of Update::integrate,
+        // in such case offset kind in use always means Yjs-compatible offset (utf-16)
+        self.id.clock += offset;
+        self.left = store
+            .blocks
+            .get_item_clean_end(&ID::new(self.id.client, self.id.clock - 1))
+            .map(|slice| store.materialize(slice));
+        self.origin = self.left.as_deref().map(|b: &Item| b.last_id());
+        self.content = self
+            .content
+            .splice(offset as usize, OffsetKind::Utf16)
+            .unwrap();
+        self.len -= offset;
+    }
+
+    fn needs_deletion(&self, parent: BranchPtr) -> bool {
+        // delete current item if its parent was deleted
+        if let Some(item) = parent.item {
+            if item.is_deleted() {
+                return true;
+            }
+        }
+
+        // delete current item if it's a Map entry and it's not the right most one entry
+        self.parent_sub.is_some() && self.right.is_some()
+    }
+
+    fn integrate_content(&mut self, txn: &mut TransactionMut) {
+        let self_ptr = ItemPtr::from(&*self);
+        match &mut self.content {
+            ItemContent::Deleted(len) => {
+                txn.delete_set.insert(self.id, *len);
+                self.mark_as_deleted();
+            }
+            ItemContent::Doc(parent_doc, doc) => {
+                *parent_doc = Some(txn.doc().clone());
+                {
+                    let mut child_txn = doc.transact_mut();
+                    child_txn.store.parent = Some(self_ptr);
+                }
+                let subdocs = txn.subdocs.get_or_init();
+                subdocs.added.insert(DocAddr::new(doc), doc.clone());
+                if doc.should_load() {
+                    subdocs.loaded.insert(doc.addr(), doc.clone());
+                }
+            }
+            ItemContent::Format(_, _) => {
+                // @todo searchmarker are currently unsupported for rich text documents
+                // /** @type {AbstractType<any>} */ (item.parent)._searchMarker = null
+            }
+            ItemContent::Type(branch) => {
+                let ptr = BranchPtr::from(branch);
+                #[cfg(feature = "weak")]
+                if let TypeRef::WeakLink(source) = &ptr.type_ref {
+                    source.materialize(txn, ptr);
+                }
+            }
+            _ => {
+                // other types don't define integration-specific actions
+            }
+        }
+    }
+
+    #[cfg(feature = "weak")]
+    fn inherit_links(mut curr: ItemPtr, mut left: ItemPtr, txn: &mut TransactionMut) {
+        left.info.clear_linked();
+        curr.info.set_linked();
+        let all_links = &mut txn.store.linked_by;
+        if let Some(linked_by) = all_links.remove(&left) {
+            all_links.insert(curr, linked_by);
+        }
+    }
+
+    fn detect_conflict(&self) -> bool {
+        // original code: ((!target.left && (!target.right || target.right.left !== null)) || (target.left && target.left.right !== target.right))
+        match (&self.left, &self.right) {
+            (None, None) => true,                        // !target.left && !target.right
+            (None, Some(right)) => right.left.is_some(), // !target.left && target.right.left !== null
+            (Some(left), _) => left.right != self.right, // target.left && target.left.right !== target.right
+        }
+    }
+
+    fn resolve_conflict(&mut self, blocks: &mut BlockStore) {
+        let parent = self.parent.as_branch().unwrap();
+
+        // set o to the first conflicting item
+        let mut o = if let Some(left) = &self.left {
+            left.right
+        } else if let Some(sub) = &self.parent_sub {
+            let mut o = parent.map.get(sub).copied();
+            while let Some(item) = o {
+                if let Some(left) = item.left {
+                    o = Some(left);
+                    continue;
+                }
+                break;
+            }
+            o
+        } else {
+            parent.start
+        };
+
+        let mut left = self.left;
+        let mut conflicting_items = HashSet::new();
+        let mut items_before_origin = HashSet::new();
+
+        // Let c in conflicting_items, b in items_before_origin
+        // ***{origin}bbbb{this}{c,b}{c,b}{o}***
+        // Note that conflicting_items is a subset of items_before_origin
+        while let Some(item) = o {
+            if self.right == Some(item) {
+                break;
+            }
+            items_before_origin.insert(item);
+            conflicting_items.insert(item);
+
+            if self.origin == item.origin {
+                // case 1
+                if item.id.client < self.id.client {
+                    left = Some(item);
+                    conflicting_items.clear();
+                } else if self.right_origin == item.right_origin {
+                    // `self` and `item` are conflicting and point to the same integration
+                    // points. The id decides which item comes first. Since `self` is to
+                    // the left of `item`, we can break here.
+                    break;
+                } // else, o might be integrated before an item that this conflicts with. If so, we will find it in the next iterations
+            } else if let Some(origin_left) =
+                item.origin.as_ref().and_then(|id| blocks.get_item(id))
+            {
+                if items_before_origin.contains(&origin_left) {
+                    // case 2
+                    if !conflicting_items.contains(&origin_left) {
+                        left = Some(item);
+                        conflicting_items.clear();
+                    }
+                } else {
+                    break;
+                }
+            } else {
+                break;
+            }
+            o = item.right;
+        }
+        self.left = left;
+    }
+}
+
+impl<'doc> TransactionMut<'doc> {
+    pub(crate) fn integrate(&mut self, block: Block, offset: u32) -> Option<ItemPtr> {
+        match block {
+            Block::Item(item) => return self.integrate_item(item, offset),
+            Block::GC(gc) => self.integrate_gc(gc, offset),
+            Block::Skip(skip) => self.integrate_skip(skip, offset),
+        }
+        None
+    }
+
+    /// Integrates current block into block store.
+    /// If it returns true, it means that the block should be deleted after being added to a block store.
+    pub(crate) fn integrate_item(&mut self, mut item: Box<Item>, offset: u32) -> Option<ItemPtr> {
+        let mut item_ptr = ItemPtr::from(&*item);
+        let store = &mut *self.store;
+        let encoding = store.offset_kind;
+        if offset > 0 {
+            item.trim(offset, store);
+        }
+
+        // always try to copy over parent_sub from neighbor - this way we can reuse Arc<str> instead
+        // of allocating new one every time
+        item.parent_sub = match item.left.as_ref().and_then(|left| left.parent_sub.clone()) {
+            None => item.right.as_ref().and_then(|left| left.parent_sub.clone()),
+            parent_sub => parent_sub,
+        }
+        .or(item.parent_sub);
+
+        let mut parent = match &item.parent {
+            TypePtr::Branch(branch) => *branch,
+            TypePtr::Named(name) => {
+                let branch = store.get_or_create_type(name.clone(), TypeRef::Undefined);
+                item.parent = TypePtr::Branch(branch);
+                branch
+            }
+            TypePtr::ID(id)
+                if let Some(branch) = store.blocks.get_item(id).and_then(|i| i.as_branch()) =>
+            {
+                item.parent = TypePtr::Branch(branch);
+                branch
+            }
+            _ => {
+                self.integrate_gc(item.range(), offset);
+                return None;
+            }
+        };
+
+        if item.detect_conflict() {
+            item.resolve_conflict(&mut store.blocks);
+        }
+
+        // reconnect left/right + update parent map/start if necessary
+        if let Some(mut left) = item.left {
+            let right = left.right;
+            item.right = right;
+            left.right = Some(item_ptr);
+        } else {
+            item.right = if let Some(parent_sub) = item.parent_sub.as_ref() {
+                let mut r = parent.map.get(parent_sub).copied();
+                while let Some(right) = r {
+                    if right.left.is_some() {
+                        r = right.left;
+                    } else {
+                        break;
+                    }
+                }
+                r
+            } else {
+                parent.start.replace(item_ptr)
+            };
+        }
+        if let Some(mut right) = item.right {
+            right.left = Some(item_ptr);
+        } else if let Some(parent_sub) = item.parent_sub.as_ref() {
+            // set as current parent value if right === null and this is parentSub
+            parent.map.insert(parent_sub.clone(), item_ptr);
+            if let Some(left) = item.left {
+                #[cfg(feature = "weak")]
+                if left.info.is_linked() {
+                    // inherit links from the block we're overriding
+                    Item::inherit_links(item_ptr, left, self);
+                    // since left is being deleted, it will remove
+                    // its links from store.linkedBy anyway
+                }
+                // this is the current attribute value of parent. delete right
+                self.delete(left);
+            }
+        }
+
+        if item.parent_sub.is_none() && !item.is_deleted() {
+            if item.is_countable() {
+                // adjust length of parent
+                parent.block_len += item.len;
+                parent.content_len += item.content_len(encoding);
+            }
+            #[cfg(feature = "weak")]
+            if let (Some(l), Some(r)) = (item.left, item.right) {
+                if l.info.is_linked() || r.info.is_linked() {
+                    crate::types::weak::join_linked_range(item_ptr, self);
+                }
+            }
+        }
+        self.insert_set.insert(item.id, item.len);
+        self.store.blocks.push(Block::Item(item));
+        let item = &mut *item_ptr;
+
+        item.integrate_content(self);
+        self.add_changed_type(parent, item.parent_sub.clone());
+
+        #[cfg(feature = "weak")]
+        if item.info.is_linked() {
+            if let Some(links) = self.store.linked_by.get(&ItemPtr::from(&*item)).cloned() {
+                // notify links about changes
+                for link in links.iter() {
+                    self.add_changed_type(*link, item.parent_sub.clone());
+                }
+            }
+        }
+
+        if item.needs_deletion(parent) {
+            self.delete(item_ptr);
+        }
+
+        Some(item_ptr)
+    }
+
+    pub(crate) fn integrate_gc(&mut self, mut gc: BlockRange, offset: u32) {
+        if offset > 0 {
+            gc.clock += offset;
+            gc.len -= offset;
+        }
+        self.delete_set.insert(gc.id(), gc.len);
+        self.insert_set.insert(gc.id(), gc.len);
+        self.store.blocks.push(Block::GC(gc));
+    }
+
+    pub(crate) fn integrate_skip(&mut self, mut skip: BlockRange, offset: u32) {
+        if offset > 0 {
+            skip.clock += offset;
+            skip.len -= offset;
+        }
+        let blocks = &mut self.store.blocks;
+        blocks.skips.insert(skip.id(), skip.len);
+        blocks.push(Block::Skip(skip));
     }
 }
 
@@ -1511,75 +1523,6 @@ impl Item {
 
     pub(crate) fn mark_as_deleted(&mut self) {
         self.info.set_deleted()
-    }
-
-    /// Assign left/right neighbors of the block. This may require for origin/right_origin
-    /// blocks to be already present in block store - which may not be the case during block
-    /// decoding. We decode entire update first, and apply individual blocks second, hence
-    /// repair function is called before applying the block rather than on decode.
-    pub(crate) fn repair(&mut self, store: &mut Store) -> Result<(), UpdateError> {
-        if let Some(origin) = self.origin.as_ref() {
-            self.left = store
-                .blocks
-                .get_item_clean_end(origin)
-                .map(|slice| store.materialize(slice));
-        }
-
-        if let Some(origin) = self.right_origin.as_ref() {
-            self.right = store
-                .blocks
-                .get_item_clean_start(origin)
-                .map(|slice| store.materialize(slice));
-        }
-
-        // We have all missing ids, now find the items
-
-        // In the original Y.js algorithm we decoded items as we go and attached them to client
-        // block list. During that process if we had right origin but no left, we made a lookup for
-        // right origin's parent and attach it as a parent of current block.
-        //
-        // Here since we decode all blocks first, then apply them, we might not find them in
-        // the block store during decoding. Therefore we retroactively reattach it here.
-
-        self.parent = match &self.parent {
-            TypePtr::Branch(branch_ptr) => TypePtr::Branch(*branch_ptr),
-            TypePtr::Unknown => match (self.left, self.right) {
-                (Some(item), _) if item.parent != TypePtr::Unknown => {
-                    self.parent_sub = item.parent_sub.clone();
-                    item.parent.clone()
-                }
-                (_, Some(item)) if item.parent != TypePtr::Unknown => {
-                    self.parent_sub = item.parent_sub.clone();
-                    item.parent.clone()
-                }
-                _ => TypePtr::Unknown,
-            },
-            TypePtr::Named(name) => {
-                let branch = store.get_or_create_type(name.clone(), TypeRef::Undefined);
-                TypePtr::Branch(branch)
-            }
-            TypePtr::ID(id) => {
-                let ptr = store.blocks.get_item(id);
-                if let Some(item) = ptr {
-                    match &item.content {
-                        ItemContent::Type(branch) => {
-                            TypePtr::Branch(BranchPtr::from(branch.as_ref()))
-                        }
-                        ItemContent::Deleted(_) => TypePtr::Unknown,
-                        other => {
-                            return Err(UpdateError::InvalidParent(
-                                id.clone(),
-                                other.get_ref_number(),
-                            ))
-                        }
-                    }
-                } else {
-                    TypePtr::Unknown
-                }
-            }
-        };
-
-        Ok(())
     }
 
     /// Returns a length of a block. For most situation it works like [Item::content_len] with a
@@ -2469,16 +2412,5 @@ mod test {
         let (a, b) = split_str(&s, 30, OffsetKind::Bytes);
         assert_eq!(a, "Zażółć gęślą jaźń😀");
         assert_eq!(b, "ありがとうございます");
-    }
-
-    #[test]
-    fn size_of_types() {
-        use super::*;
-        use std::mem::size_of;
-        println!("ClientID: {}", size_of::<ClientID>());
-        println!("Option<ClientID>: {}", size_of::<Option<ClientID>>());
-        println!("ID: {}", size_of::<ID>());
-        println!("Option<ID>: {}", size_of::<Option<ID>>());
-        println!("Item: {}", size_of::<Item>());
     }
 }

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -3,7 +3,7 @@ use crate::doc::{DocAddr, OffsetKind};
 use crate::encoding::read::Error;
 use crate::error::UpdateError;
 use crate::gc::GCCollector;
-use crate::slice::{BlockSlice, GCSlice, ItemSlice};
+use crate::slice::{BlockSlice, ItemSlice};
 use crate::store::Store;
 use crate::transaction::TransactionMut;
 use crate::types::text::update_current_attributes;
@@ -175,14 +175,14 @@ impl ID {
 
 pub(crate) enum BlockCell {
     GC(GC),
-    Block(Box<Item>),
+    Item(Box<Item>),
 }
 
 impl PartialEq for BlockCell {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (BlockCell::GC(a), BlockCell::GC(b)) => a == b,
-            (BlockCell::Block(a), BlockCell::Block(b)) => a.id == b.id,
+            (BlockCell::Item(a), BlockCell::Item(b)) => a.id == b.id,
             _ => false,
         }
     }
@@ -191,8 +191,8 @@ impl PartialEq for BlockCell {
 impl std::fmt::Debug for BlockCell {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            BlockCell::GC(gc) => write!(f, "gc({}..={})", gc.start, gc.end),
-            BlockCell::Block(item) => item.fmt(f),
+            BlockCell::GC(gc) => write!(f, "gc({}..={})", gc.clock, gc.clock + gc.len),
+            BlockCell::Item(item) => item.fmt(f),
         }
     }
 }
@@ -201,16 +201,16 @@ impl BlockCell {
     /// Returns the first clock sequence number of a current block.
     pub fn clock_start(&self) -> u32 {
         match self {
-            BlockCell::GC(gc) => gc.start,
-            BlockCell::Block(item) => item.id.clock,
+            BlockCell::GC(gc) => gc.clock,
+            BlockCell::Item(item) => item.id.clock,
         }
     }
 
     /// Returns the last clock sequence number of a current block.
     pub fn clock_end(&self) -> u32 {
         match self {
-            BlockCell::GC(gc) => gc.end,
-            BlockCell::Block(item) => item.id.clock + item.len - 1,
+            BlockCell::GC(gc) => gc.clock + gc.len - 1,
+            BlockCell::Item(item) => item.id.clock + item.len - 1,
         }
     }
 
@@ -218,29 +218,29 @@ impl BlockCell {
     #[inline]
     pub fn clock_range(&self) -> (u32, u32) {
         match self {
-            BlockCell::GC(gc) => (gc.start, gc.end),
-            BlockCell::Block(block) => block.clock_range(),
+            BlockCell::GC(gc) => (gc.clock, gc.clock + gc.len - 1),
+            BlockCell::Item(block) => block.clock_range(),
         }
     }
 
     pub fn is_deleted(&self) -> bool {
         match self {
             BlockCell::GC(_) => true,
-            BlockCell::Block(item) => item.is_deleted(),
+            BlockCell::Item(item) => item.is_deleted(),
         }
     }
 
     pub fn len(&self) -> u32 {
         match self {
-            BlockCell::GC(gc) => gc.end - gc.start + 1,
-            BlockCell::Block(block) => block.len(),
+            BlockCell::GC(gc) => gc.len,
+            BlockCell::Item(block) => block.len(),
         }
     }
 
     pub fn as_slice(&self) -> BlockSlice {
         match self {
-            BlockCell::GC(gc) => BlockSlice::GC(GCSlice::from(gc.clone())),
-            BlockCell::Block(item) => {
+            BlockCell::GC(gc) => BlockSlice::GC((*gc).into()),
+            BlockCell::Item(item) => {
                 let ptr = ItemPtr::from(item);
                 BlockSlice::Item(ItemSlice::from(ptr))
             }
@@ -248,7 +248,7 @@ impl BlockCell {
     }
 
     pub fn as_item(&self) -> Option<ItemPtr> {
-        if let BlockCell::Block(item) = self {
+        if let BlockCell::Item(item) = self {
             Some(ItemPtr::from(item))
         } else {
             None
@@ -258,7 +258,7 @@ impl BlockCell {
 
 impl From<Box<Item>> for BlockCell {
     fn from(value: Box<Item>) -> Self {
-        BlockCell::Block(value)
+        BlockCell::Item(value)
     }
 }
 
@@ -268,35 +268,62 @@ impl From<GC> for BlockCell {
     }
 }
 
+#[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) struct GC {
-    pub start: u32,
-    pub end: u32,
-}
+pub(crate) struct GC(BlockRange);
 
 impl GC {
     #[inline]
-    pub fn new(start: u32, end: u32) -> Self {
-        GC { start, end }
+    pub fn new(client: ClientID, clock: u32, len: u32) -> Self {
+        GC(BlockRange { client, clock, len })
     }
+}
 
-    pub fn len(&self) -> u32 {
-        self.end - self.start + 1
+impl<'a> From<&'a Item> for GC {
+    #[inline]
+    fn from(item: &'a Item) -> Self {
+        GC(BlockRange {
+            client: item.id.client,
+            clock: item.id.clock,
+            len: item.len,
+        })
     }
 }
 
 impl From<BlockRange> for GC {
+    #[inline(always)]
     fn from(value: BlockRange) -> Self {
-        let start = value.clock;
-        let end = start + value.len - 1;
-        GC { start, end }
+        GC(value)
+    }
+}
+
+impl From<GC> for BlockRange {
+    #[inline(always)]
+    fn from(value: GC) -> Self {
+        value.0
+    }
+}
+
+impl Deref for GC {
+    type Target = BlockRange;
+
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for GC {
+    #[inline(always)]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
 impl Encode for GC {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
         encoder.write_info(BLOCK_GC_REF_NUMBER);
-        encoder.write_len(self.len());
+        encoder.write_len(self.len);
     }
 }
 
@@ -1195,12 +1222,29 @@ impl BlockRange {
 
     /// Returns an [ID] of the last update fitting into the bounds of current [BlockRange]
     pub fn last_id(&self) -> ID {
-        ID::new(self.client, self.clock + self.len)
+        ID::new(self.client, self.clock_end())
+    }
+
+    pub fn clock_end(&self) -> u32 {
+        self.clock + self.len
     }
 
     /// Returns a range describing the clocks covered by this [BlockRange].
     pub fn clock_range(&self) -> Range<u32> {
         self.clock..(self.clock + self.len)
+    }
+
+    /// Trim a number of countable elements from the beginning of a current slice.
+    pub(crate) fn trim_start(&mut self, count: u32) {
+        debug_assert!(count <= self.len);
+        self.clock += count;
+        self.len -= count;
+    }
+
+    /// Trim a number of countable elements from the end of a current slice.
+    pub(crate) fn trim_end(&mut self, count: u32) {
+        debug_assert!(count <= self.len);
+        self.len -= count;
     }
 
     /// Returns a slice of a current [BlockRange], which starts at a given offset (relative to
@@ -1214,7 +1258,7 @@ impl BlockRange {
     /// let a = BlockRange::new(ID::new(ClientID::new(1), 2), 8); // range of clocks [2..10)
     /// let b = a.slice(3); // range of clocks [5..10)
     ///
-    /// assert_eq!(b.id, ID::new(ClientID::new(1), 5));
+    /// assert_eq!(b.id(), ID::new(ClientID::new(1), 5));
     /// assert_eq!(b.last_id(), ID::new(ClientID::new(1), 10));
     /// ```
     pub fn slice(&self, offset: u32) -> Self {

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -15,6 +15,7 @@ use crate::utils::OptionExt;
 use crate::{Any, Doc, IdSet, Options, Out, Transact};
 use serde::{Deserialize, Serialize};
 use smallstr::SmallString;
+use std::cell::UnsafeCell;
 use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::fmt::Formatter;
@@ -173,6 +174,44 @@ impl ID {
     }
 }
 
+#[repr(transparent)]
+#[derive(Copy, Clone)]
+pub(crate) struct BlockRef<'a> {
+    cell: &'a UnsafeCell<Block>,
+}
+
+impl<'a> BlockRef<'a> {
+    pub fn new(cell: &'a UnsafeCell<Block>) -> Self {
+        BlockRef { cell }
+    }
+
+    #[inline]
+    pub fn as_ref(&self) -> &'a Block {
+        unsafe { &*self.cell.get() }
+    }
+
+    #[inline]
+    pub fn as_mut(&mut self) -> &'a mut Block {
+        unsafe { &mut *self.cell.get() }
+    }
+
+    pub fn as_item(&self) -> Option<&'a Item> {
+        if let Block::Item(item) = self.as_ref() {
+            Some(item)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_item_mut(&mut self) -> Option<&'a mut Item> {
+        if let Block::Item(item) = self.as_mut() {
+            Some(item)
+        } else {
+            None
+        }
+    }
+}
+
 pub(crate) enum Block {
     Item(Box<Item>),
     GC(BlockRange),
@@ -271,7 +310,7 @@ impl Block {
     pub fn as_slice(&self) -> BlockSlice {
         match self {
             Block::Item(item) => {
-                let ptr = ItemPtr::from(item);
+                let ptr = ItemPtr::from(item.as_ref());
                 BlockSlice::Item(ItemSlice::from(ptr))
             }
             Block::GC(gc) => BlockSlice::GC(*gc),
@@ -281,7 +320,7 @@ impl Block {
 
     pub fn as_item(&self) -> Option<ItemPtr> {
         if let Block::Item(item) = self {
-            Some(ItemPtr::from(item))
+            Some(ItemPtr::from(item.as_ref()))
         } else {
             None
         }
@@ -289,7 +328,9 @@ impl Block {
 
     pub(crate) fn try_squash(&mut self, other: &Block) -> bool {
         match (self, other) {
-            (Block::Item(a), Block::Item(b)) => ItemPtr::from(a).try_squash(ItemPtr::from(b)),
+            (Block::Item(a), Block::Item(b)) => {
+                ItemPtr::from(a).try_squash(ItemPtr::from(b.as_ref()))
+            }
             (Block::Skip(a), Block::Skip(b)) => {
                 a.merge(b);
                 true
@@ -301,7 +342,7 @@ impl Block {
     pub(crate) fn splice(&self, offset: u32) -> Option<Self> {
         match self {
             Block::Item(x) => {
-                let next = ItemPtr::from(x).splice(offset, OffsetKind::Utf16)?;
+                let next = ItemPtr::from(x.as_ref()).splice(offset, OffsetKind::Utf16)?;
                 Some(Block::Item(next))
             }
             Block::Skip(x) => {
@@ -358,7 +399,7 @@ impl Block {
     pub fn encode_with_offset<E: Encoder>(&self, encoder: &mut E, offset: u32) {
         match self {
             Block::Item(x) => {
-                let slice = ItemSlice::new(x.into(), offset, x.len() - 1);
+                let slice = ItemSlice::new(x.as_ref().into(), offset, x.len() - 1);
                 slice.encode(encoder)
             }
             Block::Skip(x) => {
@@ -986,9 +1027,9 @@ impl<'a> From<&'a mut Box<Item>> for ItemPtr {
     }
 }
 
-impl<'a> From<&'a Box<Item>> for ItemPtr {
-    fn from(block: &'a Box<Item>) -> Self {
-        ItemPtr(unsafe { NonNull::new_unchecked(block.as_ref() as *const Item as *mut Item) })
+impl<'a> From<&'a Item> for ItemPtr {
+    fn from(block: &'a Item) -> Self {
+        ItemPtr(unsafe { NonNull::new_unchecked(block as *const Item as *mut Item) })
     }
 }
 

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -174,8 +174,8 @@ impl ID {
 }
 
 pub(crate) enum BlockCell {
-    GC(GC),
     Item(Box<Item>),
+    GC(BlockRange),
 }
 
 impl PartialEq for BlockCell {
@@ -259,71 +259,6 @@ impl BlockCell {
 impl From<Box<Item>> for BlockCell {
     fn from(value: Box<Item>) -> Self {
         BlockCell::Item(value)
-    }
-}
-
-impl From<GC> for BlockCell {
-    fn from(gc: GC) -> Self {
-        BlockCell::GC(gc)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) struct GC(BlockRange);
-
-impl GC {
-    #[inline]
-    pub fn new(client: ClientID, clock: u32, len: u32) -> Self {
-        GC(BlockRange { client, clock, len })
-    }
-}
-
-impl<'a> From<&'a Item> for GC {
-    #[inline]
-    fn from(item: &'a Item) -> Self {
-        GC(BlockRange {
-            client: item.id.client,
-            clock: item.id.clock,
-            len: item.len,
-        })
-    }
-}
-
-impl From<BlockRange> for GC {
-    #[inline(always)]
-    fn from(value: BlockRange) -> Self {
-        GC(value)
-    }
-}
-
-impl From<GC> for BlockRange {
-    #[inline(always)]
-    fn from(value: GC) -> Self {
-        value.0
-    }
-}
-
-impl Deref for GC {
-    type Target = BlockRange;
-
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for GC {
-    #[inline(always)]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl Encode for GC {
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
-        encoder.write_info(BLOCK_GC_REF_NUMBER);
-        encoder.write_len(self.len);
     }
 }
 
@@ -1352,6 +1287,11 @@ impl Item {
             }
         }
         Some(item)
+    }
+
+    #[inline]
+    pub fn block_range(&self) -> BlockRange {
+        BlockRange::new(self.id, self.len)
     }
 
     /// Checks if provided `id` fits inside of updates defined within bounds of current [Item].

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -173,44 +173,35 @@ impl ID {
     }
 }
 
-pub(crate) enum BlockCell {
+pub(crate) enum Block {
     Item(Box<Item>),
     GC(BlockRange),
+    Skip(BlockRange),
 }
 
-impl PartialEq for BlockCell {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (BlockCell::GC(a), BlockCell::GC(b)) => a == b,
-            (BlockCell::Item(a), BlockCell::Item(b)) => a.id == b.id,
-            _ => false,
-        }
-    }
-}
-
-impl std::fmt::Debug for BlockCell {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BlockCell::GC(gc) => write!(f, "gc({}..={})", gc.clock, gc.clock + gc.len),
-            BlockCell::Item(item) => item.fmt(f),
-        }
-    }
-}
-
-impl BlockCell {
+impl Block {
     /// Returns the first clock sequence number of a current block.
     pub fn clock_start(&self) -> u32 {
         match self {
-            BlockCell::GC(gc) => gc.clock,
-            BlockCell::Item(item) => item.id.clock,
+            Block::Item(item) => item.id.clock,
+            Block::GC(gc) => gc.clock,
+            Block::Skip(skip) => skip.clock,
         }
     }
 
-    /// Returns the last clock sequence number of a current block.
-    pub fn clock_end(&self) -> u32 {
+    pub fn client(&self) -> &ClientID {
         match self {
-            BlockCell::GC(gc) => gc.clock + gc.len - 1,
-            BlockCell::Item(item) => item.id.clock + item.len - 1,
+            Block::Item(v) => &v.id.client,
+            Block::GC(v) => &v.client,
+            Block::Skip(v) => &v.client,
+        }
+    }
+
+    /// Returns the next clock adjacent to current block.
+    pub fn next_clock(&self) -> u32 {
+        match self {
+            Block::Item(item) => item.id.clock + item.len,
+            Block::GC(r) | Block::Skip(r) => r.clock + r.len,
         }
     }
 
@@ -218,47 +209,210 @@ impl BlockCell {
     #[inline]
     pub fn clock_range(&self) -> (u32, u32) {
         match self {
-            BlockCell::GC(gc) => (gc.clock, gc.clock + gc.len - 1),
-            BlockCell::Item(block) => block.clock_range(),
+            Block::Item(block) => block.clock_range(),
+            Block::GC(r) | Block::Skip(r) => (r.clock, r.clock + r.len - 1),
         }
+    }
+
+    pub fn id(&self) -> ID {
+        match self {
+            Block::Item(x) => *x.id(),
+            Block::Skip(x) => x.id(),
+            Block::GC(x) => x.id(),
+        }
+    }
+
+    pub fn last_id(&self) -> ID {
+        match self {
+            Block::Item(x) => x.last_id(),
+            Block::Skip(x) => x.last_id(),
+            Block::GC(x) => x.last_id(),
+        }
+    }
+
+    pub fn range(&self) -> BlockRange {
+        match self {
+            Block::Item(item) => BlockRange::new(item.id, item.len),
+            Block::GC(gc) => gc.clone(),
+            Block::Skip(skip) => skip.clone(),
+        }
+    }
+
+    #[inline]
+    pub fn is_item(&self) -> bool {
+        matches!(self, Block::Item(_))
+    }
+
+    #[inline]
+    pub fn is_skip(&self) -> bool {
+        matches!(self, Block::Skip(_))
+    }
+
+    #[inline]
+    pub fn is_gc(&self) -> bool {
+        matches!(self, Block::GC(_))
     }
 
     pub fn is_deleted(&self) -> bool {
         match self {
-            BlockCell::GC(_) => true,
-            BlockCell::Item(item) => item.is_deleted(),
+            Block::Item(item) => item.is_deleted(),
+            Block::Skip(_) => false,
+            Block::GC(_) => true,
         }
     }
 
     pub fn len(&self) -> u32 {
         match self {
-            BlockCell::GC(gc) => gc.len,
-            BlockCell::Item(block) => block.len(),
+            Block::Item(block) => block.len(),
+            Block::GC(r) | Block::Skip(r) => r.len,
         }
     }
 
     pub fn as_slice(&self) -> BlockSlice {
         match self {
-            BlockCell::GC(gc) => BlockSlice::GC((*gc).into()),
-            BlockCell::Item(item) => {
+            Block::Item(item) => {
                 let ptr = ItemPtr::from(item);
                 BlockSlice::Item(ItemSlice::from(ptr))
             }
+            Block::GC(gc) => BlockSlice::GC(*gc),
+            Block::Skip(skip) => BlockSlice::Skip(*skip),
         }
     }
 
     pub fn as_item(&self) -> Option<ItemPtr> {
-        if let BlockCell::Item(item) = self {
+        if let Block::Item(item) = self {
             Some(ItemPtr::from(item))
         } else {
             None
         }
     }
+
+    pub(crate) fn try_squash(&mut self, other: &Block) -> bool {
+        match (self, other) {
+            (Block::Item(a), Block::Item(b)) => ItemPtr::from(a).try_squash(ItemPtr::from(b)),
+            (Block::Skip(a), Block::Skip(b)) => {
+                a.merge(b);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn splice(&self, offset: u32) -> Option<Self> {
+        match self {
+            Block::Item(x) => {
+                let next = ItemPtr::from(x).splice(offset, OffsetKind::Utf16)?;
+                Some(Block::Item(next))
+            }
+            Block::Skip(x) => {
+                if offset == 0 {
+                    None
+                } else {
+                    Some(Block::Skip(x.slice(offset)))
+                }
+            }
+            Block::GC(x) => {
+                if offset == 0 {
+                    None
+                } else {
+                    Some(Block::GC(x.slice(offset)))
+                }
+            }
+        }
+    }
+
+    pub(crate) fn same_type(&self, other: &Block) -> bool {
+        match (self, other) {
+            (Block::Skip(_), Block::Skip(_)) => true,
+            (Block::Item(_), Block::Item(_)) => true,
+            (Block::GC(_), Block::GC(_)) => true,
+            (_, _) => false,
+        }
+    }
+
+    pub(crate) fn integrate(&mut self, txn: &mut TransactionMut<'_>, offset: u32) -> bool {
+        match self {
+            Block::Item(item) => ItemPtr::from(item).integrate(txn, offset),
+            Block::GC(gc) => {
+                if offset > 0 {
+                    gc.clock += offset;
+                    gc.len -= offset;
+                }
+                txn.delete_set.insert(gc.id(), gc.len);
+                txn.insert_set.insert(gc.id(), gc.len);
+                txn.store.blocks.push(Block::GC(*gc));
+                false
+            }
+            Block::Skip(skip) => {
+                if offset > 0 {
+                    skip.clock += offset;
+                    skip.len -= offset;
+                }
+                txn.store.skips.insert(skip.id(), skip.len);
+                txn.store.blocks.push(Block::Skip(*skip));
+                false
+            }
+        }
+    }
+
+    pub fn encode_with_offset<E: Encoder>(&self, encoder: &mut E, offset: u32) {
+        match self {
+            Block::Item(x) => {
+                let slice = ItemSlice::new(x.into(), offset, x.len() - 1);
+                slice.encode(encoder)
+            }
+            Block::Skip(x) => {
+                encoder.write_info(BLOCK_SKIP_REF_NUMBER);
+                encoder.write_var(x.len - offset);
+            }
+            Block::GC(x) => {
+                encoder.write_info(BLOCK_GC_REF_NUMBER);
+                encoder.write_len(x.len - offset);
+            }
+        }
+    }
 }
 
-impl From<Box<Item>> for BlockCell {
+impl Encode for Block {
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        match self {
+            Block::Item(block) => block.encode(encoder),
+            Block::Skip(skip) => {
+                encoder.write_info(BLOCK_SKIP_REF_NUMBER);
+                encoder.write_len(skip.len)
+            }
+            Block::GC(gc) => {
+                encoder.write_info(BLOCK_GC_REF_NUMBER);
+                encoder.write_len(gc.len)
+            }
+        }
+    }
+}
+
+impl PartialEq for Block {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Block::Item(a), Block::Item(b)) => a.id == b.id,
+            (Block::GC(a), Block::GC(b)) => a == b,
+            (Block::Skip(a), Block::Skip(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Debug for Block {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Block::Item(item) => item.fmt(f),
+            Block::GC(gc) => write!(f, "gc({}..={})", gc.clock, gc.clock + gc.len),
+            Block::Skip(s) => write!(f, "skip({}..={})", s.clock, s.clock + s.len),
+        }
+    }
+}
+
+impl From<Box<Item>> for Block {
     fn from(value: Box<Item>) -> Self {
-        BlockCell::Item(value)
+        Block::Item(value)
     }
 }
 
@@ -444,7 +598,7 @@ impl ItemPtr {
 
         block_ptr.integrate(txn, 0);
 
-        txn.store_mut().blocks.push_block(redone_item);
+        txn.store_mut().blocks.push(Block::Item(redone_item));
         Some(block_ptr)
     }
 
@@ -1157,7 +1311,7 @@ impl BlockRange {
 
     /// Returns an [ID] of the last update fitting into the bounds of current [BlockRange]
     pub fn last_id(&self) -> ID {
-        ID::new(self.client, self.clock_end())
+        ID::new(self.client, self.clock + self.len)
     }
 
     pub fn clock_end(&self) -> u32 {

--- a/yrs/src/block.rs
+++ b/yrs/src/block.rs
@@ -331,7 +331,7 @@ impl Block {
             (Block::Item(a), Block::Item(b)) => {
                 ItemPtr::from(a).try_squash(ItemPtr::from(b.as_ref()))
             }
-            (Block::Skip(a), Block::Skip(b)) => {
+            (Block::Skip(a), Block::Skip(b)) | (Block::GC(a), Block::GC(b)) => {
                 a.merge(b);
                 true
             }

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -340,7 +340,7 @@ impl BlockIter {
         } else {
             None
         };
-        let mut block = Item::new(
+        let block = Item::new(
             id,
             left,
             left.map(|ptr| ptr.last_id()),
@@ -350,11 +350,7 @@ impl BlockIter {
             None,
             content,
         )?;
-        let mut block_ptr = ItemPtr::from(&mut block);
-
-        block_ptr.integrate(txn, 0);
-
-        txn.store_mut().blocks.push(Block::Item(block));
+        let block_ptr = txn.integrate_item(block, 0);
 
         if let Some(remainder) = remainder {
             remainder.integrate(txn, inner_ref.unwrap().into())
@@ -367,7 +363,7 @@ impl BlockIter {
             self.reached_end = true;
         }
 
-        Some(block_ptr)
+        block_ptr
     }
 
     pub fn values<'a, 'txn, T: ReadTxn>(

--- a/yrs/src/block_iter.rs
+++ b/yrs/src/block_iter.rs
@@ -1,4 +1,4 @@
-use crate::block::{Item, ItemContent, ItemPtr, Prelim};
+use crate::block::{Block, Item, ItemContent, ItemPtr, Prelim};
 use crate::branch::BranchPtr;
 use crate::transaction::{ReadTxn, TransactionMut};
 use crate::types::TypePtr;
@@ -354,7 +354,7 @@ impl BlockIter {
 
         block_ptr.integrate(txn, 0);
 
-        txn.store_mut().blocks.push_block(block);
+        txn.store_mut().blocks.push(Block::Item(block));
 
         if let Some(remainder) = remainder {
             remainder.integrate(txn, inner_ref.unwrap().into())

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -27,8 +27,8 @@ impl ClientBlockList {
             0
         } else {
             match &self.list[len - 1] {
-                BlockCell::GC(gc) => gc.end + 1,
-                BlockCell::Block(block) => block.id.clock + block.len,
+                BlockCell::GC(gc) => gc.clock + gc.len,
+                BlockCell::Item(block) => block.id.clock + block.len,
             }
         }
     }
@@ -162,7 +162,7 @@ impl ClientBlockList {
                         });
                     }
                 }
-                (BlockCell::Block(left), BlockCell::Block(right)) => {
+                (BlockCell::Item(left), BlockCell::Item(right)) => {
                     let mut left = ItemPtr::from(left);
                     let right = ItemPtr::from(right);
                     if left.try_squash(right) {
@@ -193,9 +193,9 @@ impl ClientBlockList {
 
             match (left, right) {
                 (BlockCell::GC(left), BlockCell::GC(right)) => {
-                    left.end = right.end;
+                    left.len = right.clock - left.clock + right.len;
                 }
-                (BlockCell::Block(left), BlockCell::Block(right)) => {
+                (BlockCell::Item(left), BlockCell::Item(right)) => {
                     let left = ItemPtr::from(left);
                     let right = ItemPtr::from(right);
                     if let Some(key) = right.parent_sub.as_deref() {
@@ -227,10 +227,10 @@ impl ClientBlockList {
         let right = &mut r[0];
         match (left, right) {
             (BlockCell::GC(left), BlockCell::GC(right)) => {
-                left.end = right.end;
+                left.len = right.clock - left.clock + right.len;
                 self.list.remove(index);
             }
-            (BlockCell::Block(left), BlockCell::Block(right)) => {
+            (BlockCell::Item(left), BlockCell::Item(right)) => {
                 let mut left = ItemPtr::from(left);
                 let right = ItemPtr::from(right);
                 if left.try_squash(right) {
@@ -384,7 +384,7 @@ impl BlockStore {
 
     pub(crate) fn get_item(&self, id: &ID) -> Option<ItemPtr> {
         let cell = self.get_block(id)?;
-        if let BlockCell::Block(item) = cell {
+        if let BlockCell::Item(item) = cell {
             Some(ItemPtr::from(item))
         } else {
             None

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,18 +1,20 @@
-use crate::block::{Block, BlockRange, ClientID, Item, ItemPtr, ID};
+use crate::block::{Block, BlockRef, ClientID, ItemPtr, ID};
 use crate::slice::ItemSlice;
 use crate::types::TypePtr;
 use crate::utils::client_hasher::ClientHasher;
 use crate::*;
+use std::cell::UnsafeCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use std::ops::{Index, IndexMut, Range, RangeInclusive};
+use std::ops::{Index, Range, RangeInclusive};
 use std::vec::Vec;
 
 /// A resizable list of blocks inserted by a single client.
-#[derive(PartialEq, Default)]
+#[repr(transparent)]
+#[derive(Default)]
 pub(crate) struct ClientBlockList {
-    list: Vec<Block>,
+    inner: Vec<UnsafeCell<Block>>,
 }
 
 struct SquashBlockRange {
@@ -20,24 +22,33 @@ struct SquashBlockRange {
     gc_block: bool,
 }
 
+unsafe impl Send for ClientBlockList {}
+unsafe impl Sync for ClientBlockList {}
+
 impl ClientBlockList {
+    pub fn last(&self) -> Option<BlockRef<'_>> {
+        let cell = self.inner.last()?;
+        Some(BlockRef::new(cell))
+    }
+
     pub fn clock(&self) -> u32 {
-        match self.list.last() {
+        match self.last() {
             None => 0,
-            Some(block) => block.next_clock(),
+            Some(block) => block.as_ref().next_clock(),
         }
     }
 
-    pub(crate) fn get(&self, index: usize) -> Option<&Block> {
-        self.list.get(index)
+    pub(crate) fn get(&self, index: usize) -> Option<BlockRef<'_>> {
+        let cell = self.inner.get(index)?;
+        Some(BlockRef::new(cell))
     }
 
     /// Given a block's identifier clock value, return an offset under which this block could be
     /// found using binary search algorithm, or a index under which this block should be inserted.
     pub(crate) fn find_pivot(&self, clock: u32) -> Option<usize> {
         let mut left = 0;
-        let mut right = self.list.len() - 1;
-        let mut block = &self[right];
+        let mut right = self.inner.len() - 1;
+        let mut block = unsafe { &*self.inner[right].get() };
         let (mut start, mut end) = block.clock_range();
         if start == clock {
             // a common case is to just append a block at the end, so check first if we can do that
@@ -45,7 +56,7 @@ impl ClientBlockList {
         } else {
             let mut mid = ((clock / end) * right as u32) as usize;
             while left <= right {
-                block = &self[mid];
+                block = unsafe { &*self.inner[mid].get() };
                 (start, end) = block.clock_range();
                 if start <= clock {
                     if clock <= end {
@@ -66,38 +77,29 @@ impl ClientBlockList {
     /// list. Clocks are considered to work in left-side inclusive way, meaning that block with
     /// an ID (<client-id>, 0) and length 2, with contain all elements with clock values
     /// corresponding to {0,1} but not 2.
-    fn get_block(&self, clock: u32) -> Option<&Block> {
+    fn get_block(&self, clock: u32) -> Option<BlockRef<'_>> {
         let idx = self.find_pivot(clock)?;
-        Some(&self[idx])
-    }
-
-    fn get_block_mut(&mut self, clock: u32) -> Option<&mut Block> {
-        let idx = self.find_pivot(clock)?;
-        Some(&mut self[idx])
+        self.get(idx)
     }
 
     /// Pushes a new block at the end of this block list.
     fn push(&mut self, cell: Block) {
-        self.list.push(cell);
+        self.inner.push(UnsafeCell::new(cell));
     }
 
     /// Inserts a new block at a given `index` position within this block list. This method may
     /// panic if `index` is greater than a length of the list.
     pub(crate) fn insert(&mut self, index: usize, cell: Block) {
-        self.list.insert(index, cell);
+        self.inner.insert(index, UnsafeCell::new(cell));
     }
 
     /// Returns a number of blocks stored within this list.
     pub fn len(&self) -> usize {
-        self.list.len()
+        self.inner.len()
     }
 
     pub fn iter(&self) -> ClientBlockListIter<'_> {
-        ClientBlockListIter(self.list.iter())
-    }
-
-    pub fn iter_mut(&mut self) -> ClientBlockListIterMut<'_> {
-        ClientBlockListIterMut(self.list.iter_mut())
+        ClientBlockListIter(self.inner.iter())
     }
 
     /// Attempts to squash multiple blocks within the given range of indices.
@@ -128,9 +130,9 @@ impl ClientBlockList {
         let mut squash_intervals: Vec<SquashBlockRange> = Vec::new();
 
         for right_index in indices_range.rev() {
-            let (l, r) = self.list.split_at_mut(right_index);
-            let left = &mut l.last_mut().unwrap();
-            let right = &mut r[0];
+            let (l, r) = self.inner.split_at_mut(right_index);
+            let left = unsafe { &mut *l[l.len() - 1].get() };
+            let right = unsafe { &mut *r[0].get() };
 
             match (left, right) {
                 (Block::GC(_), Block::GC(_)) => {
@@ -180,11 +182,11 @@ impl ClientBlockList {
             let end_idx = squash_range.range.end;
             assert!(start_idx <= end_idx);
 
-            let (left_slice, right_slice) = self.list.split_at_mut(end_idx);
+            let (left_slice, right_slice) = self.inner.split_at_mut(end_idx);
 
             // The start_idx - 1 element is the one want to squash into.
-            let left = &mut left_slice[start_idx - 1];
-            let right = &right_slice[0];
+            let left = unsafe { &mut *left_slice[start_idx - 1].get() };
+            let right = unsafe { &*right_slice[0].get() };
 
             match (left, right) {
                 (Block::GC(left), Block::GC(right)) => {
@@ -192,7 +194,7 @@ impl ClientBlockList {
                 }
                 (Block::Item(left), Block::Item(right)) => {
                     let left = ItemPtr::from(left);
-                    let right = ItemPtr::from(right);
+                    let right = ItemPtr::from(right.as_ref());
                     if let Some(key) = right.parent_sub.as_deref() {
                         if let TypePtr::Branch(mut parent) = right.parent {
                             if let Some(e) = parent.map.get_mut(key) {
@@ -207,7 +209,7 @@ impl ClientBlockList {
             }
 
             // Finally, remove the BlockCells in bulk.
-            self.list.drain(start_idx..=end_idx);
+            self.inner.drain(start_idx..=end_idx);
         }
     }
 
@@ -217,13 +219,13 @@ impl ClientBlockList {
     /// later on rewire left/right neighbor changes that may have occurred as a result of squashing
     /// and block removal.
     pub(crate) fn squash_left(&mut self, index: usize) {
-        let (l, r) = self.list.split_at_mut(index);
-        let left = &mut l[index - 1];
-        let right = &mut r[0];
+        let (l, r) = self.inner.split_at_mut(index);
+        let left = unsafe { &mut *l[index - 1].get() };
+        let right = unsafe { &mut *r[0].get() };
         match (left, right) {
             (Block::GC(left), Block::GC(right)) => {
                 left.len = right.clock - left.clock + right.len;
-                self.list.remove(index);
+                self.inner.remove(index);
             }
             (Block::Item(left), Block::Item(right)) => {
                 let mut left = ItemPtr::from(left);
@@ -238,7 +240,7 @@ impl ClientBlockList {
                             }
                         }
                     }
-                    self.list.remove(index);
+                    self.inner.remove(index);
                 }
             }
             _ => { /* cannot squash incompatible types */ }
@@ -250,40 +252,25 @@ impl Index<usize> for ClientBlockList {
     type Output = Block;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.list[index]
+        unsafe { &*self.inner[index].get() }
     }
 }
 
-impl IndexMut<usize> for ClientBlockList {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.list[index]
-    }
-}
-
-pub(crate) struct ClientBlockListIter<'a>(std::slice::Iter<'a, Block>);
+pub(crate) struct ClientBlockListIter<'a>(std::slice::Iter<'a, UnsafeCell<Block>>);
 
 impl<'a> Iterator for ClientBlockListIter<'a> {
-    type Item = &'a Block;
+    type Item = BlockRef<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
-    }
-}
-
-pub(crate) struct ClientBlockListIterMut<'a>(std::slice::IterMut<'a, Block>);
-
-impl<'a> Iterator for ClientBlockListIterMut<'a> {
-    type Item = &'a mut Block;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next()
+        let cell = self.0.next()?;
+        Some(BlockRef::new(cell))
     }
 }
 
 /// Block store is a collection of all blocks known to a document owning instance of this type.
 /// Blocks are organized per client ID and contain a resizable list of all blocks inserted by that
 /// client.
-#[derive(PartialEq, Default)]
+#[derive(Default)]
 pub(crate) struct BlockStore {
     clients: HashMap<ClientID, ClientBlockList, BuildHasherDefault<ClientHasher>>,
 }
@@ -353,23 +340,15 @@ impl BlockStore {
 
     /// Returns immutable reference to a block, given its pointer. Returns `None` if not such
     /// block could be found.
-    pub(crate) fn get_block(&self, id: &ID) -> Option<&Block> {
+    pub(crate) fn get_block(&self, id: &ID) -> Option<BlockRef<'_>> {
         let clients = self.clients.get(&id.client)?;
         clients.get_block(id.clock)
     }
 
-    pub(crate) fn get_block_mut(&mut self, id: &ID) -> Option<&mut Block> {
-        let clients = self.clients.get_mut(&id.client)?;
-        clients.get_block_mut(id.clock)
-    }
-
     pub(crate) fn get_item(&self, id: &ID) -> Option<ItemPtr> {
-        let cell = self.get_block(id)?;
-        if let Block::Item(item) = cell {
-            Some(ItemPtr::from(item))
-        } else {
-            None
-        }
+        let mut cell = self.get_block(id)?;
+        let item = cell.as_item_mut()?;
+        Some(ItemPtr::from(&*item))
     }
 
     /// Returns a block slice that represents a range of data within a particular block containing
@@ -443,7 +422,7 @@ impl std::fmt::Debug for ClientBlockList {
 
 impl std::fmt::Display for ClientBlockList {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_list().entries(self.list.iter()).finish()
+        f.debug_list().entries(self.inner.iter()).finish()
     }
 }
 
@@ -460,46 +439,5 @@ impl std::fmt::Display for BlockStore {
             s.field(&k.to_string(), v);
         }
         s.finish()
-    }
-}
-
-pub(crate) struct Blocks<'a> {
-    current_client: std::vec::IntoIter<(&'a ClientID, &'a ClientBlockList)>,
-    current_block: Option<ClientBlockListIter<'a>>,
-}
-
-impl<'a> Blocks<'a> {
-    fn new(update: &'a BlockStore) -> Self {
-        let mut client_blocks: Vec<(&'a ClientID, &'a ClientBlockList)> =
-            update.clients.iter().collect();
-        // sorting to return higher client ids first
-        client_blocks.sort_by(|a, b| b.0.cmp(a.0));
-        let mut current_client = client_blocks.into_iter();
-
-        let current_block = current_client.next().map(|(_, v)| v.iter());
-        Blocks {
-            current_client,
-            current_block,
-        }
-    }
-}
-
-impl<'a> Iterator for Blocks<'a> {
-    type Item = &'a Block;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(blocks) = self.current_block.as_mut() {
-            let block = blocks.next();
-            if block.is_some() {
-                return block;
-            }
-        }
-
-        if let Some(entry) = self.current_client.next() {
-            self.current_block = Some(entry.1.iter());
-            self.next()
-        } else {
-            None
-        }
     }
 }

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -45,7 +45,7 @@ impl ClientBlockList {
 
     /// Given a block's identifier clock value, return an offset under which this block could be
     /// found using binary search algorithm, or a index under which this block should be inserted.
-    pub(crate) fn find_pivot(&self, clock: u32) -> Option<usize> {
+    pub(crate) fn find_index(&self, clock: u32) -> Option<usize> {
         let mut left = 0;
         let mut right = self.inner.len() - 1;
         let mut block = unsafe { &*self.inner[right].get() };
@@ -78,7 +78,7 @@ impl ClientBlockList {
     /// an ID (<client-id>, 0) and length 2, with contain all elements with clock values
     /// corresponding to {0,1} but not 2.
     fn get_block(&self, clock: u32) -> Option<BlockRef<'_>> {
-        let idx = self.find_pivot(clock)?;
+        let idx = self.find_index(clock)?;
         self.get(idx)
     }
 
@@ -401,7 +401,7 @@ impl BlockStore {
     ) -> Option<ItemPtr> {
         let id = block.id().clone();
         let blocks = self.clients.get_mut(&id.client)?;
-        let index = blocks.find_pivot(id.clock)?;
+        let index = blocks.find_index(id.clock)?;
         let mut right = block.splice(offset, encoding)?;
         let right_ptr = ItemPtr::from(&mut right);
         blocks.insert(index + 1, right.into());

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, BlockRange, ClientID, Item, ItemPtr, ID};
+use crate::block::{Block, BlockRange, ClientID, Item, ItemPtr, ID};
 use crate::slice::ItemSlice;
 use crate::types::TypePtr;
 use crate::utils::client_hasher::ClientHasher;
@@ -12,7 +12,7 @@ use std::vec::Vec;
 /// A resizable list of blocks inserted by a single client.
 #[derive(PartialEq, Default)]
 pub(crate) struct ClientBlockList {
-    list: Vec<BlockCell>,
+    list: Vec<Block>,
 }
 
 struct SquashBlockRange {
@@ -22,18 +22,13 @@ struct SquashBlockRange {
 
 impl ClientBlockList {
     pub fn clock(&self) -> u32 {
-        let len = self.list.len();
-        if len == 0 {
-            0
-        } else {
-            match &self.list[len - 1] {
-                BlockCell::GC(gc) => gc.clock + gc.len,
-                BlockCell::Item(block) => block.id.clock + block.len,
-            }
+        match self.list.last() {
+            None => 0,
+            Some(block) => block.next_clock(),
         }
     }
 
-    pub(crate) fn get(&self, index: usize) -> Option<&BlockCell> {
+    pub(crate) fn get(&self, index: usize) -> Option<&Block> {
         self.list.get(index)
     }
 
@@ -71,24 +66,24 @@ impl ClientBlockList {
     /// list. Clocks are considered to work in left-side inclusive way, meaning that block with
     /// an ID (<client-id>, 0) and length 2, with contain all elements with clock values
     /// corresponding to {0,1} but not 2.
-    fn get_block(&self, clock: u32) -> Option<&BlockCell> {
+    fn get_block(&self, clock: u32) -> Option<&Block> {
         let idx = self.find_pivot(clock)?;
         Some(&self[idx])
     }
 
-    fn get_block_mut(&mut self, clock: u32) -> Option<&mut BlockCell> {
+    fn get_block_mut(&mut self, clock: u32) -> Option<&mut Block> {
         let idx = self.find_pivot(clock)?;
         Some(&mut self[idx])
     }
 
     /// Pushes a new block at the end of this block list.
-    fn push(&mut self, cell: BlockCell) {
+    fn push(&mut self, cell: Block) {
         self.list.push(cell);
     }
 
     /// Inserts a new block at a given `index` position within this block list. This method may
     /// panic if `index` is greater than a length of the list.
-    pub(crate) fn insert(&mut self, index: usize, cell: BlockCell) {
+    pub(crate) fn insert(&mut self, index: usize, cell: Block) {
         self.list.insert(index, cell);
     }
 
@@ -138,7 +133,7 @@ impl ClientBlockList {
             let right = &mut r[0];
 
             match (left, right) {
-                (BlockCell::GC(_), BlockCell::GC(_)) => {
+                (Block::GC(_), Block::GC(_)) => {
                     let mut extended = false;
                     match squash_intervals.last_mut() {
                         Some(last_range) if last_range.gc_block => {
@@ -162,7 +157,7 @@ impl ClientBlockList {
                         });
                     }
                 }
-                (BlockCell::Item(left), BlockCell::Item(right)) => {
+                (Block::Item(left), Block::Item(right)) => {
                     let mut left = ItemPtr::from(left);
                     let right = ItemPtr::from(right);
                     if left.try_squash(right) {
@@ -192,10 +187,10 @@ impl ClientBlockList {
             let right = &right_slice[0];
 
             match (left, right) {
-                (BlockCell::GC(left), BlockCell::GC(right)) => {
+                (Block::GC(left), Block::GC(right)) => {
                     left.len = right.clock - left.clock + right.len;
                 }
-                (BlockCell::Item(left), BlockCell::Item(right)) => {
+                (Block::Item(left), Block::Item(right)) => {
                     let left = ItemPtr::from(left);
                     let right = ItemPtr::from(right);
                     if let Some(key) = right.parent_sub.as_deref() {
@@ -226,11 +221,11 @@ impl ClientBlockList {
         let left = &mut l[index - 1];
         let right = &mut r[0];
         match (left, right) {
-            (BlockCell::GC(left), BlockCell::GC(right)) => {
+            (Block::GC(left), Block::GC(right)) => {
                 left.len = right.clock - left.clock + right.len;
                 self.list.remove(index);
             }
-            (BlockCell::Item(left), BlockCell::Item(right)) => {
+            (Block::Item(left), Block::Item(right)) => {
                 let mut left = ItemPtr::from(left);
                 let right = ItemPtr::from(right);
                 if left.try_squash(right) {
@@ -252,7 +247,7 @@ impl ClientBlockList {
 }
 
 impl Index<usize> for ClientBlockList {
-    type Output = BlockCell;
+    type Output = Block;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.list[index]
@@ -265,20 +260,20 @@ impl IndexMut<usize> for ClientBlockList {
     }
 }
 
-pub(crate) struct ClientBlockListIter<'a>(std::slice::Iter<'a, BlockCell>);
+pub(crate) struct ClientBlockListIter<'a>(std::slice::Iter<'a, Block>);
 
 impl<'a> Iterator for ClientBlockListIter<'a> {
-    type Item = &'a BlockCell;
+    type Item = &'a Block;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
     }
 }
 
-pub(crate) struct ClientBlockListIterMut<'a>(std::slice::IterMut<'a, BlockCell>);
+pub(crate) struct ClientBlockListIterMut<'a>(std::slice::IterMut<'a, Block>);
 
 impl<'a> Iterator for ClientBlockListIterMut<'a> {
-    type Item = &'a mut BlockCell;
+    type Item = &'a mut Block;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next()
@@ -311,30 +306,16 @@ impl BlockStore {
         }
     }
 
-    pub fn push_block(&mut self, block: Box<Item>) {
+    pub fn push(&mut self, block: Block) {
         let id = block.id();
         match self.clients.entry(id.client) {
             Entry::Occupied(mut e) => {
                 let list = e.get_mut();
-                list.push(block.into());
+                list.push(block);
             }
             Entry::Vacant(e) => {
                 let list = e.insert(ClientBlockList::default());
-                list.push(block.into());
-            }
-        }
-    }
-
-    pub fn push_gc(&mut self, gc: BlockRange) {
-        let cell: BlockCell = BlockCell::GC(gc);
-        match self.clients.entry(gc.client) {
-            Entry::Occupied(mut e) => {
-                let list = e.get_mut();
-                list.push(cell);
-            }
-            Entry::Vacant(e) => {
-                let list = e.insert(ClientBlockList::default());
-                list.push(cell);
+                list.push(block);
             }
         }
     }
@@ -372,19 +353,19 @@ impl BlockStore {
 
     /// Returns immutable reference to a block, given its pointer. Returns `None` if not such
     /// block could be found.
-    pub(crate) fn get_block(&self, id: &ID) -> Option<&BlockCell> {
+    pub(crate) fn get_block(&self, id: &ID) -> Option<&Block> {
         let clients = self.clients.get(&id.client)?;
         clients.get_block(id.clock)
     }
 
-    pub(crate) fn get_block_mut(&mut self, id: &ID) -> Option<&mut BlockCell> {
+    pub(crate) fn get_block_mut(&mut self, id: &ID) -> Option<&mut Block> {
         let clients = self.clients.get_mut(&id.client)?;
         clients.get_block_mut(id.clock)
     }
 
     pub(crate) fn get_item(&self, id: &ID) -> Option<ItemPtr> {
         let cell = self.get_block(id)?;
-        if let BlockCell::Item(item) = cell {
+        if let Block::Item(item) = cell {
             Some(ItemPtr::from(item))
         } else {
             None
@@ -504,7 +485,7 @@ impl<'a> Blocks<'a> {
 }
 
 impl<'a> Iterator for Blocks<'a> {
-    type Item = &'a BlockCell;
+    type Item = &'a Block;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(blocks) = self.current_block.as_mut() {

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -83,15 +83,13 @@ impl ClientBlockList {
         self.get(idx)
     }
 
+    pub(crate) fn insert(&mut self, index: usize, cell: Block) {
+        self.inner.insert(index, UnsafeCell::new(cell));
+    }
+
     /// Pushes a new block at the end of this block list.
     fn push(&mut self, cell: Block) {
         self.inner.push(UnsafeCell::new(cell));
-    }
-
-    /// Inserts a new block at a given `index` position within this block list. This method may
-    /// panic if `index` is greater than a length of the list.
-    pub(crate) fn insert(&mut self, index: usize, cell: Block) {
-        self.inner.insert(index, UnsafeCell::new(cell));
     }
 
     /// Returns a number of blocks stored within this list.
@@ -274,7 +272,7 @@ impl<'a> Iterator for ClientBlockListIter<'a> {
 #[derive(Default)]
 pub(crate) struct BlockStore {
     clients: HashMap<ClientID, ClientBlockList, BuildHasherDefault<ClientHasher>>,
-    skips: IdSet,
+    pub(crate) skips: IdSet,
 }
 
 pub(crate) type Iter<'a> = std::collections::hash_map::Iter<'a, ClientID, ClientBlockList>;
@@ -285,10 +283,6 @@ impl BlockStore {
     /// nor tombstoned.
     pub fn is_empty(&self) -> bool {
         self.clients.is_empty()
-    }
-
-    pub fn skips(&self) -> &IdSet {
-        &self.skips
     }
 
     pub fn is_missing(&self, id: &ID) -> bool {
@@ -308,7 +302,29 @@ impl BlockStore {
         match self.clients.entry(id.client) {
             Entry::Occupied(mut e) => {
                 let list = e.get_mut();
-                list.push(block);
+                match list.last() {
+                    Some(last) if last.as_ref().next_clock() != block.clock_start() => {
+                        // this replaces an integrated skip
+                        let clock_start = block.clock_start();
+                        let mut index = list.find_index(clock_start).unwrap();
+                        let skip = unsafe { &mut *list.inner[index].get() };
+                        let diff_start = clock_start - skip.clock_start();
+                        let diff_end = block.next_clock() - skip.next_clock();
+                        if diff_start > 0 {
+                            *skip = Block::Skip(BlockRange::new(skip.id(), diff_start));
+                            index += 1;
+                        }
+                        if diff_end > 0 {
+                            let mut id = block.id();
+                            id.clock += block.len();
+                            let skip = Block::Skip(BlockRange::new(id, diff_end));
+                            list.inner.insert(index + 1, UnsafeCell::new(skip));
+                        }
+                        self.skips.remove_range(&block.range());
+                        list.inner[index] = UnsafeCell::new(block);
+                    }
+                    _ => list.inner.push(UnsafeCell::new(block)),
+                }
             }
             Entry::Vacant(e) => {
                 let list = e.insert(ClientBlockList::default());

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -217,33 +217,39 @@ impl ClientBlockList {
     /// squashed into its left neighbor. In such case a squash result will be returned in order to
     /// later on rewire left/right neighbor changes that may have occurred as a result of squashing
     /// and block removal.
-    pub(crate) fn squash_left(&mut self, index: usize) {
-        let (l, r) = self.inner.split_at_mut(index);
-        let left = unsafe { &mut *l[index - 1].get() };
-        let right = unsafe { &mut *r[0].get() };
-        match (left, right) {
-            (Block::GC(left), Block::GC(right)) => {
-                left.len = right.clock - left.clock + right.len;
-                self.inner.remove(index);
-            }
-            (Block::Item(left), Block::Item(right)) => {
-                let mut left = ItemPtr::from(left);
-                let right = ItemPtr::from(right);
-                if left.try_squash(right) {
-                    if let Some(key) = right.parent_sub.as_deref() {
-                        if let TypePtr::Branch(mut parent) = right.parent {
-                            if let Some(e) = parent.map.get_mut(key) {
-                                if right == *e {
-                                    *e = ItemPtr::from(left);
-                                }
+    pub(crate) fn squash_left(&mut self, pos: usize) -> usize {
+        let mut right = unsafe { &mut *self.inner[pos].get() };
+        let mut i = pos;
+        while i > 0 {
+            let left = unsafe { &mut *self.inner[i - 1].get() };
+            if left.is_deleted() == right.is_deleted()
+                && left.same_type(right)
+                && left.try_squash(right)
+            {
+                // update parent's map entry if necessary
+                if let Block::Item(right) = right {
+                    if let Some(parent_sub) = &right.parent_sub {
+                        if let Some(mut parent) = right.parent.as_branch().copied() {
+                            let e = parent.map.get_mut(parent_sub).unwrap();
+                            if &**e == &**right {
+                                *e = left.as_item().unwrap(); // already confirmed they're the same_type
                             }
                         }
                     }
-                    self.inner.remove(index);
                 }
+            } else {
+                break;
             }
-            _ => { /* cannot squash incompatible types */ }
+
+            i -= 1;
+            right = left;
         }
+
+        let merged = pos - i;
+        if merged > 0 {
+            self.inner.drain(i + 1..=pos);
+        }
+        merged
     }
 }
 

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,6 +1,7 @@
-use crate::block::{Block, BlockRef, ClientID, ItemPtr, ID};
+use crate::block::{Block, BlockRange, BlockRef, ClientID, ItemPtr, ID};
 use crate::slice::ItemSlice;
 use crate::types::TypePtr;
+use crate::update::BlockSet;
 use crate::utils::client_hasher::ClientHasher;
 use crate::*;
 use std::cell::UnsafeCell;
@@ -273,6 +274,7 @@ impl<'a> Iterator for ClientBlockListIter<'a> {
 #[derive(Default)]
 pub(crate) struct BlockStore {
     clients: HashMap<ClientID, ClientBlockList, BuildHasherDefault<ClientHasher>>,
+    skips: IdSet,
 }
 
 pub(crate) type Iter<'a> = std::collections::hash_map::Iter<'a, ClientID, ClientBlockList>;
@@ -283,6 +285,14 @@ impl BlockStore {
     /// nor tombstoned.
     pub fn is_empty(&self) -> bool {
         self.clients.is_empty()
+    }
+
+    pub fn skips(&self) -> &IdSet {
+        &self.skips
+    }
+
+    pub fn is_missing(&self, id: &ID) -> bool {
+        id.clock >= self.get_clock(&id.client) || self.skips.contains(id)
     }
 
     pub fn contains(&self, id: &ID) -> bool {
@@ -322,12 +332,39 @@ impl BlockStore {
     /// peers in order to calculate differences between two stored and produce a compact update,
     /// that can be applied in order to fill missing update information.
     pub fn get_state_vector(&self) -> StateVector {
-        let map = self
+        let mut map: HashMap<ClientID, u32, _> = self
             .clients
             .iter()
             .map(|(client_id, list)| (*client_id, list.clock()))
             .collect();
+
+        for (client, ranges) in self.skips.iter() {
+            if let Some(clock) = ranges.clock_start() {
+                map.insert(*client, clock);
+            }
+        }
+
         StateVector::new(map)
+    }
+
+    pub(crate) fn known_state(&self, ss: &BlockSet) -> IdSet {
+        let mut known_state = IdSet::default();
+        for (client, _) in ss.clients.iter() {
+            if let Some(store_structs) = self.clients.get(client) {
+                let last = store_structs.last().unwrap().as_ref();
+                known_state.insert(ID::new(*client, 0), last.next_clock());
+                // remove known items from ss
+                if let Some(skips) = self.skips.get(client) {
+                    for (skip, _) in skips.iter() {
+                        known_state.remove_range(&BlockRange::new(
+                            ID::new(*client, skip.start),
+                            skip.end - skip.start,
+                        ));
+                    }
+                }
+            }
+        }
+        known_state
     }
 
     pub(crate) fn get_client(&self, client_id: &ClientID) -> Option<&ClientBlockList> {

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, BlockRange, ClientID, Item, ItemPtr, GC, ID};
+use crate::block::{BlockCell, BlockRange, ClientID, Item, ItemPtr, ID};
 use crate::slice::ItemSlice;
 use crate::types::TypePtr;
 use crate::utils::client_hasher::ClientHasher;
@@ -326,7 +326,7 @@ impl BlockStore {
     }
 
     pub fn push_gc(&mut self, gc: BlockRange) {
-        let cell: BlockCell = GC::from(gc).into();
+        let cell: BlockCell = BlockCell::GC(gc);
         match self.clients.entry(gc.client) {
             Entry::Occupied(mut e) => {
                 let list = e.get_mut();

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -326,16 +326,15 @@ impl BlockStore {
     }
 
     pub fn push_gc(&mut self, gc: BlockRange) {
-        let id = gc.id;
-        let gc: BlockCell = GC::from(gc).into();
-        match self.clients.entry(id.client) {
+        let cell: BlockCell = GC::from(gc).into();
+        match self.clients.entry(gc.client) {
             Entry::Occupied(mut e) => {
                 let list = e.get_mut();
-                list.push(gc);
+                list.push(cell);
             }
             Entry::Vacant(e) => {
                 let list = e.insert(ClientBlockList::default());
-                list.push(gc);
+                list.push(cell);
             }
         }
     }

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, Item, ItemContent, ItemPosition, ItemPtr, Prelim};
+use crate::block::{Block, Item, ItemContent, ItemPosition, ItemPtr, Prelim};
 use crate::types::array::ArrayEvent;
 use crate::types::map::MapEvent;
 use crate::types::text::TextEvent;
@@ -761,7 +761,7 @@ impl<S: SharedRef> Nested<S> {
     pub fn get<T: ReadTxn>(&self, txn: &T) -> Option<S> {
         let store = txn.store();
         let block = store.blocks.get_block(&self.id)?;
-        if let BlockCell::Item(block) = block {
+        if let Block::Item(block) = block {
             if let ItemContent::Type(branch) = &block.content {
                 if let Some(ptr) = branch.item {
                     if !ptr.is_deleted() {
@@ -922,7 +922,7 @@ impl BranchID {
 
     pub fn get_nested<T: ReadTxn>(txn: &T, id: &ID) -> Option<BranchPtr> {
         let block = txn.store().blocks.get_block(id)?;
-        if let BlockCell::Item(block) = block {
+        if let Block::Item(block) = block {
             if let ItemContent::Type(branch) = &block.content {
                 return Some(BranchPtr::from(&*branch));
             }

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -761,7 +761,7 @@ impl<S: SharedRef> Nested<S> {
     pub fn get<T: ReadTxn>(&self, txn: &T) -> Option<S> {
         let store = txn.store();
         let block = store.blocks.get_block(&self.id)?;
-        if let Block::Item(block) = block {
+        if let Block::Item(block) = block.as_ref() {
             if let ItemContent::Type(branch) = &block.content {
                 if let Some(ptr) = branch.item {
                     if !ptr.is_deleted() {
@@ -922,7 +922,7 @@ impl BranchID {
 
     pub fn get_nested<T: ReadTxn>(txn: &T, id: &ID) -> Option<BranchPtr> {
         let block = txn.store().blocks.get_block(id)?;
-        if let Block::Item(block) = block {
+        if let Block::Item(block) = block.as_ref() {
             if let ItemContent::Type(branch) = &block.content {
                 return Some(BranchPtr::from(&*branch));
             }

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -761,7 +761,7 @@ impl<S: SharedRef> Nested<S> {
     pub fn get<T: ReadTxn>(&self, txn: &T) -> Option<S> {
         let store = txn.store();
         let block = store.blocks.get_block(&self.id)?;
-        if let BlockCell::Block(block) = block {
+        if let BlockCell::Item(block) = block {
             if let ItemContent::Type(branch) = &block.content {
                 if let Some(ptr) = branch.item {
                     if !ptr.is_deleted() {
@@ -922,7 +922,7 @@ impl BranchID {
 
     pub fn get_nested<T: ReadTxn>(txn: &T, id: &ID) -> Option<BranchPtr> {
         let block = txn.store().blocks.get_block(id)?;
-        if let BlockCell::Block(block) = block {
+        if let BlockCell::Item(block) = block {
             if let ItemContent::Type(branch) = &block.content {
                 return Some(BranchPtr::from(&*branch));
             }

--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -209,6 +209,8 @@ pub struct Branch {
     /// An identifier of an underlying complex data type (eg. is it an Array or a Map).
     pub(crate) type_ref: TypeRef,
 
+    pub(crate) has_formatting: bool,
+
     pub(crate) observers: Observer<ObserveFn>,
 
     pub(crate) deep_observers: Observer<DeepObserveFn>,
@@ -254,6 +256,7 @@ impl Branch {
             type_ref,
             observers: Observer::default(),
             deep_observers: Observer::default(),
+            has_formatting: false,
         })
     }
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -2455,7 +2455,8 @@ mod test {
             .store()
             .blocks
             .get_block(&ID::new(ClientID::new(1), 1))
-            .unwrap();
+            .unwrap()
+            .as_ref();
         assert_eq!(block.len(), 3, "GCed blocks should be squashed");
         assert!(block.is_deleted(), "`abc` should be deleted");
         assert_matches!(&block, &Block::GC(_));
@@ -2530,7 +2531,8 @@ mod test {
             .store()
             .blocks
             .get_block(&ID::new(ClientID::new(1), 1))
-            .unwrap();
+            .unwrap()
+            .as_ref();
         assert_eq!(
             block,
             &Block::GC(BlockRange::new(ID::new(ClientID::new(1), 1), 3)),

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -2535,7 +2535,7 @@ mod test {
             .unwrap();
         assert_eq!(
             block,
-            &BlockCell::GC(GC::new(1, 3)),
+            &BlockCell::GC(GC::new(ClientID::new(1), 1, 3)),
             "block should be GCed & compressed"
         );
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1357,11 +1357,11 @@ mod test {
             // Compare values
             assert_eq!(
                 before_state.swap(None),
-                Some(Arc::new(txn.before_state.clone()))
+                Some(Arc::new(txn.before_state().clone()))
             );
             assert_eq!(
                 after_state.swap(None),
-                Some(Arc::new(txn.after_state.clone()))
+                Some(Arc::new(txn.after_state().clone()))
             );
             assert_eq!(
                 delete_set.swap(None),
@@ -1376,7 +1376,7 @@ mod test {
         txn.commit();
         assert_ne!(
             after_state.swap(None),
-            Some(Arc::new(txn.after_state.clone()))
+            Some(Arc::new(txn.after_state().clone()))
         );
     }
 
@@ -2363,8 +2363,8 @@ mod test {
         let e_copy = e.clone();
         d1.observe_after_transaction_with("key", move |txn| {
             e_copy.swap(Some(Arc::new((
-                txn.before_state.clone(),
-                txn.after_state.clone(),
+                txn.before_state().clone(),
+                txn.after_state().clone(),
                 txn.delete_set.clone(),
             ))));
         })
@@ -2375,7 +2375,7 @@ mod test {
         assert_eq!(
             actual,
             Some(Arc::new((
-                StateVector::default(),
+                StateVector::from_iter([(ClientID::new(1), 0)]),
                 StateVector::from_iter([(ClientID::new(1), 11)]),
                 IdSet::default()
             )))

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -2282,30 +2282,31 @@ mod test {
         };
 
         let map = d1.get_or_insert_map("map");
-        map.insert(&mut d1.transact_mut(), "a", 1);
-        map.insert(&mut d1.transact_mut(), "a", 1.1);
-        map.insert(&mut d1.transact_mut(), "b", 2);
+        map.insert(&mut d1.transact_mut(), "a", 1); // U1: 'a' => 1
+        map.insert(&mut d1.transact_mut(), "a", 1.1); // U2: 'a' => 1.1
+        map.insert(&mut d1.transact_mut(), "b", 2); // U3: 'b' => 2
 
         assert_eq!(map.to_json(&d1.transact()), any!({"a": 1.1, "b": 2}));
 
         let d2 = Doc::new();
+        let map = d2.get_or_insert_map("map");
 
         {
             let mut updates = updates.lock().unwrap();
-            let u3 = updates.pop().unwrap();
-            let u2 = updates.pop().unwrap();
-            let u1 = updates.pop().unwrap();
+            let u3 = updates.pop().unwrap(); // 'b' => 2
+            let u2 = updates.pop().unwrap(); // 'a' => 1.1
+            let u1 = updates.pop().unwrap(); // 'a' => 1
             let mut txn = d2.transact_mut();
-            txn.apply_update(u1).unwrap();
-            assert!(txn.store.pending.is_none()); // applied
-            txn.apply_update(u3).unwrap();
-            assert!(txn.store.pending.is_some()); // pending update waiting for u2
-            txn.apply_update(u2).unwrap();
-            assert!(txn.store.pending.is_none()); // applied after fixing the missing update
-        }
 
-        let map = d2.get_or_insert_map("map");
-        assert_eq!(map.to_json(&d2.transact()), any!({"a": 1.1, "b": 2}));
+            txn.apply_update(u1).unwrap(); // apply: 'a' => 1
+            assert_eq!(map.to_json(&txn), any!({"a": 1}));
+
+            txn.apply_update(u3).unwrap(); // apply: 'b' => 2 (it's ok, we insert a skip for u2)
+            assert_eq!(map.to_json(&txn), any!({"a": 1, "b": 2}));
+
+            txn.apply_update(u2).unwrap(); // apply: 'a' => 1.1
+            assert_eq!(map.to_json(&txn), any!({"a": 1.1, "b": 2}));
+        }
     }
 
     #[test]

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1034,7 +1034,7 @@ impl DocAddr {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockCell, ClientID, ItemContent, GC};
+    use crate::block::{BlockCell, BlockRange, ClientID, ItemContent};
     use crate::error::Error;
     use crate::test_utils::exchange_updates;
     use crate::transaction::{ReadTxn, TransactionMut};
@@ -2535,7 +2535,7 @@ mod test {
             .unwrap();
         assert_eq!(
             block,
-            &BlockCell::GC(GC::new(ClientID::new(1), 1, 3)),
+            &BlockCell::GC(BlockRange::new(ID::new(ClientID::new(1), 1), 3)),
             "block should be GCed & compressed"
         );
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -910,6 +910,13 @@ pub struct Options {
     ///
     /// Default value: `true`.
     pub should_load: bool,
+
+    /// Whenever we receive an update that might remove piece of text, it might turn out that it was
+    /// surrounded by the formatting attributes, that now are effectively dead and unrenderable, but
+    /// still are considered alive blocks.
+    ///
+    /// This flag orders cleanup of dangling formatting attributes.
+    pub cleanup_formatting: bool,
 }
 
 impl Options {
@@ -922,6 +929,7 @@ impl Options {
             skip_gc: false,
             auto_load: false,
             should_load: true,
+            cleanup_formatting: true,
         }
     }
 
@@ -934,6 +942,7 @@ impl Options {
             skip_gc: false,
             auto_load: false,
             should_load: true,
+            cleanup_formatting: false,
         }
     }
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -1034,9 +1034,9 @@ impl DocAddr {
 
 #[cfg(test)]
 mod test {
-    use crate::block::{BlockCell, BlockRange, ClientID, ItemContent};
+    use crate::block::{Block, BlockRange, ClientID, ItemContent};
     use crate::error::Error;
-    use crate::test_utils::exchange_updates;
+    use crate::test_utils::{exchange_updates, Blocks};
     use crate::transaction::{ReadTxn, TransactionMut};
     use crate::types::ToJson;
     use crate::update::Update;
@@ -1175,7 +1175,8 @@ mod test {
         let c = counter.clone();
         let sub = doc2.observe_update_v1(move |_, e| {
             let u = Update::decode_v1(&e.update).unwrap();
-            for block in u.blocks.blocks() {
+            let blocks = Blocks::new(&u.blocks);
+            for block in blocks {
                 c.fetch_add(block.len(), Ordering::SeqCst);
             }
         });
@@ -1420,19 +1421,16 @@ mod test {
         let _sub = d1.observe_update_v1(move |_: &TransactionMut, e| {
             let u = Update::decode_v1(&e.update).unwrap();
             for mut block in u.blocks.into_blocks(false) {
-                match block.as_item_ptr().as_deref() {
-                    Some(item) => {
-                        if let ItemContent::String(s) = &item.content {
-                            // each character is appended in individual transaction 1-by-1,
-                            // therefore each update should contain a single string with only
-                            // one element
-                            let mut aref = a.lock().unwrap();
-                            aref.push_str(s.as_str());
-                        } else {
-                            panic!("unexpected content type")
-                        }
+                if let Block::Item(item) = block {
+                    if let ItemContent::String(s) = &item.content {
+                        // each character is appended in individual transaction 1-by-1,
+                        // therefore each update should contain a single string with only
+                        // one element
+                        let mut aref = a.lock().unwrap();
+                        aref.push_str(s.as_str());
+                    } else {
+                        panic!("unexpected content type")
                     }
-                    _ => {}
                 }
             }
         });
@@ -2460,7 +2458,7 @@ mod test {
             .unwrap();
         assert_eq!(block.len(), 3, "GCed blocks should be squashed");
         assert!(block.is_deleted(), "`abc` should be deleted");
-        assert_matches!(&block, &BlockCell::GC(_));
+        assert_matches!(&block, &Block::GC(_));
     }
 
     #[test]
@@ -2535,7 +2533,7 @@ mod test {
             .unwrap();
         assert_eq!(
             block,
-            &BlockCell::GC(BlockRange::new(ID::new(ClientID::new(1), 1), 3)),
+            &Block::GC(BlockRange::new(ID::new(ClientID::new(1), 1), 3)),
             "block should be GCed & compressed"
         );
 

--- a/yrs/src/event.rs
+++ b/yrs/src/event.rs
@@ -34,8 +34,8 @@ pub struct TransactionCleanupEvent {
 impl TransactionCleanupEvent {
     pub fn new(txn: &TransactionMut) -> Self {
         TransactionCleanupEvent {
-            before_state: txn.before_state.clone(),
-            after_state: txn.after_state.clone(),
+            before_state: txn.before_state().clone(),
+            after_state: txn.after_state().clone(),
             delete_set: txn.delete_set.clone(),
         }
     }

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, ClientID, GC};
+use crate::block::{BlockCell, ClientID};
 use crate::{IdSet, Store, TransactionMut, ID};
 use std::collections::HashMap;
 
@@ -87,7 +87,7 @@ impl GCCollector {
                     let block = &mut client[index];
                     if let BlockCell::Item(item) = block {
                         if item.is_deleted() && !item.info.is_keep() {
-                            let gc = BlockCell::GC(GC::from(item.as_ref()));
+                            let gc = BlockCell::GC(item.block_range());
                             *block = gc;
                         }
                     }

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, ClientID};
+use crate::block::{Block, ClientID};
 use crate::{IdSet, Store, TransactionMut, ID};
 use std::collections::HashMap;
 
@@ -44,7 +44,7 @@ impl GCCollector {
                             if start > delete_item.end {
                                 break;
                             } else {
-                                if let BlockCell::Item(item) = block {
+                                if let Block::Item(item) = block {
                                     item.gc(self, false);
                                     if let Some(merge_blocks) = merge_blocks.as_deref_mut() {
                                         merge_blocks.push(item.id);
@@ -62,7 +62,7 @@ impl GCCollector {
     fn mark_all(&mut self, txn: &mut TransactionMut) {
         for (_, client_blocks) in txn.store.blocks.iter_mut() {
             for block in client_blocks.iter_mut() {
-                if let BlockCell::Item(item) = block {
+                if let Block::Item(item) = block {
                     if item.is_deleted() {
                         item.gc(self, false);
                         txn.merge_blocks.push(item.id);
@@ -85,9 +85,9 @@ impl GCCollector {
             for clock in clocks {
                 if let Some(index) = client.find_pivot(clock) {
                     let block = &mut client[index];
-                    if let BlockCell::Item(item) = block {
+                    if let Block::Item(item) = block {
                         if item.is_deleted() && !item.info.is_keep() {
-                            let gc = BlockCell::GC(item.block_range());
+                            let gc = Block::GC(item.block_range());
                             *block = gc;
                         }
                     }

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -38,7 +38,8 @@ impl GCCollector {
                     let mut start = delete_item.start;
                     if let Some(mut i) = blocks.find_pivot(start) {
                         while i < blocks.len() {
-                            let block = &mut blocks[i];
+                            let mut block = unsafe { blocks.get(i).unwrap_unchecked() };
+                            let block = block.as_mut();
                             let len = block.len();
                             start += len;
                             if start > delete_item.end {
@@ -61,8 +62,8 @@ impl GCCollector {
 
     fn mark_all(&mut self, txn: &mut TransactionMut) {
         for (_, client_blocks) in txn.store.blocks.iter_mut() {
-            for block in client_blocks.iter_mut() {
-                if let Block::Item(item) = block {
+            for mut block in client_blocks.iter() {
+                if let Block::Item(item) = block.as_mut() {
                     if item.is_deleted() {
                         item.gc(self, false);
                         txn.merge_blocks.push(item.id);
@@ -84,7 +85,7 @@ impl GCCollector {
             let client = txn.store.blocks.get_client_blocks_mut(client_id);
             for clock in clocks {
                 if let Some(index) = client.find_pivot(clock) {
-                    let block = &mut client[index];
+                    let block = unsafe { client.get(index).unwrap_unchecked() }.as_mut();
                     if let Block::Item(item) = block {
                         if item.is_deleted() && !item.info.is_keep() {
                             let gc = Block::GC(item.block_range());

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -36,7 +36,7 @@ impl GCCollector {
             if let Some(blocks) = store.blocks.get_client_mut(client) {
                 for delete_item in range.iter().rev() {
                     let mut start = delete_item.start;
-                    if let Some(mut i) = blocks.find_pivot(start) {
+                    if let Some(mut i) = blocks.find_index(start) {
                         while i < blocks.len() {
                             let mut block = unsafe { blocks.get(i).unwrap_unchecked() };
                             let block = block.as_mut();
@@ -84,7 +84,7 @@ impl GCCollector {
         for (client_id, clocks) in self.marked.into_iter() {
             let client = txn.store.blocks.get_client_blocks_mut(client_id);
             for clock in clocks {
-                if let Some(index) = client.find_pivot(clock) {
+                if let Some(index) = client.find_index(clock) {
                     let block = unsafe { client.get(index).unwrap_unchecked() }.as_mut();
                     if let Block::Item(item) = block {
                         if item.is_deleted() && !item.info.is_keep() {

--- a/yrs/src/gc.rs
+++ b/yrs/src/gc.rs
@@ -44,7 +44,7 @@ impl GCCollector {
                             if start > delete_item.end {
                                 break;
                             } else {
-                                if let BlockCell::Block(item) = block {
+                                if let BlockCell::Item(item) = block {
                                     item.gc(self, false);
                                     if let Some(merge_blocks) = merge_blocks.as_deref_mut() {
                                         merge_blocks.push(item.id);
@@ -62,7 +62,7 @@ impl GCCollector {
     fn mark_all(&mut self, txn: &mut TransactionMut) {
         for (_, client_blocks) in txn.store.blocks.iter_mut() {
             for block in client_blocks.iter_mut() {
-                if let BlockCell::Block(item) = block {
+                if let BlockCell::Item(item) = block {
                     if item.is_deleted() {
                         item.gc(self, false);
                         txn.merge_blocks.push(item.id);
@@ -85,10 +85,9 @@ impl GCCollector {
             for clock in clocks {
                 if let Some(index) = client.find_pivot(clock) {
                     let block = &mut client[index];
-                    if let BlockCell::Block(item) = block {
+                    if let BlockCell::Item(item) = block {
                         if item.is_deleted() && !item.info.is_keep() {
-                            let (start, end) = item.clock_range();
-                            let gc = BlockCell::GC(GC::new(start, end));
+                            let gc = BlockCell::GC(GC::from(item.as_ref()));
                             *block = gc;
                         }
                     }

--- a/yrs/src/id_map.rs
+++ b/yrs/src/id_map.rs
@@ -121,9 +121,9 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
     }
 
     pub fn attributions(&self, range: &BlockRange) -> Vec<AttrRange<A>> {
-        let client = range.id.client;
-        let block_start = range.id.clock;
-        let block_end = range.id.clock + range.len;
+        let client = range.client;
+        let block_start = range.clock;
+        let block_end = range.clock + range.len;
         let mut result: Vec<AttrRange<A>> = Vec::new();
 
         if let Some(dr) = self.inner.get(&client) {
@@ -178,7 +178,7 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
         self.ensure_attrs(&mut attrs);
         let content_attrs = ContentAttributes(attrs.into());
         self.inner
-            .insert_range(range.id.client, range.clock_range(), content_attrs);
+            .insert_range(range.client, range.clock_range(), content_attrs);
     }
 
     pub fn remove(&mut self, range: &BlockRange) {
@@ -186,7 +186,7 @@ impl<A: PartialEq + Eq + Hash + Clone> IdMap<A> {
             return;
         }
 
-        if let Entry::Occupied(mut e) = self.inner.entry(range.id.client) {
+        if let Entry::Occupied(mut e) = self.inner.entry(range.client) {
             let ranges = e.get_mut();
             ranges.remove(range.clock_range());
             if ranges.is_empty() {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -226,6 +226,10 @@ impl IdSet {
         self.0.len()
     }
 
+    pub fn client_ids<'a>(&'a self) -> impl Iterator<Item = ClientID> + 'a {
+        self.0.clients().keys().copied()
+    }
+
     pub fn iter(&self) -> Iter<'_> {
         Iter(self.0.clients().iter())
     }
@@ -455,7 +459,7 @@ impl DeleteSet for IdSet {
             for (r, _) in range.iter().rev() {
                 // start with merging the item next to the last deleted item
                 let mut si =
-                    (blocks.len() - 1).min(1 + blocks.find_pivot(r.end - 1).unwrap_or_default());
+                    (blocks.len() - 1).min(1 + blocks.find_index(r.end - 1).unwrap_or_default());
                 let mut block = &blocks[si];
 
                 let mut valid_range = usize::MAX..usize::MIN;
@@ -527,7 +531,7 @@ impl<'ds> TxnIterator for Blocks<'ds> {
                     .blocks
                     .get_client(&self.current_client_id?)
                     .unwrap();
-                if let Some(idx) = list.find_pivot(r.start) {
+                if let Some(idx) = list.find_index(r.start) {
                     let mut block = list[idx].as_slice();
                     let clock = block.clock_start();
 

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -169,6 +169,10 @@ impl<'a> Ranges<'a> {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    pub(crate) fn clock_start(&self) -> Option<u32> {
+        self.0.clock_start()
+    }
 }
 
 impl<'a> IntoIterator for Ranges<'a> {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -173,6 +173,10 @@ impl<'a> Ranges<'a> {
     pub(crate) fn clock_start(&self) -> Option<u32> {
         self.0.clock_start()
     }
+
+    pub(crate) fn clock_end(&self) -> Option<u32> {
+        self.0.clock_end()
+    }
 }
 
 impl<'a> IntoIterator for Ranges<'a> {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -1,7 +1,7 @@
 use crate::block::{BlockRange, ClientID, ID};
 use crate::block_store::BlockStore;
 use crate::encoding::read::Error;
-use crate::ids::{IdMapInner, IdRanges};
+use crate::ids::{BlockSliceIter, IdMapInner, IdRanges};
 use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::store::Store;
@@ -240,6 +240,10 @@ impl IdSet {
 
     pub fn iter(&self) -> Iter<'_> {
         Iter(self.0.clients().iter())
+    }
+
+    pub(crate) fn iter_blocks<'a>(&'a self, blocks: &'a BlockStore) -> BlockSliceIter<'a, ()> {
+        self.0.iter_blocks(blocks)
     }
 
     pub fn range_mut(&mut self, client_id: ClientID) -> &mut IdRange {

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -434,6 +434,7 @@ impl DeleteSet for IdSet {
         for (&client, blocks) in store.iter() {
             let mut deletes = IdRange::with_capacity(blocks.len());
             for block in blocks.iter() {
+                let block = block.as_ref();
                 if block.is_deleted() {
                     let (start, end) = block.clock_range();
                     deletes.insert(start..(end + 1));
@@ -513,7 +514,7 @@ impl<'ds> TxnIterator for Blocks<'ds> {
                     .get(*idx)
                 {
                     *idx += 1;
-                    block.as_slice()
+                    block.as_ref().as_slice()
                 } else {
                     self.current_range = None;
                     self.current_index = None;

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -303,7 +303,7 @@ impl IdSet {
     /// Remove a given range of elements from the current [IdSet]. If the client's [IdRange]
     /// becomes empty as a result, the client entry is dropped from the set entirely.
     pub fn remove_range(&mut self, range: &BlockRange) {
-        if let Entry::Occupied(mut e) = self.0.entry(range.id.client) {
+        if let Entry::Occupied(mut e) = self.0.entry(range.client) {
             let ranges = e.get_mut();
             ranges.remove(range.clock_range());
             if ranges.is_empty() {

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -73,6 +73,11 @@ impl<T: Merge> IdRanges<T> {
         self.0.is_empty()
     }
 
+    pub fn clock_start(&self) -> Option<u32> {
+        let r = self.0.first()?;
+        Some(r.0.start)
+    }
+
     /// Check if a given clock value is covered by any range in this set.
     pub fn contains_clock(&self, clock: u32) -> bool {
         let idx = self.0.partition_point(|e| e.0.start <= clock);

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -78,6 +78,11 @@ impl<T: Merge> IdRanges<T> {
         Some(r.0.start)
     }
 
+    pub fn clock_end(&self) -> Option<u32> {
+        let r = self.0.last()?;
+        Some(r.0.end)
+    }
+
     /// Check if a given clock value is covered by any range in this set.
     pub fn contains_clock(&self, clock: u32) -> bool {
         let idx = self.0.partition_point(|e| e.0.start <= clock);

--- a/yrs/src/ids.rs
+++ b/yrs/src/ids.rs
@@ -1,4 +1,6 @@
 use crate::block::{ClientID, ID};
+use crate::block_store::{BlockStore, ClientBlockList};
+use crate::slice::BlockSlice;
 use smallvec::SmallVec;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
@@ -738,6 +740,131 @@ impl<T: Merge> IdMapInner<T> {
     pub(crate) fn clients_mut(&mut self) -> &mut BTreeMap<ClientID, IdRanges<T>> {
         &mut self.0
     }
+
+    /// Iterate over all blocks referenced by this ID map without splitting them.
+    ///
+    /// This is the Rust equivalent of yjs `iterateStructsByIdSetWithoutSplits`.
+    /// For each block that overlaps with a range in this map, a [`BlockSlice`] is
+    /// yielded with appropriate trimming applied (the underlying blocks in the store
+    /// are never split).
+    pub(crate) fn iter_blocks<'a>(&'a self, store: &'a BlockStore) -> BlockSliceIter<'a, T> {
+        BlockSliceIter {
+            store,
+            client_iter: self.0.iter(),
+            blocks: None,
+            client_end_clock: 0,
+            range_iter: None,
+            range_start: 0,
+            range_end: 0,
+            block_idx: 0,
+            in_range: false,
+        }
+    }
+}
+
+/// Iterator that yields [`BlockSlice`] values for every block in a [`BlockStore`]
+/// that overlaps with ranges described by an [`IdMapInner`]. Blocks are never
+/// split — instead each yielded slice carries the appropriate start/end trim.
+///
+/// Created by [`IdMapInner::iter_blocks`].
+pub(crate) struct BlockSliceIter<'a, T: Merge> {
+    store: &'a BlockStore,
+    client_iter: std::collections::btree_map::Iter<'a, ClientID, IdRanges<T>>,
+    /// Current client's block list (None = need to advance to next client).
+    blocks: Option<&'a ClientBlockList>,
+    /// Exclusive upper clock bound for the current client's blocks.
+    client_end_clock: u32,
+    /// Iterator over ranges for the current client (None = need to advance to next client).
+    range_iter: Option<std::slice::Iter<'a, (Range<u32>, T)>>,
+    /// Inclusive start of the current range being iterated.
+    range_start: u32,
+    /// Exclusive end of the current range being iterated.
+    range_end: u32,
+    /// Index of the next block to yield within the current range.
+    block_idx: usize,
+    /// Whether we are currently yielding blocks within a range.
+    in_range: bool,
+}
+
+impl<'a, T: Merge> Iterator for BlockSliceIter<'a, T> {
+    type Item = BlockSlice;
+
+    fn next(&mut self) -> Option<BlockSlice> {
+        loop {
+            if self.in_range {
+                let blocks = self.blocks?;
+                if let Some(block_ref) = blocks.get(self.block_idx) {
+                    let block = block_ref.as_ref();
+                    let clock = block.clock_start();
+
+                    if clock >= self.range_end {
+                        // Block is past current range — advance to next range.
+                        self.in_range = false;
+                        continue;
+                    }
+
+                    let mut slice = block.as_slice();
+                    let block_end = block.next_clock(); // exclusive
+
+                    // Trim start if block begins before the range.
+                    if clock < self.range_start {
+                        slice.trim_start(self.range_start - clock);
+                    }
+
+                    // Trim end if block extends past the range.
+                    if block_end > self.range_end {
+                        slice.trim_end(block_end - self.range_end);
+                    }
+
+                    if block_end >= self.range_end {
+                        // This block covers the rest of the range — mark range as done.
+                        self.in_range = false;
+                    } else {
+                        self.block_idx += 1;
+                    }
+                    return Some(slice);
+                } else {
+                    // No more blocks at this index — range is done.
+                    self.in_range = false;
+                    continue;
+                }
+            }
+
+            // Try to advance to the next range for the current client.
+            if let Some(range_iter) = self.range_iter.as_mut() {
+                if let Some((range, _)) = range_iter.next() {
+                    if range.start < self.client_end_clock {
+                        let blocks = self.blocks.unwrap();
+                        if let Some(idx) = blocks.find_index(range.start) {
+                            self.range_start = range.start;
+                            self.range_end = range.end;
+                            self.block_idx = idx;
+                            self.in_range = true;
+                            continue;
+                        }
+                    }
+                    // Range past client's blocks or block not found — try next range.
+                    continue;
+                } else {
+                    // No more ranges — advance to next client.
+                    self.range_iter = None;
+                    self.blocks = None;
+                }
+            }
+
+            // Advance to the next client.
+            let (client_id, ranges) = self.client_iter.next()?;
+            if let Some(blocks) = self.store.get_client(client_id) {
+                if let Some(last) = blocks.last() {
+                    self.client_end_clock = last.as_ref().next_clock();
+                    self.blocks = Some(blocks);
+                    self.range_iter = Some(ranges.iter());
+                    continue;
+                }
+            }
+            // No blocks for this client — try next.
+        }
+    }
 }
 
 impl<T: Merge + std::fmt::Debug> std::fmt::Debug for IdMapInner<T> {
@@ -753,8 +880,6 @@ impl<T: Merge + std::fmt::Debug> std::fmt::Debug for IdMapInner<T> {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    // ---- IdRanges<()> tests (equivalent to old IdRange) ----
 
     #[test]
     fn insert_non_overlapping() {
@@ -1078,5 +1203,229 @@ mod test {
         assert!(a.contains(&ID::new(ClientID::new(1), 2)));
         assert!(!a.contains(&ID::new(ClientID::new(1), 5)));
         assert!(a.contains(&ID::new(ClientID::new(1), 8)));
+    }
+
+    use crate::test_utils::exchange_updates;
+    use crate::{Doc, IdSet, Options, ReadTxn, Text, Transact};
+
+    /// Helper: collect (clock_start, len) tuples from iter_blocks.
+    fn collect_slices(id_set: &IdSet, store: &BlockStore) -> Vec<(u32, u32)> {
+        id_set
+            .iter_blocks(store)
+            .map(|s| (s.clock_start(), s.len()))
+            .collect()
+    }
+
+    #[test]
+    fn iter_blocks_exact_range() {
+        // Single client, range exactly covers the block.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let doc = Doc::with_options(o);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abcde"); // block: client=1, clock=0..5
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [0..5])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(0, 5)]);
+    }
+
+    #[test]
+    fn iter_blocks_partial_range_trims_both_ends() {
+        // Range covers the middle of a block — should trim both start and end.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let doc = Doc::with_options(o);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abcdefghij"); // block: client=1, clock=0..10
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [3..7])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(3, 4)]); // clocks 3,4,5,6
+    }
+
+    #[test]
+    fn iter_blocks_partial_range_trim_start_only() {
+        // Range starts in the middle of the block but extends to the end.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let doc = Doc::with_options(o);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abcde"); // block: client=1, clock=0..5
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [2..5])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(2, 3)]); // clocks 2,3,4
+    }
+
+    #[test]
+    fn iter_blocks_partial_range_trim_end_only() {
+        // Range starts at the beginning of the block but ends before it.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let doc = Doc::with_options(o);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abcde"); // block: client=1, clock=0..5
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [0..3])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(0, 3)]); // clocks 0,1,2
+    }
+
+    #[test]
+    fn iter_blocks_multiple_ranges_single_client() {
+        // Two disjoint ranges within the same client's blocks.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let doc = Doc::with_options(o);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abcdefghij"); // block: client=1, clock=0..10
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [1..3, 7..9])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(1, 2), (7, 2)]);
+    }
+
+    #[test]
+    fn iter_blocks_multiple_clients() {
+        // Two clients, each with their own blocks and ranges.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let d1 = Doc::with_options(o.clone());
+        let t1 = d1.get_or_insert_text("test");
+
+        o.client_id = ClientID::new(2);
+        let d2 = Doc::with_options(o);
+        let t2 = d2.get_or_insert_text("test");
+
+        t1.push(&mut d1.transact_mut(), "aaaaa"); // client=1, clock=0..5
+        exchange_updates(&[&d1, &d2]);
+
+        t2.push(&mut d2.transact_mut(), "bbb"); // client=2, clock=0..3
+        exchange_updates(&[&d1, &d2]);
+
+        let txn = d1.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [1..4]), (ClientID::new(2), [0..2])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(1, 3), (0, 2)]);
+    }
+
+    #[test]
+    fn iter_blocks_range_spans_multiple_blocks() {
+        // A single range that spans across two separate blocks for the same client.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let d1 = Doc::with_options(o.clone());
+        let t1 = d1.get_or_insert_text("test");
+
+        o.client_id = ClientID::new(2);
+        let d2 = Doc::with_options(o);
+        let t2 = d2.get_or_insert_text("test");
+
+        t1.push(&mut d1.transact_mut(), "aaa"); // client=1, clock=0..3
+        exchange_updates(&[&d1, &d2]);
+
+        // d2 inserts in the middle, which will cause block split on integration
+        t2.insert(&mut d2.transact_mut(), 1, "bb"); // client=2, clock=0..2
+        exchange_updates(&[&d1, &d2]);
+
+        // Append more to client=1
+        t1.push(&mut d1.transact_mut(), "cc"); // client=1, clock=3..5
+
+        // d1 store has client=1 blocks split around client=2's insertion.
+        // A range covering clock 0..5 should yield all of them.
+        let txn = d1.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [0..5])]);
+
+        let slices: Vec<_> = set.iter_blocks(&txn.store().blocks).collect();
+        // Verify all clocks 0..5 are covered
+        let total_len: u32 = slices.iter().map(|s| s.len()).sum();
+        assert_eq!(total_len, 5);
+        // First slice should start at clock 0
+        assert_eq!(slices.first().unwrap().clock_start(), 0);
+    }
+
+    #[test]
+    fn iter_blocks_range_past_client_blocks() {
+        // Range extends beyond what the client has — should only yield existing blocks.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let doc = Doc::with_options(o);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abc"); // block: client=1, clock=0..3
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(1), [0..100])]); // range far past actual blocks
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert_eq!(result, vec![(0, 3)]);
+    }
+
+    #[test]
+    fn iter_blocks_unknown_client() {
+        // Range for a client that has no blocks in the store — yields nothing.
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abc");
+
+        let txn = doc.transact();
+        let set = IdSet::from_iter([(ClientID::new(999), [0..10])]);
+
+        let result = collect_slices(&set, &txn.store().blocks);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn iter_blocks_empty_map() {
+        // Empty IdMapInner — yields nothing.
+        let doc = Doc::with_client_id(1);
+        let txt = doc.get_or_insert_text("test");
+        txt.push(&mut doc.transact_mut(), "abc");
+
+        let txn = doc.transact();
+        let empty = IdSet::default();
+
+        let result = collect_slices(&empty, &txn.store().blocks);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn iter_blocks_partial_overlap_multiple_clients_and_ranges() {
+        // Multiple clients with multiple ranges, partial overlap on both.
+        let mut o = Options::default();
+        o.client_id = ClientID::new(1);
+        let d1 = Doc::with_options(o.clone());
+        let t1 = d1.get_or_insert_text("test");
+
+        o.client_id = ClientID::new(2);
+        let d2 = Doc::with_options(o);
+        let t2 = d2.get_or_insert_text("test");
+
+        t1.push(&mut d1.transact_mut(), "abcdefghij"); // client=1, clock=0..10
+        exchange_updates(&[&d1, &d2]);
+
+        t2.push(&mut d2.transact_mut(), "ABCDEFGH"); // client=2, clock=0..8
+        exchange_updates(&[&d1, &d2]);
+
+        let txn = d1.transact();
+        let mut map = IdSet::from_iter([
+            (ClientID::new(1), vec![2..5, 8..20]), // client=1: two partial ranges into the 10-char block
+            (ClientID::new(2), vec![3..6]), // client=2: one partial range into the 8-char block
+        ]);
+
+        let result = collect_slices(&map, &txn.store().blocks);
+        // client=1 ranges: (2, 3) and (8, 2); client=2 range: (3, 3)
+        assert_eq!(result, vec![(2, 3), (8, 2), (3, 3)]);
     }
 }

--- a/yrs/src/slice.rs
+++ b/yrs/src/slice.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockRange, ItemPtr, BLOCK_GC_REF_NUMBER, GC, HAS_ORIGIN, HAS_RIGHT_ORIGIN};
+use crate::block::{BlockRange, ItemPtr, BLOCK_GC_REF_NUMBER, HAS_ORIGIN, HAS_RIGHT_ORIGIN};
 use crate::types::TypePtr;
 use crate::updates::encoder::Encoder;
 use crate::ID;

--- a/yrs/src/slice.rs
+++ b/yrs/src/slice.rs
@@ -1,4 +1,6 @@
-use crate::block::{BlockRange, ItemPtr, BLOCK_GC_REF_NUMBER, HAS_ORIGIN, HAS_RIGHT_ORIGIN};
+use crate::block::{
+    BlockRange, ItemPtr, BLOCK_GC_REF_NUMBER, BLOCK_SKIP_REF_NUMBER, HAS_ORIGIN, HAS_RIGHT_ORIGIN,
+};
 use crate::types::TypePtr;
 use crate::updates::encoder::Encoder;
 use crate::ID;
@@ -8,20 +10,21 @@ use std::ops::Deref;
 pub(crate) enum BlockSlice {
     Item(ItemSlice),
     GC(BlockRange),
+    Skip(BlockRange),
 }
 
 impl BlockSlice {
     pub fn clock_start(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.clock_start(),
-            BlockSlice::GC(s) => s.clock,
+            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.clock,
         }
     }
 
     pub fn clock_end(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.clock_end(),
-            BlockSlice::GC(s) => s.clock,
+            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.clock,
         }
     }
 
@@ -36,7 +39,7 @@ impl BlockSlice {
     pub fn len(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.len(),
-            BlockSlice::GC(s) => s.len,
+            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.len,
         }
     }
 
@@ -45,6 +48,7 @@ impl BlockSlice {
         match self {
             BlockSlice::Item(s) => s.is_deleted(),
             BlockSlice::GC(_) => true,
+            BlockSlice::Skip(_) => false,
         }
     }
 
@@ -52,7 +56,7 @@ impl BlockSlice {
     pub fn trim_start(&mut self, count: u32) {
         match self {
             BlockSlice::Item(s) => s.trim_start(count),
-            BlockSlice::GC(s) => s.trim_start(count),
+            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.trim_start(count),
         }
     }
 
@@ -60,7 +64,7 @@ impl BlockSlice {
     pub fn trim_end(&mut self, count: u32) {
         match self {
             BlockSlice::Item(s) => s.trim_end(count),
-            BlockSlice::GC(s) => s.trim_end(count),
+            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.trim_end(count),
         }
     }
 
@@ -69,6 +73,10 @@ impl BlockSlice {
             BlockSlice::Item(s) => s.encode(encoder),
             BlockSlice::GC(s) => {
                 encoder.write_info(BLOCK_GC_REF_NUMBER);
+                encoder.write_len(s.len);
+            }
+            BlockSlice::Skip(s) => {
+                encoder.write_info(BLOCK_SKIP_REF_NUMBER);
                 encoder.write_len(s.len);
             }
         }

--- a/yrs/src/slice.rs
+++ b/yrs/src/slice.rs
@@ -1,4 +1,4 @@
-use crate::block::{ItemPtr, BLOCK_GC_REF_NUMBER, GC, HAS_ORIGIN, HAS_RIGHT_ORIGIN};
+use crate::block::{BlockRange, ItemPtr, BLOCK_GC_REF_NUMBER, GC, HAS_ORIGIN, HAS_RIGHT_ORIGIN};
 use crate::types::TypePtr;
 use crate::updates::encoder::Encoder;
 use crate::ID;
@@ -7,21 +7,21 @@ use std::ops::Deref;
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub(crate) enum BlockSlice {
     Item(ItemSlice),
-    GC(GCSlice),
+    GC(BlockRange),
 }
 
 impl BlockSlice {
     pub fn clock_start(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.clock_start(),
-            BlockSlice::GC(s) => s.clock_start(),
+            BlockSlice::GC(s) => s.clock,
         }
     }
 
     pub fn clock_end(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.clock_end(),
-            BlockSlice::GC(s) => s.clock_end(),
+            BlockSlice::GC(s) => s.clock,
         }
     }
 
@@ -36,7 +36,7 @@ impl BlockSlice {
     pub fn len(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.len(),
-            BlockSlice::GC(s) => s.len(),
+            BlockSlice::GC(s) => s.len,
         }
     }
 
@@ -67,7 +67,10 @@ impl BlockSlice {
     pub fn encode<E: Encoder>(&self, encoder: &mut E) {
         match self {
             BlockSlice::Item(s) => s.encode(encoder),
-            BlockSlice::GC(s) => s.encode(encoder),
+            BlockSlice::GC(s) => {
+                encoder.write_info(BLOCK_GC_REF_NUMBER);
+                encoder.write_len(s.len);
+            }
         }
     }
 }
@@ -75,12 +78,6 @@ impl BlockSlice {
 impl From<ItemSlice> for BlockSlice {
     fn from(slice: ItemSlice) -> Self {
         BlockSlice::Item(slice)
-    }
-}
-
-impl From<GCSlice> for BlockSlice {
-    fn from(slice: GCSlice) -> Self {
-        BlockSlice::GC(slice)
     }
 }
 
@@ -275,51 +272,5 @@ impl ItemSlice {
 impl From<ItemPtr> for ItemSlice {
     fn from(ptr: ItemPtr) -> Self {
         ItemSlice::new(ptr, 0, ptr.len() - 1)
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub(crate) struct GCSlice {
-    pub start: u32,
-    pub end: u32,
-}
-
-impl GCSlice {
-    pub fn clock_start(&self) -> u32 {
-        self.start
-    }
-
-    pub fn clock_end(&self) -> u32 {
-        self.end
-    }
-
-    /// Trim a number of countable elements from the beginning of a current slice.
-    pub(crate) fn trim_start(&mut self, count: u32) {
-        debug_assert!(count <= self.len());
-        self.start += count;
-    }
-
-    /// Trim a number of countable elements from the end of a current slice.
-    pub(crate) fn trim_end(&mut self, count: u32) {
-        debug_assert!(count <= self.len());
-        self.end -= count;
-    }
-
-    pub fn len(&self) -> u32 {
-        self.end - self.start + 1
-    }
-
-    pub fn encode<E: Encoder>(&self, encoder: &mut E) {
-        encoder.write_info(BLOCK_GC_REF_NUMBER);
-        encoder.write_len(self.len());
-    }
-}
-
-impl From<GC> for GCSlice {
-    fn from(gc: GC) -> Self {
-        GCSlice {
-            start: gc.start,
-            end: gc.end,
-        }
     }
 }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -311,7 +311,7 @@ impl Store {
                     let dest = self.linked_by.entry(ItemPtr::from(&new)).or_default();
                     dest.extend(source);
                 }
-                blocks.insert(i + 1, BlockCell::Block(new));
+                blocks.insert(i + 1, BlockCell::Item(new));
                 i += 1;
                 //todo: txn merge blocks insert?
                 index = Some(i);
@@ -334,7 +334,7 @@ impl Store {
                 let dest = self.linked_by.entry(ItemPtr::from(&new)).or_default();
                 dest.extend(source);
             }
-            blocks.insert(i + 1, BlockCell::Block(new));
+            blocks.insert(i + 1, BlockCell::Item(new));
             //todo: txn merge blocks insert?
         }
 

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -256,7 +256,7 @@ impl Store {
             }
         }
         for (client, _) in local_sv.iter() {
-            if remote_sv.get(client) == 0 {
+            if !remote_sv.contains_client(client) {
                 diff.push((*client, 0));
             }
         }
@@ -582,7 +582,7 @@ pub struct StoreEvents {
 impl StoreEvents {
     pub fn emit_update_v1(&self, txn: &TransactionMut) {
         if self.update_v1_events.has_subscribers() {
-            if !txn.delete_set.is_empty() || txn.after_state != txn.before_state {
+            if !txn.delete_set.is_empty() || txn.after_state() != txn.before_state() {
                 // produce update only if anything changed
                 let update = UpdateEvent::new_v1(txn);
                 self.update_v1_events
@@ -593,7 +593,7 @@ impl StoreEvents {
 
     pub fn emit_update_v2(&self, txn: &TransactionMut) {
         if self.update_v2_events.has_subscribers() {
-            if !txn.delete_set.is_empty() || txn.after_state != txn.before_state {
+            if !txn.delete_set.is_empty() || txn.after_state() != txn.before_state() {
                 // produce update only if anything changed
                 let update = UpdateEvent::new_v2(txn);
                 self.update_v2_events.trigger(|fun| fun(txn, &update));

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -1,4 +1,4 @@
-use crate::block::{BlockCell, ClientID, ItemContent, ItemPtr};
+use crate::block::{Block, ClientID, ItemContent, ItemPtr};
 use crate::block_store::BlockStore;
 use crate::branch::{Branch, BranchPtr};
 use crate::doc::{DocAddr, Options};
@@ -40,6 +40,8 @@ pub struct Store {
     /// operations) integrated - and therefore visible - into a current document.
     pub(crate) blocks: BlockStore,
 
+    pub(crate) skips: IdSet,
+
     /// A pending update. It contains blocks, which are not yet integrated into `blocks`, usually
     /// because due to issues in update exchange, there were some missing blocks that need to be
     /// integrated first before the data from `pending` can be applied safely.
@@ -69,6 +71,7 @@ impl Store {
             client_id: options.client_id,
             offset_kind: options.offset_kind,
             skip_gc: options.skip_gc,
+            skips: IdSet::default(),
             types: HashMap::default(),
             blocks: BlockStore::default(),
             subdocs: HashMap::default(),
@@ -311,7 +314,7 @@ impl Store {
                     let dest = self.linked_by.entry(ItemPtr::from(&new)).or_default();
                     dest.extend(source);
                 }
-                blocks.insert(i + 1, BlockCell::Item(new));
+                blocks.insert(i + 1, Block::Item(new));
                 i += 1;
                 //todo: txn merge blocks insert?
                 index = Some(i);
@@ -334,7 +337,7 @@ impl Store {
                 let dest = self.linked_by.entry(ItemPtr::from(&new)).or_default();
                 dest.extend(source);
             }
-            blocks.insert(i + 1, BlockCell::Item(new));
+            blocks.insert(i + 1, Block::Item(new));
             //todo: txn merge blocks insert?
         }
 

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -180,7 +180,7 @@ impl Store {
         for (client, clock) in diff {
             let blocks = self.blocks.get_client(&client).unwrap();
             let clock = clock.min(blocks.clock() + 1);
-            let last_idx = blocks.find_pivot(clock - 1).unwrap();
+            let last_idx = blocks.find_index(clock - 1).unwrap();
             // write # encoded structs
             encoder.write_var(last_idx + 1);
             encoder.write_client(client);
@@ -232,7 +232,7 @@ impl Store {
                     .map(|i| i.as_ref().clock_start())
                     .unwrap_or_default(),
             ); // make sure the first id exists
-            let start = blocks.find_pivot(clock).unwrap();
+            let start = blocks.find_index(clock).unwrap();
             // write # encoded structs
             encoder.write_var(blocks.len() - start);
             encoder.write_client(client);
@@ -313,7 +313,7 @@ impl Store {
         let mut ptr = if slice.adjacent_left() {
             slice.ptr
         } else {
-            let mut i = blocks.find_pivot(id.clock).unwrap();
+            let mut i = blocks.find_index(id.clock).unwrap();
             if let Some(new) = slice.ptr.splice(slice.start, OffsetKind::Utf16) {
                 if let Some(source) = links.clone() {
                     let dest = self
@@ -338,7 +338,7 @@ impl Store {
                 i
             } else {
                 let last_id = slice.last_id();
-                blocks.find_pivot(last_id.clock).unwrap()
+                blocks.find_index(last_id.clock).unwrap()
             };
             let new = ptr.splice(slice.len(), OffsetKind::Utf16).unwrap();
             if let Some(source) = links {

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -226,13 +226,18 @@ impl Store {
         encoder.write_var(diff.len());
         for (client, clock) in diff {
             let blocks = self.blocks.get_client(&client).unwrap();
-            let clock = clock.max(blocks.get(0).map(|i| i.clock_start()).unwrap_or_default()); // make sure the first id exists
+            let clock = clock.max(
+                blocks
+                    .get(0)
+                    .map(|i| i.as_ref().clock_start())
+                    .unwrap_or_default(),
+            ); // make sure the first id exists
             let start = blocks.find_pivot(clock).unwrap();
             // write # encoded structs
             encoder.write_var(blocks.len() - start);
             encoder.write_client(client);
             encoder.write_var(clock);
-            let first_block = blocks.get(start).unwrap();
+            let first_block = blocks.get(start).unwrap().as_ref();
             // write first struct with an offset
             let offset = clock - first_block.clock_start();
             let mut slice = first_block.as_slice();
@@ -311,7 +316,10 @@ impl Store {
             let mut i = blocks.find_pivot(id.clock).unwrap();
             if let Some(new) = slice.ptr.splice(slice.start, OffsetKind::Utf16) {
                 if let Some(source) = links.clone() {
-                    let dest = self.linked_by.entry(ItemPtr::from(&new)).or_default();
+                    let dest = self
+                        .linked_by
+                        .entry(ItemPtr::from(new.as_ref()))
+                        .or_default();
                     dest.extend(source);
                 }
                 blocks.insert(i + 1, Block::Item(new));
@@ -334,7 +342,10 @@ impl Store {
             };
             let new = ptr.splice(slice.len(), OffsetKind::Utf16).unwrap();
             if let Some(source) = links {
-                let dest = self.linked_by.entry(ItemPtr::from(&new)).or_default();
+                let dest = self
+                    .linked_by
+                    .entry(ItemPtr::from(new.as_ref()))
+                    .or_default();
                 dest.extend(source);
             }
             blocks.insert(i + 1, Block::Item(new));

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -30,6 +30,7 @@ pub struct Store {
     pub(crate) client_id: ClientID,
     pub(crate) offset_kind: OffsetKind,
     pub(crate) skip_gc: bool,
+    pub(crate) cleanup_formatting: bool,
 
     /// Root types (a.k.a. top-level types). These types are defined by users at the document level,
     /// they have their own unique names and represent core shared types that expose operations
@@ -69,6 +70,7 @@ impl Store {
             client_id: options.client_id,
             offset_kind: options.offset_kind,
             skip_gc: options.skip_gc,
+            cleanup_formatting: options.cleanup_formatting,
             types: HashMap::default(),
             blocks: BlockStore::default(),
             subdocs: HashMap::default(),

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -40,8 +40,6 @@ pub struct Store {
     /// operations) integrated - and therefore visible - into a current document.
     pub(crate) blocks: BlockStore,
 
-    pub(crate) skips: IdSet,
-
     /// A pending update. It contains blocks, which are not yet integrated into `blocks`, usually
     /// because due to issues in update exchange, there were some missing blocks that need to be
     /// integrated first before the data from `pending` can be applied safely.
@@ -71,7 +69,6 @@ impl Store {
             client_id: options.client_id,
             offset_kind: options.offset_kind,
             skip_gc: options.skip_gc,
-            skips: IdSet::default(),
             types: HashMap::default(),
             blocks: BlockStore::default(),
             subdocs: HashMap::default(),

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -5,12 +5,13 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use fastrand::Rng;
 
-use crate::block::ClientID;
+use crate::block::{Block, ClientID};
 use crate::encoding::read::{Cursor, Read};
 use crate::transaction::ReadTxn;
+use crate::update::UpdateBlocks;
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::{Encode, Encoder, EncoderV1};
-use crate::{Doc, Options, StateVector, Transact, Update};
+use crate::{Doc, Options, StateVector, Store, Transact, Update};
 
 pub const EXCHANGE_UPDATES_ORIGIN: &str = "exchange_updates";
 
@@ -545,5 +546,64 @@ impl RngExt for Rng {
             res.push(self.alphanumeric());
         }
         res
+    }
+}
+
+pub(crate) struct Blocks<'a> {
+    current_client: std::vec::IntoIter<(&'a ClientID, &'a VecDeque<Block>)>,
+    current_block: Option<std::collections::vec_deque::Iter<'a, Block>>,
+}
+
+impl<'a> Blocks<'a> {
+    pub fn new(update: &'a UpdateBlocks) -> Self {
+        let mut client_blocks: Vec<(&'a ClientID, &'a VecDeque<Block>)> =
+            update.clients.iter().collect();
+        // sorting to return higher client ids first
+        client_blocks.sort_by(|a, b| b.0.cmp(a.0));
+        let mut current_client = client_blocks.into_iter();
+
+        let current_block = current_client.next().map(|(_, v)| v.iter());
+        Blocks {
+            current_client,
+            current_block,
+        }
+    }
+}
+
+impl<'a> Iterator for Blocks<'a> {
+    type Item = &'a Block;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(blocks) = self.current_block.as_mut() {
+            let block = blocks.next();
+            if block.is_some() {
+                return block;
+            }
+        }
+
+        if let Some(entry) = self.current_client.next() {
+            self.current_block = Some(entry.1.iter());
+            self.next()
+        } else {
+            None
+        }
+    }
+}
+
+impl Into<Store> for Update {
+    fn into(self) -> Store {
+        use crate::doc::Options;
+
+        let mut store = Store::new(&Options::with_client_id(ClientID::new(0)));
+        for (_, vec) in self.blocks.clients {
+            for block in vec {
+                if let Block::Item(block) = block {
+                    store.blocks.push(Block::Item(block));
+                } else {
+                    panic!("Cannot convert Update into block store - Skip block detected");
+                }
+            }
+        }
+        store
     }
 }

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use fastrand::Rng;
@@ -424,8 +424,16 @@ impl TestConnector {
 
             let astore = a.store();
             let bstore = b.store();
-            for ((ac, al), (bc, bl)) in astore.blocks.iter().zip(bstore.blocks.iter()) {
-                assert_eq!(ac, bc);
+            let mut all_clients = HashSet::new();
+            for (&client, _) in astore.blocks.iter() {
+                all_clients.insert(client);
+            }
+            for (&client, _) in bstore.blocks.iter() {
+                all_clients.insert(client);
+            }
+            for client in all_clients {
+                let al = astore.blocks.get_client(&client).unwrap();
+                let bl = bstore.blocks.get_client(&client).unwrap();
                 for (ablock, bblock) in al.iter().zip(bl.iter()) {
                     assert_eq!(ablock.as_ref(), bblock.as_ref());
                 }

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -8,7 +8,7 @@ use fastrand::Rng;
 use crate::block::{Block, ClientID};
 use crate::encoding::read::{Cursor, Read};
 use crate::transaction::ReadTxn;
-use crate::update::UpdateBlocks;
+use crate::update::BlockSet;
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::{Encode, Encoder, EncoderV1};
 use crate::{Doc, Options, StateVector, Store, Transact, Update};
@@ -560,7 +560,7 @@ pub(crate) struct Blocks<'a> {
 }
 
 impl<'a> Blocks<'a> {
-    pub fn new(update: &'a UpdateBlocks) -> Self {
+    pub fn new(update: &'a BlockSet) -> Self {
         let mut client_blocks: Vec<(&'a ClientID, &'a VecDeque<Block>)> =
             update.clients.iter().collect();
         // sorting to return higher client ids first

--- a/yrs/src/test_utils.rs
+++ b/yrs/src/test_utils.rs
@@ -424,7 +424,12 @@ impl TestConnector {
 
             let astore = a.store();
             let bstore = b.store();
-            assert_eq!(astore.blocks, bstore.blocks);
+            for ((ac, al), (bc, bl)) in astore.blocks.iter().zip(bstore.blocks.iter()) {
+                assert_eq!(ac, bc);
+                for (ablock, bblock) in al.iter().zip(bl.iter()) {
+                    assert_eq!(ablock.as_ref(), bblock.as_ref());
+                }
+            }
             assert_eq!(astore.pending, bstore.pending);
             assert_eq!(astore.pending_ds, bstore.pending_ds);
         }

--- a/yrs/src/tests/compatibility_tests.rs
+++ b/yrs/src/tests/compatibility_tests.rs
@@ -5,14 +5,15 @@ use std::io::BufReader;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crate::block::{ClientID, Item, ItemContent};
+use crate::block::{Block, ClientID, Item, ItemContent};
 use crate::branch::Branch;
 use crate::encoding::read::Read;
-use crate::id_set::{DeleteSet, IdSet};
+use crate::id_set::IdSet;
 use crate::store::Store;
+use crate::test_utils::Blocks;
 use crate::types::xml::XmlFragment;
 use crate::types::{ToJson, TypePtr, TypeRef};
-use crate::update::{BlockCarrier, Update};
+use crate::update::Update;
 use crate::updates::decoder::{Decode, Decoder, DecoderV1};
 use crate::updates::encoder::Encode;
 use crate::{
@@ -117,8 +118,9 @@ fn text_insert_delete() {
     let txt = doc.get_or_insert_text("type");
     let _sub = doc.observe_update_v1(move |_, e| {
         let u = Update::decode_v1(&e.update).unwrap();
-        for (actual, expected) in u.blocks.blocks().zip(expected_blocks.as_slice()) {
-            if let BlockCarrier::Item(block) = actual {
+        let update_blocks = Blocks::new(&u.blocks);
+        for (actual, expected) in update_blocks.zip(expected_blocks.as_slice()) {
+            if let Block::Item(block) = actual {
                 assert_eq!(block, expected);
             }
         }
@@ -374,10 +376,10 @@ fn utf32_lib0_v2_decoding() {
 /// Verify if given `payload` can be deserialized into series
 /// of `expected` blocks, then serialize them back and check
 /// if produced binary is equivalent to `payload`.
-fn roundtrip_v1(payload: &[u8], expected: &Vec<BlockCarrier>) {
+fn roundtrip_v1(payload: &[u8], expected: &Vec<Block>) {
     let u = Update::decode_v1(payload).unwrap();
-    let expected: Vec<&BlockCarrier> = expected.iter().collect();
-    let blocks: Vec<&BlockCarrier> = u.blocks.blocks().collect();
+    let expected: Vec<&Block> = expected.iter().collect();
+    let blocks: Vec<&Block> = Blocks::new(&u.blocks).collect();
     assert_eq!(blocks, expected, "failed to decode V1");
 
     let store: Store = u.into();
@@ -386,10 +388,10 @@ fn roundtrip_v1(payload: &[u8], expected: &Vec<BlockCarrier>) {
 }
 
 /// Same as [roundtrip_v2] but using lib0 v2 encoding.
-fn roundtrip_v2(payload: &[u8], expected: &Vec<BlockCarrier>) {
+fn roundtrip_v2(payload: &[u8], expected: &Vec<Block>) {
     let u = Update::decode_v2(payload).unwrap();
-    let expected: Vec<&BlockCarrier> = expected.iter().collect();
-    let blocks: Vec<&BlockCarrier> = u.blocks.blocks().collect();
+    let expected: Vec<&Block> = expected.iter().collect();
+    let blocks: Vec<&Block> = Blocks::new(&u.blocks).collect();
     assert_eq!(blocks, expected, "failed to decode V2");
 
     let store: Store = u.into();

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 use async_lock::{RwLockReadGuard, RwLockWriteGuard};
 use smallvec::SmallVec;
+use std::cell::OnceCell;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Formatter;
 use std::hash::Hash;
@@ -444,9 +445,9 @@ impl<'doc> ReadTxn for Transaction<'doc> {
 pub struct TransactionMut<'doc> {
     pub(crate) store: RwLockWriteGuard<'doc, Store>,
     /// State vector of a current transaction at the moment of its creation.
-    pub(crate) before_state: StateVector,
+    before_state: OnceCell<StateVector>,
     /// Current state vector of a transaction, which includes all performed updates.
-    pub(crate) after_state: StateVector,
+    after_state: OnceCell<StateVector>,
     /// ID's of the blocks to be merged.
     pub(crate) merge_blocks: Vec<ID>,
     /// Describes the set of deleted items by ids.
@@ -494,16 +495,15 @@ impl<'doc> TransactionMut<'doc> {
         store: RwLockWriteGuard<'doc, Store>,
         origin: Option<Origin>,
     ) -> Self {
-        let begin_timestamp = store.blocks.get_state_vector();
         TransactionMut {
             store,
             doc,
             origin,
-            before_state: begin_timestamp,
+            before_state: OnceCell::new(),
             merge_blocks: Vec::default(),
             delete_set: IdSet::new(),
             insert_set: IdSet::new(),
-            after_state: StateVector::default(),
+            after_state: OnceCell::new(),
             changed: HashMap::default(),
             changed_parent_types: Vec::default(),
             subdocs: None,
@@ -526,12 +526,33 @@ impl<'doc> TransactionMut<'doc> {
 
     /// Corresponding document's state vector at the moment when current transaction was created.
     pub fn before_state(&self) -> &StateVector {
-        &self.before_state
+        self.before_state.get_or_init(|| {
+            let mut sv = self.store.blocks.get_state_vector();
+            for (client, ranges) in self.insert_set.iter() {
+                if let Some(clock) = ranges.clock_start() {
+                    sv.set_min(*client, clock);
+                }
+            }
+            sv
+        })
     }
 
     /// State vector of the transaction after [Transaction::commit] has been called.
     pub fn after_state(&self) -> &StateVector {
-        &self.after_state
+        self.after_state.get_or_init(|| {
+            let mut sv = self.store.blocks.get_state_vector();
+            for (client, ranges) in self.insert_set.iter() {
+                if let Some(clock) = ranges.clock_end() {
+                    sv.set_max(*client, clock);
+                }
+            }
+            sv
+        })
+    }
+
+    /// Data about insertions performed in the scope of current transaction.
+    pub fn insert_set(&self) -> &IdSet {
+        &self.insert_set
     }
 
     /// Data about deletions performed in the scope of current transaction.
@@ -599,7 +620,7 @@ impl<'doc> TransactionMut<'doc> {
     ///   is extracted and integrated into the document structure.
     pub fn encode_update<E: Encoder>(&self, encoder: &mut E) {
         let store = self.store();
-        store.write_blocks_from(&self.before_state, encoder);
+        store.write_blocks_from(self.before_state(), encoder);
         self.delete_set.encode(encoder);
     }
 
@@ -950,6 +971,47 @@ impl<'doc> TransactionMut<'doc> {
         }
     }
 
+    fn call_observers(&mut self) {
+        let mut changed_parents: HashMap<BranchPtr, Vec<usize>> = HashMap::new();
+        let mut event_cache = Vec::new();
+
+        for (ptr, subs) in self.changed.iter() {
+            if let TypePtr::Branch(branch) = ptr {
+                if let Some(e) = branch.trigger(self, subs.clone()) {
+                    event_cache.push(e);
+                    Self::call_type_observers(
+                        &mut self.changed_parent_types,
+                        &self.store.linked_by,
+                        *branch,
+                        &mut changed_parents,
+                        &event_cache,
+                        &mut HashSet::default(),
+                    );
+                }
+            }
+        }
+
+        // deep observe events
+        for (&branch, events) in changed_parents.iter() {
+            // sort events by path length so that top-level events are fired first.
+            let mut unsorted: Vec<&Event> = Vec::with_capacity(events.len());
+
+            for &i in events.iter() {
+                let e = &mut event_cache[i];
+                e.set_current_target(branch);
+            }
+
+            for &i in events.iter() {
+                unsorted.push(&event_cache[i]);
+            }
+
+            // We don't need to check for events.length
+            // because we know it has at least one element
+            let events = Events::new(&mut unsorted);
+            branch.trigger_deep(self, &events);
+        }
+    }
+
     /// Commits current transaction. This step involves cleaning up and optimizing changes performed
     /// during lifetime of a transaction. Such changes include squashing delete sets data,
     /// squashing blocks that have been appended one after another to preserve memory and triggering
@@ -963,50 +1025,10 @@ impl<'doc> TransactionMut<'doc> {
         }
         self.committed = true;
 
-        // 1. delete set is already canonical — every IdRange::push / IdRange::merge
-        //    maintains sorted, non-overlapping, non-adjacent invariant on the fly.
-        self.after_state = self.store.blocks.get_state_vector();
         // 2. emit 'beforeObserverCalls'
         // 3. for each change observed by the transaction call 'afterTransaction'
         if !self.changed.is_empty() {
-            let mut changed_parents: HashMap<BranchPtr, Vec<usize>> = HashMap::new();
-            let mut event_cache = Vec::new();
-
-            for (ptr, subs) in self.changed.iter() {
-                if let TypePtr::Branch(branch) = ptr {
-                    if let Some(e) = branch.trigger(self, subs.clone()) {
-                        event_cache.push(e);
-                        Self::call_type_observers(
-                            &mut self.changed_parent_types,
-                            &self.store.linked_by,
-                            *branch,
-                            &mut changed_parents,
-                            &event_cache,
-                            &mut HashSet::default(),
-                        );
-                    }
-                }
-            }
-
-            // deep observe events
-            for (&branch, events) in changed_parents.iter() {
-                // sort events by path length so that top-level events are fired first.
-                let mut unsorted: Vec<&Event> = Vec::with_capacity(events.len());
-
-                for &i in events.iter() {
-                    let e = &mut event_cache[i];
-                    e.set_current_target(branch);
-                }
-
-                for &i in events.iter() {
-                    unsorted.push(&event_cache[i]);
-                }
-
-                // We don't need to check for events.length
-                // because we know it has at least one element
-                let events = Events::new(&mut unsorted);
-                branch.trigger_deep(self, &events);
-            }
+            self.call_observers();
         }
 
         if let Some(events) = self.store.events.take() {
@@ -1022,16 +1044,15 @@ impl<'doc> TransactionMut<'doc> {
         // 5. try merge delete set
         self.delete_set.try_squash_with(&mut self.store);
 
-        // 6. get transaction after state and try to merge to left
-        for (client, &clock) in self.after_state.iter() {
-            let before_clock = self.before_state.get(client);
-            if before_clock != clock {
-                let blocks = self.store.blocks.get_client_mut(client).unwrap();
-                let first_change = blocks.find_index(before_clock).unwrap().max(1);
+        // 6. on all affected store.clients props, try to merge
+        for (client, ids) in self.insert_set.iter() {
+            if let Some(first_clock) = ids.clock_start() {
+                let blocks = unsafe { self.store.blocks.get_client_mut(client).unwrap_unchecked() };
+                // we iterate from right to left so we can safely remove entries
+                let first_change_pos = blocks.find_index(first_clock).unwrap_or_default().max(1);
                 let mut i = blocks.len() - 1;
-                while i >= first_change {
-                    blocks.squash_left(i);
-                    i -= 1;
+                while i >= first_change_pos {
+                    i = i.saturating_sub(1 + blocks.squash_left(i));
                 }
             }
         }
@@ -1105,7 +1126,7 @@ impl<'doc> TransactionMut<'doc> {
 
     pub(crate) fn add_changed_type(&mut self, parent: BranchPtr, parent_sub: Option<Arc<str>>) {
         let trigger = if let Some(ptr) = parent.item {
-            (ptr.id().clock < self.before_state.get(&ptr.id().client)) && !ptr.is_deleted()
+            (ptr.id().clock < self.before_state().get(&ptr.id().client)) && !ptr.is_deleted()
         } else {
             true
         };
@@ -1117,7 +1138,7 @@ impl<'doc> TransactionMut<'doc> {
 
     /// Checks if item with a given `id` has been added to a block store within this transaction.
     pub(crate) fn has_added(&self, id: &ID) -> bool {
-        id.clock >= self.before_state.get(&id.client)
+        self.insert_set.contains(id)
     }
 
     /// Checks if item with a given `id` has been deleted within this transaction.

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -620,7 +620,8 @@ impl<'doc> TransactionMut<'doc> {
                         // We can ignore the case of GC and Delete structs, because we are going to skip them
                         if let Some(mut index) = blocks.find_pivot(clock) {
                             // We can ignore the case of GC and Delete structs, because we are going to skip them
-                            let block = &mut blocks[index];
+                            let mut block = unsafe { blocks.get(index).unwrap_unchecked() };
+                            let block = block.as_mut();
                             // split the first item if necessary
                             if !block.is_deleted() && block.clock_start() < clock {
                                 if let Some(item) = block.as_item() {
@@ -637,7 +638,8 @@ impl<'doc> TransactionMut<'doc> {
                             }
 
                             while index < blocks.len() {
-                                let block = &mut blocks[index];
+                                let mut block = unsafe { blocks.get(index).unwrap_unchecked() };
+                                let block = block.as_mut();
                                 index += 1;
                                 if block.clock_start() < clock_end {
                                     if !block.is_deleted() {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1,4 +1,4 @@
-use crate::block::{Block, Item, ItemContent, ItemPosition, ItemPtr, Prelim, ID};
+use crate::block::{Block, BlockRange, Item, ItemContent, ItemPosition, ItemPtr, Prelim, ID};
 use crate::branch::{Branch, BranchPtr};
 use crate::doc::DocAddr;
 use crate::error::{Error, UpdateError};
@@ -460,6 +460,7 @@ pub struct TransactionMut<'doc> {
     pub(crate) subdocs: Option<Box<Subdocs>>,
     pub(crate) origin: Option<Origin>,
     doc: Doc,
+    local: bool,
     committed: bool,
 }
 
@@ -506,6 +507,7 @@ impl<'doc> TransactionMut<'doc> {
             changed: HashMap::default(),
             changed_parent_types: Vec::default(),
             subdocs: None,
+            local: true,
             committed: false,
         }
     }
@@ -618,7 +620,7 @@ impl<'doc> TransactionMut<'doc> {
                             unapplied.insert(ID::new(*client, clock), clock_end - state);
                         }
                         // We can ignore the case of GC and Delete structs, because we are going to skip them
-                        if let Some(mut index) = blocks.find_pivot(clock) {
+                        if let Some(mut index) = blocks.find_index(clock) {
                             // We can ignore the case of GC and Delete structs, because we are going to skip them
                             let mut block = unsafe { blocks.get(index).unwrap_unchecked() };
                             let block = block.as_mut();
@@ -791,6 +793,7 @@ impl<'doc> TransactionMut<'doc> {
     /// predecessors already in place. Out of order updates from the same peer will be stashed
     /// internally and their integration will be postponed until missing blocks arrive first.
     pub fn apply_update(&mut self, update: Update) -> Result<(), UpdateError> {
+        self.local = false;
         let (remaining, remaining_ds) = update.integrate(self)?;
         let mut retry = false;
         {
@@ -1015,7 +1018,7 @@ impl<'doc> TransactionMut<'doc> {
             let before_clock = self.before_state.get(client);
             if before_clock != clock {
                 let blocks = self.store.blocks.get_client_mut(client).unwrap();
-                let first_change = blocks.find_pivot(before_clock).unwrap().max(1);
+                let first_change = blocks.find_index(before_clock).unwrap().max(1);
                 let mut i = blocks.len() - 1;
                 while i >= first_change {
                     blocks.squash_left(i);
@@ -1027,7 +1030,7 @@ impl<'doc> TransactionMut<'doc> {
         // 7. get merge_structs and try to merge to left
         for id in self.merge_blocks.iter() {
             if let Some(blocks) = self.store.blocks.get_client_mut(&id.client) {
-                if let Some(replaced_pos) = blocks.find_pivot(id.clock) {
+                if let Some(replaced_pos) = blocks.find_index(id.clock) {
                     if replaced_pos + 1 < blocks.len() {
                         blocks.squash_left(replaced_pos + 1);
                     } else if replaced_pos > 0 {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -792,9 +792,19 @@ impl<'doc> TransactionMut<'doc> {
     /// Remote update integration requires that all to-be-integrated blocks must have their direct
     /// predecessors already in place. Out of order updates from the same peer will be stashed
     /// internally and their integration will be postponed until missing blocks arrive first.
-    pub fn apply_update(&mut self, update: Update) -> Result<(), UpdateError> {
+    pub fn apply_update(&mut self, mut update: Update) -> Result<(), UpdateError> {
+        // force that transaction.local is set to non-local
         self.local = false;
+        let store = self.store_mut();
+
+        // 1. Trim the incoming update with the blocks that we already have
+        let known_state = store.blocks.known_state(&update.blocks);
+        update.blocks.exclude(&known_state);
+
+        // 2. Integrate incoming update
         let (remaining, remaining_ds) = update.integrate(self)?;
+
+        // 3. Check if we have pending updates to integrate
         let mut retry = false;
         {
             let store = self.store_mut();
@@ -819,8 +829,10 @@ impl<'doc> TransactionMut<'doc> {
                 remaining
             };
         }
-        if let Some(pending) = self.store_mut().pending_ds.take() {
-            let ds2 = self.apply_delete(&pending);
+
+        // 4. Check if we have pending delete set to apply
+        if let Some(pending_ds) = self.store_mut().pending_ds.take() {
+            let ds2 = self.apply_delete(&pending_ds);
             let ds = match (remaining_ds, ds2) {
                 (Some(mut a), Some(b)) => {
                     a.delete_set.merge_with(b);
@@ -835,6 +847,7 @@ impl<'doc> TransactionMut<'doc> {
             self.store_mut().pending_ds = remaining_ds.map(|update| update.delete_set);
         }
 
+        // 5. check if we should reapply pending data
         if retry {
             let store = self.store_mut();
             if let Some(pending) = store.pending.take() {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -13,7 +13,7 @@ use crate::update::Update;
 use crate::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use crate::utils::OptionExt;
 use crate::{
-    merge_updates_v1, merge_updates_v2, ArrayRef, BranchID, Doc, IdSet, MapRef, Out, Snapshot,
+    merge_updates_v1, merge_updates_v2, Any, ArrayRef, BranchID, Doc, IdSet, MapRef, Out, Snapshot,
     StateVector, TextRef, Transact, XmlElementRef, XmlFragmentRef, XmlTextRef,
 };
 use async_lock::{RwLockReadGuard, RwLockWriteGuard};
@@ -454,6 +454,7 @@ pub struct TransactionMut<'doc> {
     pub(crate) delete_set: IdSet,
     /// Describes the set of inserted items by ids.
     pub(crate) insert_set: IdSet,
+    pub(crate) cleanups: IdSet,
     /// All types that were directly modified (property added or child inserted/deleted).
     /// New types are not included in this Set.
     pub(crate) changed: HashMap<TypePtr, HashSet<Option<Arc<str>>>>,
@@ -463,6 +464,7 @@ pub struct TransactionMut<'doc> {
     doc: Doc,
     local: bool,
     committed: bool,
+    needs_cleanup: bool,
 }
 
 impl<'doc> ReadTxn for TransactionMut<'doc> {
@@ -503,12 +505,14 @@ impl<'doc> TransactionMut<'doc> {
             merge_blocks: Vec::default(),
             delete_set: IdSet::new(),
             insert_set: IdSet::new(),
+            cleanups: IdSet::new(),
             after_state: OnceCell::new(),
             changed: HashMap::default(),
             changed_parent_types: Vec::default(),
             subdocs: None,
             local: true,
             committed: false,
+            needs_cleanup: false,
         }
     }
 
@@ -977,6 +981,9 @@ impl<'doc> TransactionMut<'doc> {
 
         for (ptr, subs) in self.changed.iter() {
             if let TypePtr::Branch(branch) = ptr {
+                if branch.has_formatting && !self.local {
+                    self.needs_cleanup = true;
+                }
                 if let Some(e) = branch.trigger(self, subs.clone()) {
                     event_cache.push(e);
                     Self::call_type_observers(
@@ -1029,6 +1036,10 @@ impl<'doc> TransactionMut<'doc> {
         // 3. for each change observed by the transaction call 'afterTransaction'
         if !self.changed.is_empty() {
             self.call_observers();
+        }
+
+        if self.needs_cleanup && self.store.cleanup_formatting {
+            self.cleanup_fmt();
         }
 
         if let Some(events) = self.store.events.take() {
@@ -1112,6 +1123,176 @@ impl<'doc> TransactionMut<'doc> {
                 subdoc.destroy(self);
             }
         }
+    }
+
+    fn cleanup_fmt(&mut self) {
+        let mut needs_cleanup = HashSet::new();
+
+        // check if another formatting item was inserted
+        for item in self.insert_set.iter_blocks(&self.store.blocks) {
+            if let Some(item) = item.as_item() {
+                if !item.is_deleted() {
+                    if let ItemContent::Format(_, _) = &item.content {
+                        needs_cleanup.insert(*item.parent.as_branch().unwrap());
+                    }
+                }
+            }
+        }
+
+        // cleanup in a new transaction
+        let cleanup = self
+            .delete_set
+            .iter_blocks(&self.store.blocks)
+            .filter_map(|slice| {
+                let item = slice.as_item()?;
+                let parent = item.parent.as_branch()?;
+                if parent.has_formatting && !needs_cleanup.contains(&parent) {
+                    if let ItemContent::Format(_, _) = &item.content {
+                        needs_cleanup.insert(*parent);
+                    } else {
+                        return Some(item);
+                    }
+                }
+                None
+            })
+            .collect::<Vec<_>>();
+        for item in cleanup {
+            // If no formatting attribute was inserted or deleted, we can make due with contextless
+            // formatting cleanups.
+            // Contextless: it is not necessary to compute currentAttributes for the affected position.
+            self.cleanup_fmt_gap_contextless(item);
+        }
+
+        // If a formatting item was inserted, we simply clean the whole type.
+        // We need to compute currentAttributes for the current position anyway.
+        for text_ref in needs_cleanup {
+            self.cleanup_text_fmt(text_ref);
+        }
+    }
+
+    fn cleanup_text_fmt(&mut self, text_ref: BranchPtr) -> usize {
+        if !self.store.cleanup_formatting {
+            return 0;
+        }
+        let mut res = 0;
+        let mut start = text_ref.start;
+        let mut end = text_ref.start;
+        let mut start_attrs = HashMap::new();
+        let mut current_attrs = HashMap::new();
+        while let Some(endp) = end {
+            if !endp.is_deleted() {
+                match &endp.content {
+                    ItemContent::Format(key, value) if &**value == &Any::Null => {
+                        current_attrs.remove(key);
+                    }
+                    ItemContent::Format(key, value) => {
+                        current_attrs.insert(key.clone(), value.clone());
+                    }
+                    _ => {
+                        res += self.cleanup_fmt_gap(start, end, &start_attrs, &mut current_attrs);
+                        start_attrs = current_attrs.clone();
+                        start = end;
+                    }
+                }
+            }
+            end = endp.right;
+        }
+        res
+    }
+
+    fn cleanup_fmt_gap_contextless(&mut self, mut item: ItemPtr) {
+        // iterate until item.right is null or content
+        while let Some(right) = item.right {
+            if !right.is_deleted() && right.is_countable() {
+                break; // we hit non-deleted non-format item
+            }
+            item = right;
+        }
+        let mut attrs = HashSet::new();
+        // iterate back until a content item is found
+        let mut itemo = Some(item);
+        while let Some(item) = itemo {
+            if !item.is_deleted() && item.is_countable() {
+                break; // we hit non-deleted non-format item
+            }
+            if let ItemContent::Format(key, _) = &item.content {
+                if !item.is_deleted() {
+                    if !attrs.insert(key.clone()) {
+                        self.delete(item);
+                        self.cleanups.insert(item.id, item.len);
+                    }
+                }
+            }
+            itemo = item.left;
+        }
+    }
+
+    fn cleanup_fmt_gap(
+        &mut self,
+        mut start: Option<ItemPtr>,
+        curr: Option<ItemPtr>,
+        start_attrs: &HashMap<Arc<str>, Box<Any>>,
+        curr_attrs: &mut HashMap<Arc<str>, Box<Any>>,
+    ) -> usize {
+        if !self.store.cleanup_formatting {
+            return 0;
+        }
+        let mut end = start;
+        let mut end_fmts = HashMap::new();
+        while let Some(endp) = end {
+            if endp.is_countable() && !endp.is_deleted() {
+                break;
+            }
+
+            if !endp.is_deleted() {
+                if let ItemContent::Format(key, _) = &endp.content {
+                    end_fmts.insert(key.clone(), endp);
+                }
+            }
+            end = endp.right;
+        }
+
+        let mut cleanups = 0;
+        let mut reached_curr = false;
+        while start != end {
+            if curr == start {
+                reached_curr = true;
+            }
+            let startp = start.unwrap();
+            if !startp.is_deleted() {
+                if let ItemContent::Format(key, attr) = &startp.content {
+                    let value = &**attr;
+                    let start_attr_value = start_attrs.get(key).map_or(&Any::Null, |a| &**a);
+                    if end_fmts.get(key) != Some(&startp) || start_attr_value == value {
+                        // Either this format is overwritten or it is not necessary because the attribute already existed.
+                        self.delete(startp);
+                        self.cleanups.insert(startp.id, startp.len);
+                        cleanups += 1;
+
+                        if !reached_curr
+                            && curr_attrs.get(key).map_or(&Any::Null, |a| &**a) == value
+                            && start_attr_value != value
+                        {
+                            if value == &Any::Null {
+                                curr_attrs.remove(key);
+                            } else {
+                                curr_attrs.insert(key.clone(), Box::new(start_attr_value.clone()));
+                            }
+                        }
+                    }
+                    if !reached_curr && !startp.is_deleted() {
+                        if value == &Any::Null {
+                            curr_attrs.remove(key);
+                        } else {
+                            curr_attrs.insert(key.clone(), attr.clone());
+                        }
+                    }
+                }
+            }
+            start = startp.right;
+        }
+
+        cleanups
     }
 
     /// Perform garbage collection of deleted blocks, even if a document was created with `skip_gc`

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -898,17 +898,13 @@ impl<'doc> TransactionMut<'doc> {
             parent_sub,
             content,
         )?;
-        let mut block_ptr = ItemPtr::from(&mut block);
-
-        block_ptr.integrate(self, 0);
-
-        self.store_mut().blocks.push(Block::Item(block));
+        let block_ptr = self.integrate_item(block, 0);
 
         if let Some(remainder) = remainder {
             remainder.integrate(self, inner_ref.unwrap().into())
         }
 
-        Some(block_ptr)
+        block_ptr
     }
 
     fn call_type_observers(

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1,4 +1,4 @@
-use crate::block::{Item, ItemContent, ItemPosition, ItemPtr, Prelim, ID};
+use crate::block::{Block, Item, ItemContent, ItemPosition, ItemPtr, Prelim, ID};
 use crate::branch::{Branch, BranchPtr};
 use crate::doc::DocAddr;
 use crate::error::{Error, UpdateError};
@@ -451,6 +451,8 @@ pub struct TransactionMut<'doc> {
     pub(crate) merge_blocks: Vec<ID>,
     /// Describes the set of deleted items by ids.
     pub(crate) delete_set: IdSet,
+    /// Describes the set of inserted items by ids.
+    pub(crate) insert_set: IdSet,
     /// All types that were directly modified (property added or child inserted/deleted).
     /// New types are not included in this Set.
     pub(crate) changed: HashMap<TypePtr, HashSet<Option<Arc<str>>>>,
@@ -499,6 +501,7 @@ impl<'doc> TransactionMut<'doc> {
             before_state: begin_timestamp,
             merge_blocks: Vec::default(),
             delete_set: IdSet::new(),
+            insert_set: IdSet::new(),
             after_state: StateVector::default(),
             changed: HashMap::default(),
             changed_parent_types: Vec::default(),
@@ -881,7 +884,7 @@ impl<'doc> TransactionMut<'doc> {
 
         block_ptr.integrate(self, 0);
 
-        self.store_mut().blocks.push_block(block);
+        self.store_mut().blocks.push(Block::Item(block));
 
         if let Some(remainder) = remainder {
             remainder.integrate(self, inner_ref.unwrap().into())

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -905,7 +905,7 @@ pub(crate) fn event_keys(
         if let Some(key) = opt {
             let block = target.map.get(key.as_ref()).cloned();
             if let Some(item) = block.as_deref() {
-                if item.id.clock >= txn.before_state.get(&item.id.client) {
+                if item.id.clock >= txn.before_state().get(&item.id.client) {
                     let mut prev = item.left;
                     while let Some(p) = prev.as_deref() {
                         if !txn.has_added(&p.id) {

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -1,4 +1,4 @@
-use crate::block::{EmbedPrelim, Item, ItemContent, ItemPosition, ItemPtr, Prelim, Unused};
+use crate::block::{Block, EmbedPrelim, Item, ItemContent, ItemPosition, ItemPtr, Prelim, Unused};
 use crate::transaction::TransactionMut;
 use crate::types::{
     AsPrelim, Attrs, Branch, BranchPtr, DefaultPrelim, Delta, Out, Path, RootRef, SharedRef,
@@ -996,7 +996,7 @@ fn insert_attributes(
             let mut item_ptr = ItemPtr::from(&mut item);
             pos.right = Some(item_ptr);
             item_ptr.integrate(txn, 0);
-            txn.store_mut().blocks.push_block(item);
+            txn.store_mut().blocks.push(Block::Item(item));
 
             pos.forward();
             store = txn.store_mut();
@@ -1048,7 +1048,7 @@ fn insert_negated_attributes(
         pos.right = Some(item_ptr);
         item_ptr.integrate(txn, 0);
 
-        txn.store_mut().blocks.push_block(item);
+        txn.store_mut().blocks.push(Block::Item(item));
 
         pos.forward();
         store = txn.store_mut();

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -982,7 +982,7 @@ fn insert_attributes(
 
             let client_id = store.client_id;
             let parent = this.into();
-            let mut item = Item::new(
+            let item = Item::new(
                 ID::new(client_id, store.blocks.get_clock(&client_id)),
                 pos.left.clone(),
                 pos.left.map(|ptr| ptr.last_id()),
@@ -993,11 +993,8 @@ fn insert_attributes(
                 ItemContent::Format(k, v.into()),
             )
             .unwrap();
-            let mut item_ptr = ItemPtr::from(&mut item);
-            pos.right = Some(item_ptr);
-            item_ptr.integrate(txn, 0);
-            txn.store_mut().blocks.push(Block::Item(item));
-
+            let item_ptr = txn.integrate_item(item, 0);
+            pos.right = item_ptr;
             pos.forward();
             store = txn.store_mut();
         }
@@ -1033,7 +1030,7 @@ fn insert_negated_attributes(
     for (k, v) in attrs {
         let client_id = store.client_id;
         let parent = this.into();
-        let mut item = Item::new(
+        let item = Item::new(
             ID::new(client_id, store.blocks.get_clock(&client_id)),
             pos.left.clone(),
             pos.left.map(|ptr| ptr.last_id()),
@@ -1044,12 +1041,8 @@ fn insert_negated_attributes(
             ItemContent::Format(k, v.into()),
         )
         .unwrap();
-        let mut item_ptr = ItemPtr::from(&mut item);
-        pos.right = Some(item_ptr);
-        item_ptr.integrate(txn, 0);
-
-        txn.store_mut().blocks.push(Block::Item(item));
-
+        let item_ptr = txn.integrate_item(item, 0);
+        pos.right = item_ptr;
         pos.forward();
         store = txn.store_mut();
     }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -180,7 +180,7 @@ where
 
         let mut insertions = IdSet::new();
         for (client, &end_clock) in txn.after_state().iter() {
-            let start_clock = txn.before_state.get(client);
+            let start_clock = txn.before_state().get(client);
             let diff = end_clock - start_clock;
             if diff != 0 {
                 insertions.insert(ID::new(*client, start_clock), diff);

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -8,6 +8,7 @@ use crate::block::{
     Block, BlockRange, ClientID, Item, ItemContent, ItemPtr, BLOCK_GC_REF_NUMBER,
     BLOCK_SKIP_REF_NUMBER, HAS_ORIGIN, HAS_PARENT_SUB, HAS_RIGHT_ORIGIN,
 };
+use crate::block_store::BlockStore;
 use crate::encoding::read::Error;
 use crate::error::UpdateError;
 use crate::id_set::IdSet;
@@ -426,19 +427,17 @@ impl Update {
         Ok((remaining_blocks, remaining_ds))
     }
 
-    fn missing(block: &Block, local_sv: &StateVector) -> Option<ClientID> {
+    fn missing(block: &Block, store: &BlockStore) -> Option<ClientID> {
         if let Block::Item(item) = block {
-            if let Some(origin) = &item.origin {
-                if origin.client != item.id.client && origin.clock >= local_sv.get(&origin.client) {
-                    return Some(origin.client);
+            if let Some(origin_left) = &item.origin {
+                if store.is_missing(origin_left) {
+                    return Some(origin_left.client);
                 }
             }
 
-            if let Some(right_origin) = &item.right_origin {
-                if right_origin.client != item.id.client
-                    && right_origin.clock >= local_sv.get(&right_origin.client)
-                {
-                    return Some(right_origin.client);
+            if let Some(origin_right) = &item.right_origin {
+                if store.is_missing(origin_right) {
+                    return Some(origin_right.client);
                 }
             }
 
@@ -446,17 +445,13 @@ impl Update {
                 TypePtr::Branch(parent) => {
                     if let Some(block) = &parent.item {
                         let parent_id = block.id();
-                        if parent_id.client != item.id.client
-                            && parent_id.clock >= local_sv.get(&parent_id.client)
-                        {
+                        if store.is_missing(parent_id) {
                             return Some(parent_id.client);
                         }
                     }
                 }
                 TypePtr::ID(parent_id) => {
-                    if parent_id.client != item.id.client
-                        && parent_id.clock >= local_sv.get(&parent_id.client)
-                    {
+                    if store.is_missing(parent_id) {
                         return Some(parent_id.client);
                     }
                 }
@@ -470,13 +465,13 @@ impl Update {
                         let start = source.quote_start.id();
                         let end = source.quote_end.id();
                         if let Some(start) = start {
-                            if start.clock >= local_sv.get(&start.client) {
+                            if store.is_missing(start) {
                                 return Some(start.client);
                             }
                         }
                         if start != end {
                             if let Some(end) = &source.quote_end.id() {
-                                if end.clock >= local_sv.get(&end.client) {
+                                if store.is_missing(end) {
                                     return Some(end.client);
                                 }
                             }

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -11,7 +11,6 @@ use crate::block::{
 use crate::encoding::read::Error;
 use crate::error::UpdateError;
 use crate::id_set::IdSet;
-use crate::slice::ItemSlice;
 #[cfg(test)]
 use crate::store::Store;
 use crate::transaction::TransactionMut;
@@ -19,14 +18,14 @@ use crate::types::TypePtr;
 use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::client_hasher::ClientHasher;
-use crate::{OffsetKind, StateVector, ID};
+use crate::{StateVector, ID};
 
 #[derive(Debug, Default, PartialEq)]
-pub(crate) struct UpdateBlocks {
+pub(crate) struct BlockSet {
     pub(crate) clients: HashMap<ClientID, VecDeque<Block>, BuildHasherDefault<ClientHasher>>,
 }
 
-impl UpdateBlocks {
+impl BlockSet {
     /**
     @todo this should be refactored.
     I'm currently using this to add blocks to the Update
@@ -45,6 +44,75 @@ impl UpdateBlocks {
     pub(crate) fn into_blocks(self, ignore_skip: bool) -> IntoBlocks {
         IntoBlocks::new(self, ignore_skip)
     }
+
+    pub fn as_id_set(&self) -> IdSet {
+        let mut inserts = IdSet::default();
+
+        for (client, blocks) in self.clients.iter() {
+            let mut last_clock = 0;
+            let mut last_len = 0;
+            for block in blocks {
+                if block.is_skip() {
+                    continue;
+                }
+                let clock = block.clock_start();
+                if last_clock + last_len == clock {
+                    // default case: extend prev entry
+                    last_len += block.len();
+                } else {
+                    if last_len > 0 {
+                        inserts.insert(ID::new(*client, last_clock), last_len);
+                    }
+                    last_clock = clock;
+                    last_len = block.len();
+                }
+            }
+            inserts.insert(ID::new(*client, last_clock), last_len);
+        }
+
+        inserts
+    }
+
+    pub fn exclude(&mut self, exclude: &IdSet) {
+        let client_ids: Vec<ClientID> = if self.clients.len() < exclude.len() {
+            self.clients.keys().copied().collect()
+        } else {
+            exclude.client_ids().collect()
+        };
+        for client_id in client_ids {
+            if let Some(id_range) = exclude.get(&client_id) {
+                if let Some(structs) = self.clients.get_mut(&client_id) {
+                    let clock_start = structs.front().unwrap().clock_start();
+                    let clock_end = structs.back().unwrap().next_clock();
+                    for (range, _) in id_range.iter() {
+                        let mut start_index = 0;
+                        if range.start >= clock_end {
+                            continue;
+                        }
+                        if range.start > clock_start {
+                            todo!("startIndex = findIndexCleanStart(null, structs, range.clock)")
+                        }
+                        let end_index = structs.len(); // must be set here, after structs is modified
+                        if range.end <= clock_start {
+                            continue;
+                        }
+                        if range.end < clock_end {
+                            todo!("endIndex = findIndexCleanStart(null, structs, range.clock + range.len)")
+                        }
+                        if start_index < end_index {
+                            structs[start_index] = Block::Skip(BlockRange::new(
+                                ID::new(client_id, range.start),
+                                range.len() as u32,
+                            ));
+                            if end_index - start_index > 1 {
+                                structs.drain((start_index + 1)..end_index);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Update type which contains an information about all decoded blocks which are incoming from a
@@ -55,7 +123,7 @@ impl UpdateBlocks {
 /// Update is conceptually similar to a block store itself, however the work patters are different.
 #[derive(Default, PartialEq)]
 pub struct Update {
-    pub(crate) blocks: UpdateBlocks,
+    pub(crate) blocks: BlockSet,
     pub(crate) delete_set: IdSet,
 }
 
@@ -236,7 +304,7 @@ impl Update {
 
             let mut local_sv = store.blocks.get_state_vector();
             let mut missing_sv = StateVector::default();
-            let mut remaining = UpdateBlocks::default();
+            let mut remaining = BlockSet::default();
             let mut stack = Vec::new();
 
             while let Some(mut block) = stack_head {
@@ -423,7 +491,7 @@ impl Update {
 
     fn next_target<'a, 'b>(
         client_block_ref_ids: &'a mut Vec<ClientID>,
-        blocks: &'b mut UpdateBlocks,
+        blocks: &'b mut BlockSet,
     ) -> Option<(ClientID, &'b mut VecDeque<Block>)> {
         while let Some(id) = client_block_ref_ids.pop() {
             match blocks.clients.get(&id) {
@@ -444,7 +512,7 @@ impl Update {
         None
     }
 
-    fn return_stack(stack: Vec<Block>, refs: &mut UpdateBlocks, remaining: &mut UpdateBlocks) {
+    fn return_stack(stack: Vec<Block>, refs: &mut BlockSet, remaining: &mut BlockSet) {
         for item in stack.into_iter() {
             let client = item.id().client;
             // remove client from clientsStructRefsIds to prevent users from applying the same update again
@@ -571,7 +639,7 @@ impl Update {
         T: IntoIterator<Item = Update>,
     {
         let mut result = Update::new();
-        let update_blocks: Vec<UpdateBlocks> = block_stores
+        let update_blocks: Vec<BlockSet> = block_stores
             .into_iter()
             .map(|update| {
                 result.delete_set.merge_with(update.delete_set);
@@ -750,7 +818,7 @@ impl Decode for Update {
         let mut clients = HashMap::with_hasher(BuildHasherDefault::default());
         clients.try_reserve(clients_len as usize)?;
 
-        let mut blocks = UpdateBlocks { clients };
+        let mut blocks = BlockSet { clients };
         for _ in 0..clients_len {
             let blocks_len = decoder.read_var::<u32>()? as usize;
 
@@ -852,7 +920,7 @@ pub(crate) struct IntoBlocks {
 }
 
 impl IntoBlocks {
-    fn new(update: UpdateBlocks, ignore_skip: bool) -> Self {
+    fn new(update: BlockSet, ignore_skip: bool) -> Self {
         let mut client_blocks: Vec<(ClientID, VecDeque<Block>)> =
             update.clients.into_iter().collect();
         // sorting to return higher client ids first
@@ -899,7 +967,7 @@ mod test {
     use crate::block::{Block, BlockRange, ClientID, Item, ItemContent};
     use crate::encoding::read::Cursor;
     use crate::types::{Delta, TypePtr};
-    use crate::update::{Update, UpdateBlocks};
+    use crate::update::{BlockSet, Update};
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::Encode;
     use crate::{
@@ -1267,7 +1335,7 @@ mod test {
 
     fn update_with_skips() -> Update {
         Update {
-            blocks: UpdateBlocks {
+            blocks: BlockSet {
                 clients: HashMap::from_iter([(
                     ClientID::new(1),
                     VecDeque::from_iter([

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -5,8 +5,8 @@ use std::hash::BuildHasherDefault;
 use std::sync::Arc;
 
 use crate::block::{
-    BlockRange, ClientID, Item, ItemContent, ItemPtr, BLOCK_GC_REF_NUMBER, BLOCK_SKIP_REF_NUMBER,
-    HAS_ORIGIN, HAS_PARENT_SUB, HAS_RIGHT_ORIGIN,
+    Block, BlockRange, ClientID, Item, ItemContent, ItemPtr, BLOCK_GC_REF_NUMBER,
+    BLOCK_SKIP_REF_NUMBER, HAS_ORIGIN, HAS_PARENT_SUB, HAS_RIGHT_ORIGIN,
 };
 use crate::encoding::read::Error;
 use crate::error::UpdateError;
@@ -23,7 +23,7 @@ use crate::{OffsetKind, StateVector, ID};
 
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct UpdateBlocks {
-    clients: HashMap<ClientID, VecDeque<BlockCarrier>, BuildHasherDefault<ClientHasher>>,
+    pub(crate) clients: HashMap<ClientID, VecDeque<Block>, BuildHasherDefault<ClientHasher>>,
 }
 
 impl UpdateBlocks {
@@ -31,8 +31,8 @@ impl UpdateBlocks {
     @todo this should be refactored.
     I'm currently using this to add blocks to the Update
     */
-    pub(crate) fn add_block(&mut self, block: BlockCarrier) {
-        let e = self.clients.entry(block.id().client).or_default();
+    pub(crate) fn add_block(&mut self, block: Block) {
+        let e = self.clients.entry(*block.client()).or_default();
         e.push_back(block);
     }
 
@@ -40,45 +40,10 @@ impl UpdateBlocks {
         self.clients.is_empty()
     }
 
-    /// Returns an iterator that allows a traversal of all of the blocks
-    /// which consist into this [Update].
-    pub(crate) fn blocks(&self) -> Blocks<'_> {
-        Blocks::new(self)
-    }
-
-    /// Returns an iterator that allows a traversal of all of the blocks
+    /// Returns an iterator that allows a traversal of all the blocks
     /// which consist into this [Update].
     pub(crate) fn into_blocks(self, ignore_skip: bool) -> IntoBlocks {
         IntoBlocks::new(self, ignore_skip)
-    }
-}
-
-impl std::fmt::Display for UpdateBlocks {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{{")?;
-        for (client, blocks) in self.clients.iter() {
-            writeln!(f, "\t{} -> [", client)?;
-            for block in blocks {
-                writeln!(f, "\t\t{}", block)?;
-            }
-            write!(f, "\t]")?;
-        }
-        writeln!(f, "}}")
-    }
-}
-
-impl std::fmt::Debug for BlockCarrier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(self, f)
-    }
-}
-impl std::fmt::Display for BlockCarrier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BlockCarrier::Item(x) => x.fmt(f),
-            BlockCarrier::Skip(x) => write!(f, "Skip{}", x),
-            BlockCarrier::GC(x) => write!(f, "GC{}", x),
-        }
     }
 }
 
@@ -139,7 +104,7 @@ impl Update {
                 // we expect clocks to start from 0, otherwise blocks for this client are not
                 // continuous
                 for block in blocks.iter() {
-                    if let BlockCarrier::Skip(_) = block {
+                    if let Block::Skip(_) = block {
                         // if we met skip, we stop counting: blocks are not continuous any more
                         break;
                     }
@@ -178,10 +143,10 @@ impl Update {
         for blocks in self.blocks.clients.values() {
             for block in blocks.iter() {
                 match block {
-                    BlockCarrier::Item(item) if include_deleted || !item.is_deleted() => {
+                    Block::Item(item) if include_deleted || !item.is_deleted() => {
                         insertions.insert(item.id, item.len);
                     }
-                    BlockCarrier::GC(range) if include_deleted => {
+                    Block::GC(range) if include_deleted => {
                         insertions.insert(range.id(), range.len);
                     }
                     _ => {}
@@ -213,7 +178,7 @@ impl Update {
                             if a.try_squash(b) {
                                 n2 = i2.next();
                                 continue;
-                            } else if let BlockCarrier::Item(block) = a {
+                            } else if let Block::Item(block) = a {
                                 // we only can split Block::Item
                                 let diff = (block.id().clock + block.len()) as isize
                                     - b.id().clock as isize;
@@ -302,29 +267,31 @@ impl Update {
                             let offset = offset as u32;
                             let client = id.client;
                             local_sv.set_max(client, id.clock + block.len());
-                            if let BlockCarrier::Item(item) = &mut block {
+                            if let Block::Item(item) = &mut block {
                                 item.repair(store)?;
                             }
                             let should_delete = block.integrate(txn, offset);
                             let mut delete_ptr = if should_delete {
-                                let ptr = block.as_item_ptr();
+                                let ptr = block.as_item();
                                 ptr
                             } else {
                                 None
                             };
                             store = txn.store_mut();
                             match block {
-                                BlockCarrier::Item(item) => {
+                                Block::Item(item) => {
                                     if item.parent != TypePtr::Unknown {
-                                        store.blocks.push_block(item)
+                                        store.blocks.push(Block::Item(item))
                                     } else {
                                         // parent is not defined. Integrate GC struct instead
-                                        store.blocks.push_gc(BlockRange::new(item.id, item.len));
+                                        store
+                                            .blocks
+                                            .push(Block::GC(BlockRange::new(item.id, item.len)));
                                         delete_ptr = None;
                                     }
                                 }
-                                BlockCarrier::GC(gc) => store.blocks.push_gc(gc),
-                                BlockCarrier::Skip(_) => { /* do nothing */ }
+                                Block::GC(gc) => store.blocks.push(Block::GC(gc)),
+                                Block::Skip(_) => { /* do nothing */ }
                             }
 
                             if let Some(ptr) = delete_ptr {
@@ -391,8 +358,8 @@ impl Update {
         Ok((remaining_blocks, remaining_ds))
     }
 
-    fn missing(block: &BlockCarrier, local_sv: &StateVector) -> Option<ClientID> {
-        if let BlockCarrier::Item(item) = block {
+    fn missing(block: &Block, local_sv: &StateVector) -> Option<ClientID> {
+        if let Block::Item(item) = block {
             if let Some(origin) = &item.origin {
                 if origin.client != item.id.client && origin.clock >= local_sv.get(&origin.client) {
                     return Some(origin.client);
@@ -457,7 +424,7 @@ impl Update {
     fn next_target<'a, 'b>(
         client_block_ref_ids: &'a mut Vec<ClientID>,
         blocks: &'b mut UpdateBlocks,
-    ) -> Option<(ClientID, &'b mut VecDeque<BlockCarrier>)> {
+    ) -> Option<(ClientID, &'b mut VecDeque<Block>)> {
         while let Some(id) = client_block_ref_ids.pop() {
             match blocks.clients.get(&id) {
                 Some(client_blocks) if !client_blocks.is_empty() => {
@@ -465,8 +432,7 @@ impl Update {
                     // doing so in a loop at the same time - this combination causes
                     // Rust borrow checker go nuts. TODO: remove the unsafe block
                     let client_blocks = unsafe {
-                        (client_blocks as *const VecDeque<BlockCarrier>
-                            as *mut VecDeque<BlockCarrier>)
+                        (client_blocks as *const VecDeque<Block> as *mut VecDeque<Block>)
                             .as_mut()
                             .unwrap()
                     };
@@ -478,11 +444,7 @@ impl Update {
         None
     }
 
-    fn return_stack(
-        stack: Vec<BlockCarrier>,
-        refs: &mut UpdateBlocks,
-        remaining: &mut UpdateBlocks,
-    ) {
+    fn return_stack(stack: Vec<Block>, refs: &mut UpdateBlocks, remaining: &mut UpdateBlocks) {
         for item in stack.into_iter() {
             let client = item.id().client;
             // remove client from clientsStructRefsIds to prevent users from applying the same update again
@@ -500,16 +462,16 @@ impl Update {
         }
     }
 
-    fn decode_block<D: Decoder>(id: ID, decoder: &mut D) -> Result<Option<BlockCarrier>, Error> {
+    fn decode_block<D: Decoder>(id: ID, decoder: &mut D) -> Result<Option<Block>, Error> {
         let info = decoder.read_info()?;
         match info {
             BLOCK_SKIP_REF_NUMBER => {
                 let len: u32 = decoder.read_var()?;
-                Ok(Some(BlockCarrier::Skip(BlockRange::new(id, len))))
+                Ok(Some(Block::Skip(BlockRange::new(id, len))))
             }
             BLOCK_GC_REF_NUMBER => {
                 let len: u32 = decoder.read_len()?;
-                Ok(Some(BlockCarrier::GC(BlockRange::new(id, len))))
+                Ok(Some(Block::GC(BlockRange::new(id, len))))
             }
             info => {
                 let cant_copy_parent_info = info & (HAS_ORIGIN | HAS_RIGHT_ORIGIN) == 0;
@@ -551,7 +513,7 @@ impl Update {
                 );
                 match item {
                     None => Ok(None),
-                    Some(item) => Ok(Some(BlockCarrier::from(item))),
+                    Some(item) => Ok(Some(Block::from(item))),
                 }
             }
         }
@@ -627,7 +589,7 @@ impl Update {
             })
             .collect();
 
-        let mut curr_write: Option<BlockCarrier> = None;
+        let mut curr_write: Option<Block> = None;
 
         // Note: We need to ensure that all lazyStructDecoders are fully consumed
         // Note: Should merge document updates whenever possible - even from different updates
@@ -710,7 +672,7 @@ impl Update {
                 } else if curr_write_last < curr_block.id().clock {
                     //TODO: write currStruct & set currStruct = Skip(clock = currStruct.id.clock + currStruct.length, length = curr.id.clock - self.clock)
                     let skip = match curr_write.unwrap_or_else(|| unreachable!()) {
-                        BlockCarrier::Skip(mut skip) => {
+                        Block::Skip(mut skip) => {
                             // extend existing skip
                             skip.len = curr_block.id().clock + curr_block.len() - skip.clock;
                             skip
@@ -721,14 +683,14 @@ impl Update {
                             BlockRange::new(ID::new(first_client, curr_write_last), diff)
                         }
                     };
-                    curr_write = Some(BlockCarrier::Skip(skip));
+                    curr_write = Some(Block::Skip(skip));
                 } else {
                     // if (currWrite.struct.id.clock + currWrite.struct.length >= curr.id.clock) {
                     let diff = curr_write_last.saturating_sub(curr_block.id().clock);
 
                     let mut block_slice = None;
                     if diff > 0 {
-                        if let BlockCarrier::Skip(skip) = curr_write_block {
+                        if let Block::Skip(skip) = curr_write_block {
                             // prefer to slice Skip because the other struct might contain more information
                             skip.len -= diff as u32;
                         } else {
@@ -854,161 +816,6 @@ impl<T: Iterator> Memoizable for T {
     }
 }
 
-#[derive(PartialEq)]
-pub(crate) enum BlockCarrier {
-    Item(Box<Item>),
-    GC(BlockRange),
-    Skip(BlockRange),
-}
-
-impl BlockCarrier {
-    pub(crate) fn splice(&self, offset: u32) -> Option<Self> {
-        match self {
-            BlockCarrier::Item(x) => {
-                let next = ItemPtr::from(x).splice(offset, OffsetKind::Utf16)?;
-                Some(BlockCarrier::Item(next))
-            }
-            BlockCarrier::Skip(x) => {
-                if offset == 0 {
-                    None
-                } else {
-                    Some(BlockCarrier::Skip(x.slice(offset)))
-                }
-            }
-            BlockCarrier::GC(x) => {
-                if offset == 0 {
-                    None
-                } else {
-                    Some(BlockCarrier::GC(x.slice(offset)))
-                }
-            }
-        }
-    }
-    pub(crate) fn same_type(&self, other: &BlockCarrier) -> bool {
-        match (self, other) {
-            (BlockCarrier::Skip(_), BlockCarrier::Skip(_)) => true,
-            (BlockCarrier::Item(_), BlockCarrier::Item(_)) => true,
-            (BlockCarrier::GC(_), BlockCarrier::GC(_)) => true,
-            (_, _) => false,
-        }
-    }
-    pub(crate) fn id(&self) -> ID {
-        match self {
-            BlockCarrier::Item(x) => *x.id(),
-            BlockCarrier::Skip(x) => x.id(),
-            BlockCarrier::GC(x) => x.id(),
-        }
-    }
-
-    pub(crate) fn len(&self) -> u32 {
-        match self {
-            BlockCarrier::Item(x) => x.len(),
-            BlockCarrier::Skip(x) => x.len,
-            BlockCarrier::GC(x) => x.len,
-        }
-    }
-
-    pub(crate) fn range(&self) -> BlockRange {
-        match self {
-            BlockCarrier::Item(item) => BlockRange::new(item.id, item.len),
-            BlockCarrier::GC(gc) => gc.clone(),
-            BlockCarrier::Skip(skip) => skip.clone(),
-        }
-    }
-
-    pub(crate) fn last_id(&self) -> ID {
-        match self {
-            BlockCarrier::Item(x) => x.last_id(),
-            BlockCarrier::Skip(x) => x.last_id(),
-            BlockCarrier::GC(x) => x.last_id(),
-        }
-    }
-
-    pub(crate) fn try_squash(&mut self, other: &BlockCarrier) -> bool {
-        match (self, other) {
-            (BlockCarrier::Item(a), BlockCarrier::Item(b)) => {
-                ItemPtr::from(a).try_squash(ItemPtr::from(b))
-            }
-            (BlockCarrier::Skip(a), BlockCarrier::Skip(b)) => {
-                a.merge(b);
-                true
-            }
-            _ => false,
-        }
-    }
-
-    pub fn as_item_ptr(&mut self) -> Option<ItemPtr> {
-        if let BlockCarrier::Item(block) = self {
-            Some(ItemPtr::from(block))
-        } else {
-            None
-        }
-    }
-
-    pub fn into_block(self) -> Option<Box<Item>> {
-        if let BlockCarrier::Item(block) = self {
-            Some(block)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn is_skip(&self) -> bool {
-        if let BlockCarrier::Skip(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-    pub fn encode_with_offset<E: Encoder>(&self, encoder: &mut E, offset: u32) {
-        match self {
-            BlockCarrier::Item(x) => {
-                let slice = ItemSlice::new(x.into(), offset, x.len() - 1);
-                slice.encode(encoder)
-            }
-            BlockCarrier::Skip(x) => {
-                encoder.write_info(BLOCK_SKIP_REF_NUMBER);
-                encoder.write_var(x.len - offset);
-            }
-            BlockCarrier::GC(x) => {
-                encoder.write_info(BLOCK_GC_REF_NUMBER);
-                encoder.write_len(x.len - offset);
-            }
-        }
-    }
-
-    pub fn integrate(&mut self, txn: &mut TransactionMut, offset: u32) -> bool {
-        match self {
-            BlockCarrier::Item(x) => ItemPtr::from(x).integrate(txn, offset),
-            BlockCarrier::Skip(x) => x.integrate(offset),
-            BlockCarrier::GC(x) => x.integrate(offset),
-        }
-    }
-}
-
-impl From<Box<Item>> for BlockCarrier {
-    fn from(block: Box<Item>) -> Self {
-        BlockCarrier::Item(block)
-    }
-}
-
-impl Encode for BlockCarrier {
-    fn encode<E: Encoder>(&self, encoder: &mut E) {
-        match self {
-            BlockCarrier::Item(block) => block.encode(encoder),
-            BlockCarrier::Skip(skip) => {
-                encoder.write_info(BLOCK_SKIP_REF_NUMBER);
-                encoder.write_len(skip.len)
-            }
-            BlockCarrier::GC(gc) => {
-                encoder.write_info(BLOCK_GC_REF_NUMBER);
-                encoder.write_len(gc.len)
-            }
-        }
-    }
-}
-
 /// A pending update which contains unapplied blocks from the update which created it.
 #[derive(Debug, PartialEq)]
 pub struct PendingUpdate {
@@ -1038,76 +845,15 @@ impl std::fmt::Display for Update {
     }
 }
 
-/// Conversion for tests only
-#[cfg(test)]
-impl Into<Store> for Update {
-    fn into(self) -> Store {
-        use crate::doc::Options;
-
-        let mut store = Store::new(&Options::with_client_id(ClientID::new(0)));
-        for (_, vec) in self.blocks.clients {
-            for block in vec {
-                if let BlockCarrier::Item(block) = block {
-                    store.blocks.push_block(block);
-                } else {
-                    panic!("Cannot convert Update into block store - Skip block detected");
-                }
-            }
-        }
-        store
-    }
-}
-
-pub(crate) struct Blocks<'a> {
-    current_client: std::vec::IntoIter<(&'a ClientID, &'a VecDeque<BlockCarrier>)>,
-    current_block: Option<std::collections::vec_deque::Iter<'a, BlockCarrier>>,
-}
-
-impl<'a> Blocks<'a> {
-    fn new(update: &'a UpdateBlocks) -> Self {
-        let mut client_blocks: Vec<(&'a ClientID, &'a VecDeque<BlockCarrier>)> =
-            update.clients.iter().collect();
-        // sorting to return higher client ids first
-        client_blocks.sort_by(|a, b| b.0.cmp(a.0));
-        let mut current_client = client_blocks.into_iter();
-
-        let current_block = current_client.next().map(|(_, v)| v.iter());
-        Blocks {
-            current_client,
-            current_block,
-        }
-    }
-}
-
-impl<'a> Iterator for Blocks<'a> {
-    type Item = &'a BlockCarrier;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some(blocks) = self.current_block.as_mut() {
-            let block = blocks.next();
-            if block.is_some() {
-                return block;
-            }
-        }
-
-        if let Some(entry) = self.current_client.next() {
-            self.current_block = Some(entry.1.iter());
-            self.next()
-        } else {
-            None
-        }
-    }
-}
-
 pub(crate) struct IntoBlocks {
-    current_client: std::vec::IntoIter<(ClientID, VecDeque<BlockCarrier>)>,
-    current_block: Option<std::collections::vec_deque::IntoIter<BlockCarrier>>,
+    current_client: std::vec::IntoIter<(ClientID, VecDeque<Block>)>,
+    current_block: Option<std::collections::vec_deque::IntoIter<Block>>,
     ignore_skip: bool,
 }
 
 impl IntoBlocks {
     fn new(update: UpdateBlocks, ignore_skip: bool) -> Self {
-        let mut client_blocks: Vec<(ClientID, VecDeque<BlockCarrier>)> =
+        let mut client_blocks: Vec<(ClientID, VecDeque<Block>)> =
             update.clients.into_iter().collect();
         // sorting to return higher client ids first
         client_blocks.sort_by(|a, b| b.0.cmp(&a.0));
@@ -1123,13 +869,13 @@ impl IntoBlocks {
 }
 
 impl Iterator for IntoBlocks {
-    type Item = BlockCarrier;
+    type Item = Block;
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(blocks) = self.current_block.as_mut() {
             let block = blocks.next();
             match block {
-                Some(BlockCarrier::Skip(_)) if self.ignore_skip => return self.next(),
+                Some(Block::Skip(_)) if self.ignore_skip => return self.next(),
                 Some(block) => return Some(block),
                 None => {}
             }
@@ -1150,10 +896,10 @@ mod test {
     use std::iter::FromIterator;
     use std::sync::{Arc, Mutex};
 
-    use crate::block::{BlockRange, ClientID, Item, ItemContent};
+    use crate::block::{Block, BlockRange, ClientID, Item, ItemContent};
     use crate::encoding::read::Cursor;
     use crate::types::{Delta, TypePtr};
-    use crate::update::{BlockCarrier, Update, UpdateBlocks};
+    use crate::update::{Update, UpdateBlocks};
     use crate::updates::decoder::{Decode, DecoderV1};
     use crate::updates::encoder::Encode;
     use crate::{
@@ -1185,7 +931,7 @@ mod test {
 
         let id = ID::new(ClientID::new(2026372272), 0);
         let block = u.blocks.clients.get(&id.client).unwrap();
-        let mut expected: Vec<BlockCarrier> = Vec::new();
+        let mut expected: Vec<Block> = Vec::new();
         expected.push(
             Item::new(
                 id,
@@ -1430,7 +1176,7 @@ mod test {
     fn update_state_vector_with_skips() {
         let mut update = Update::new();
         // skip followed by item => not included in state vector as it's not continuous from 0
-        update.blocks.add_block(BlockCarrier::Skip(BlockRange::new(
+        update.blocks.add_block(Block::Skip(BlockRange::new(
             ID::new(ClientID::new(1), 0),
             1,
         )));
@@ -1439,7 +1185,7 @@ mod test {
         update.blocks.add_block(test_item(ClientID::new(2), 1, 1));
         // item => skip => item : second item not included
         update.blocks.add_block(test_item(ClientID::new(3), 0, 1));
-        update.blocks.add_block(BlockCarrier::Skip(BlockRange::new(
+        update.blocks.add_block(Block::Skip(BlockRange::new(
             ID::new(ClientID::new(3), 1),
             1,
         )));
@@ -1460,7 +1206,7 @@ mod test {
         assert!(!u.extends(&StateVector::from_iter([(ClientID::new(1), 1)])));
 
         let mut u = Update::new();
-        u.blocks.add_block(BlockCarrier::Skip(BlockRange::new(
+        u.blocks.add_block(Block::Skip(BlockRange::new(
             ID::new(ClientID::new(1), 0),
             2,
         )));
@@ -1525,7 +1271,7 @@ mod test {
                 clients: HashMap::from_iter([(
                     ClientID::new(1),
                     VecDeque::from_iter([
-                        BlockCarrier::Item(
+                        Block::Item(
                             Item::new(
                                 ID::new(ClientID::new(1), 0),
                                 None,
@@ -1538,8 +1284,8 @@ mod test {
                             )
                             .unwrap(),
                         ),
-                        BlockCarrier::Skip(BlockRange::new(ID::new(ClientID::new(1), 5), 3)),
-                        BlockCarrier::Item(
+                        Block::Skip(BlockRange::new(ID::new(ClientID::new(1), 5), 3)),
+                        Block::Item(
                             Item::new(
                                 ID::new(ClientID::new(1), 8),
                                 None,
@@ -1559,10 +1305,10 @@ mod test {
         }
     }
 
-    fn test_item(client_id: ClientID, clock: u32, len: u32) -> BlockCarrier {
+    fn test_item(client_id: ClientID, clock: u32, len: u32) -> Block {
         assert!(len > 0);
         let any: Vec<_> = (0..len).into_iter().map(Any::from).collect();
-        BlockCarrier::Item(
+        Block::Item(
             Item::new(
                 ID::new(client_id, clock),
                 None,

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1,25 +1,24 @@
+use crate::block::{
+    Block, BlockRange, ClientID, Item, ItemContent, BLOCK_GC_REF_NUMBER, BLOCK_SKIP_REF_NUMBER,
+    HAS_ORIGIN, HAS_PARENT_SUB, HAS_RIGHT_ORIGIN,
+};
+use crate::branch::BranchPtr;
+use crate::encoding::read::Error;
+use crate::error::UpdateError;
+use crate::id_set::IdSet;
+use crate::store::Store;
+use crate::transaction::TransactionMut;
+use crate::types::{TypePtr, TypeRef};
+use crate::updates::decoder::{Decode, Decoder};
+use crate::updates::encoder::{Encode, Encoder};
+use crate::utils::client_hasher::ClientHasher;
+use crate::{StateVector, ID};
+use smallvec::SmallVec;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, VecDeque};
 use std::hash::BuildHasherDefault;
 use std::sync::Arc;
-
-use crate::block::{
-    Block, BlockRange, ClientID, Item, ItemContent, ItemPtr, BLOCK_GC_REF_NUMBER,
-    BLOCK_SKIP_REF_NUMBER, HAS_ORIGIN, HAS_PARENT_SUB, HAS_RIGHT_ORIGIN,
-};
-use crate::block_store::BlockStore;
-use crate::encoding::read::Error;
-use crate::error::UpdateError;
-use crate::id_set::IdSet;
-#[cfg(test)]
-use crate::store::Store;
-use crate::transaction::TransactionMut;
-use crate::types::TypePtr;
-use crate::updates::decoder::{Decode, Decoder};
-use crate::updates::encoder::{Encode, Encoder};
-use crate::utils::client_hasher::ClientHasher;
-use crate::{StateVector, ID};
 
 #[derive(Debug, Default, PartialEq)]
 pub(crate) struct BlockSet {
@@ -91,14 +90,14 @@ impl BlockSet {
                             continue;
                         }
                         if range.start > clock_start {
-                            todo!("startIndex = findIndexCleanStart(null, structs, range.clock)")
+                            start_index = Self::split_at(structs, range.start);
                         }
-                        let end_index = structs.len(); // must be set here, after structs is modified
+                        let mut end_index = structs.len(); // must be set here, after structs is modified
                         if range.end <= clock_start {
                             continue;
                         }
                         if range.end < clock_end {
-                            todo!("endIndex = findIndexCleanStart(null, structs, range.clock + range.len)")
+                            end_index = Self::split_at(structs, range.end);
                         }
                         if start_index < end_index {
                             structs[start_index] = Block::Skip(BlockRange::new(
@@ -112,6 +111,45 @@ impl BlockSet {
                     }
                 }
             }
+        }
+    }
+
+    fn split_at(blocks: &mut VecDeque<Block>, clock: u32) -> usize {
+        let mut index = Self::find_index(blocks, clock);
+        let block = &mut blocks[index];
+        let block_clock = block.clock_start();
+        if let Some(right) = block.splice(clock - block_clock) {
+            index += 1;
+            blocks.insert(index, right);
+        }
+        index
+    }
+
+    fn find_index(blocks: &VecDeque<Block>, clock: u32) -> usize {
+        let mut left = 0;
+        let mut right = blocks.len() - 1;
+        let mut block = &blocks[right];
+        let (mut start, mut end) = block.clock_range();
+        if start == clock {
+            // a common case is to just append a block at the end, so check first if we can do that
+            right
+        } else {
+            let mut mid = ((clock / end) * right as u32) as usize;
+            while left <= right {
+                block = &blocks[mid];
+                (start, end) = block.clock_range();
+                if start <= clock {
+                    if clock <= end {
+                        return mid;
+                    }
+                    left = mid + 1;
+                } else {
+                    right = mid - 1;
+                }
+                mid = (left + right) / 2;
+            }
+
+            unreachable!()
         }
     }
 }
@@ -290,132 +328,45 @@ impl Update {
         let remaining_blocks = if self.blocks.is_empty() {
             None
         } else {
-            let mut store = txn.store_mut();
-            let mut client_block_ref_ids: Vec<ClientID> =
-                self.blocks.clients.keys().cloned().collect();
-            client_block_ref_ids.sort();
+            let mut picker = BlockPicker::new(&mut self.blocks);
+            let mut next = picker.next();
+            let mut state = HashMap::new();
+            while let Some(mut stack_head) = next {
+                if !stack_head.is_skip() {
+                    let id = stack_head.id();
+                    let len = stack_head.len();
+                    let local_clock = state
+                        .entry(id.client)
+                        .or_insert_with(|| txn.store.blocks.get_clock(&id.client));
+                    let offset = (*local_clock as i32) - (id.clock as i32);
 
-            let mut current_client_id = client_block_ref_ids.pop().unwrap();
-            let mut current_target = self.blocks.clients.get_mut(&current_client_id);
-            let mut stack_head = if let Some(v) = current_target.as_mut() {
-                v.pop_front()
-            } else {
-                None
-            };
-
-            let mut local_sv = store.blocks.get_state_vector();
-            let mut missing_sv = StateVector::default();
-            let mut remaining = BlockSet::default();
-            let mut stack = Vec::new();
-
-            while let Some(mut block) = stack_head {
-                if !block.is_skip() {
-                    let id = block.id();
-                    if local_sv.contains(&id) {
-                        let offset = local_sv.get(&id.client) as i32 - id.clock as i32;
-                        if let Some(dep) = Self::missing(&block, &local_sv) {
-                            stack.push(block);
-                            // get the struct reader that has the missing struct
-                            match self.blocks.clients.get_mut(&dep) {
-                                Some(block_refs) if !block_refs.is_empty() => {
-                                    stack_head = block_refs.pop_front();
-                                    current_target =
-                                        self.blocks.clients.get_mut(&current_client_id);
-                                    continue;
-                                }
-                                _ => {
-                                    // This update message causally depends on another update message that doesn't exist yet
-                                    missing_sv.set_min(dep, local_sv.get(&dep));
-                                    Self::return_stack(stack, &mut self.blocks, &mut remaining);
-                                    current_target =
-                                        self.blocks.clients.get_mut(&current_client_id);
-                                    stack = Vec::new();
-                                }
-                            }
-                        } else if offset == 0 || (offset as u32) < block.len() {
-                            let offset = offset as u32;
-                            let client = id.client;
-                            local_sv.set_max(client, id.clock + block.len());
-                            if let Block::Item(item) = &mut block {
-                                item.repair(store)?;
-                            }
-                            let should_delete = block.integrate(txn, offset);
-                            let mut delete_ptr = if should_delete {
-                                let ptr = block.as_item();
-                                ptr
-                            } else {
-                                None
-                            };
-                            store = txn.store_mut();
-                            match block {
-                                Block::Item(item) => {
-                                    if item.parent != TypePtr::Unknown {
-                                        store.blocks.push(Block::Item(item))
-                                    } else {
-                                        // parent is not defined. Integrate GC struct instead
-                                        store
-                                            .blocks
-                                            .push(Block::GC(BlockRange::new(item.id, item.len)));
-                                        delete_ptr = None;
-                                    }
-                                }
-                                Block::GC(gc) => store.blocks.push(Block::GC(gc)),
-                                Block::Skip(_) => { /* do nothing */ }
-                            }
-
-                            if let Some(ptr) = delete_ptr {
-                                txn.delete(ptr);
-                            }
-                            store = txn.store_mut();
-                        }
+                    if let Some(missing) =
+                        Self::missing_dependency(&mut stack_head, &mut txn.store)?
+                    {
+                        next =
+                            picker.switch(stack_head, &missing, |c| txn.store.blocks.get_clock(c));
+                        continue;
                     } else {
-                        // update from the same client is missing
-                        let id = block.id();
-                        missing_sv.set_min(id.client, id.clock - 1);
-                        stack.push(block);
-                        // hid a dead wall, add all items from stack to restSS
-                        Self::return_stack(stack, &mut self.blocks, &mut remaining);
-                        current_target = self.blocks.clients.get_mut(&current_client_id);
-                        stack = Vec::new();
+                        // block has no missing dependencies, therefore we can integrate it right away
+                        if offset < 0 {
+                            // Block was send out of order (previous blocks from the same client are
+                            // missing), however since it has no dependency on them, it's still safe
+                            // to integrate. For that we prepend the missing hole with a Skip block.
+                            txn.integrate_skip(
+                                BlockRange::new(
+                                    ID::new(id.client, *local_clock),
+                                    offset.abs() as u32,
+                                ),
+                                0,
+                            );
+                        }
+                        txn.integrate(stack_head, 0);
+                        *local_clock = (*local_clock).max(id.clock + len);
                     }
                 }
-
-                // iterate to next stackHead
-                if !stack.is_empty() {
-                    stack_head = stack.pop();
-                } else {
-                    match current_target.take() {
-                        Some(v) if !v.is_empty() => {
-                            stack_head = v.pop_front();
-                            current_target = Some(v);
-                        }
-                        _ => {
-                            if let Some((client_id, target)) =
-                                Self::next_target(&mut client_block_ref_ids, &mut self.blocks)
-                            {
-                                stack_head = target.pop_front();
-                                current_client_id = client_id;
-                                current_target = Some(target);
-                            } else {
-                                // we're done
-                                break;
-                            }
-                        }
-                    };
-                }
+                next = picker.next();
             }
-
-            if remaining.is_empty() {
-                None
-            } else {
-                Some(PendingUpdate {
-                    update: Update {
-                        blocks: remaining,
-                        delete_set: IdSet::new(),
-                    },
-                    missing: missing_sv,
-                })
-            }
+            picker.pending()
         };
 
         let remaining_ds = txn.apply_delete(&self.delete_set).map(|ds| {
@@ -427,17 +378,20 @@ impl Update {
         Ok((remaining_blocks, remaining_ds))
     }
 
-    fn missing(block: &Block, store: &BlockStore) -> Option<ClientID> {
+    fn missing_dependency(
+        block: &mut Block,
+        store: &mut Store,
+    ) -> Result<Option<ClientID>, UpdateError> {
         if let Block::Item(item) = block {
             if let Some(origin_left) = &item.origin {
-                if store.is_missing(origin_left) {
-                    return Some(origin_left.client);
+                if store.blocks.is_missing(origin_left) {
+                    return Ok(Some(origin_left.client));
                 }
             }
 
             if let Some(origin_right) = &item.right_origin {
-                if store.is_missing(origin_right) {
-                    return Some(origin_right.client);
+                if store.blocks.is_missing(origin_right) {
+                    return Ok(Some(origin_right.client));
                 }
             }
 
@@ -445,34 +399,34 @@ impl Update {
                 TypePtr::Branch(parent) => {
                     if let Some(block) = &parent.item {
                         let parent_id = block.id();
-                        if store.is_missing(parent_id) {
-                            return Some(parent_id.client);
+                        if store.blocks.is_missing(parent_id) {
+                            return Ok(Some(parent_id.client));
                         }
                     }
                 }
                 TypePtr::ID(parent_id) => {
-                    if store.is_missing(parent_id) {
-                        return Some(parent_id.client);
+                    if store.blocks.is_missing(parent_id) {
+                        return Ok(Some(parent_id.client));
                     }
                 }
                 _ => {}
             }
 
+            #[cfg(feature = "weak")]
             match &item.content {
                 ItemContent::Type(branch) => {
-                    #[cfg(feature = "weak")]
                     if let crate::types::TypeRef::WeakLink(source) = &branch.type_ref {
                         let start = source.quote_start.id();
                         let end = source.quote_end.id();
                         if let Some(start) = start {
-                            if store.is_missing(start) {
-                                return Some(start.client);
+                            if store.blocks.is_missing(start) {
+                                return Ok(Some(start.client));
                             }
                         }
                         if start != end {
                             if let Some(end) = &source.quote_end.id() {
-                                if store.is_missing(end) {
-                                    return Some(end.client);
+                                if store.blocks.is_missing(end) {
+                                    return Ok(Some(end.client));
                                 }
                             }
                         }
@@ -480,8 +434,70 @@ impl Update {
                 }
                 _ => { /* do nothing */ }
             }
+
+            // We have all missing ids, now find the items
+            if let Some(origin) = item.origin.as_ref() {
+                item.left = store
+                    .blocks
+                    .get_item_clean_end(origin)
+                    .map(|slice| store.materialize(slice));
+            }
+
+            if let Some(origin) = item.right_origin.as_ref() {
+                item.right = store
+                    .blocks
+                    .get_item_clean_start(origin)
+                    .map(|slice| store.materialize(slice));
+            }
+
+            // We have all missing ids, now find the items
+
+            // In the original Y.js algorithm we decoded items as we go and attached them to client
+            // block list. During that process if we had right origin but no left, we made a lookup for
+            // right origin's parent and attach it as a parent of current block.
+            //
+            // Here since we decode all blocks first, then apply them, we might not find them in
+            // the block store during decoding. Therefore, we retroactively reattach it here.
+
+            item.parent = match &item.parent {
+                TypePtr::Branch(branch_ptr) => TypePtr::Branch(*branch_ptr),
+                TypePtr::Unknown => match (item.left, item.right) {
+                    (Some(left), _) if left.parent != TypePtr::Unknown => {
+                        item.parent_sub = left.parent_sub.clone();
+                        left.parent.clone()
+                    }
+                    (_, Some(right)) if right.parent != TypePtr::Unknown => {
+                        item.parent_sub = right.parent_sub.clone();
+                        right.parent.clone()
+                    }
+                    _ => TypePtr::Unknown,
+                },
+                TypePtr::Named(name) => {
+                    let branch = store.get_or_create_type(name.clone(), TypeRef::Undefined);
+                    TypePtr::Branch(branch)
+                }
+                TypePtr::ID(id) => {
+                    let ptr = store.blocks.get_item(id);
+                    if let Some(item) = ptr {
+                        match &item.content {
+                            ItemContent::Type(branch) => {
+                                TypePtr::Branch(BranchPtr::from(branch.as_ref()))
+                            }
+                            ItemContent::Deleted(_) => TypePtr::Unknown,
+                            other => {
+                                return Err(UpdateError::InvalidParent(
+                                    id.clone(),
+                                    other.get_ref_number(),
+                                ))
+                            }
+                        }
+                    } else {
+                        TypePtr::Unknown
+                    }
+                }
+            };
         }
-        None
+        Ok(None)
     }
 
     fn next_target<'a, 'b>(
@@ -840,6 +856,98 @@ impl Decode for Update {
         // read delete set
         let delete_set = IdSet::decode(decoder)?;
         Ok(Update { blocks, delete_set })
+    }
+}
+
+struct BlockPicker<'a> {
+    store: &'a mut BlockSet,
+    latest: Option<(ClientID, VecDeque<Block>)>,
+    stack: Vec<Block>,
+    /// Order in which clients in `store` should be accessed. Ordered by ClientID asc, works as stack.
+    clients: SmallVec<[ClientID; 2]>,
+    /// State vector for retrieving clock data about missing updates.
+    missing: StateVector,
+    /// Blocks from the original update that couldn't be applied.
+    unapplicable: BlockSet,
+}
+
+impl<'a> BlockPicker<'a> {
+    fn new(store: &'a mut BlockSet) -> Self {
+        let mut clients: SmallVec<[ClientID; 2]> = store.clients.keys().copied().collect();
+        clients.sort();
+        BlockPicker {
+            store,
+            clients,
+            missing: StateVector::default(),
+            latest: None,
+            stack: vec![],
+            unapplicable: BlockSet::default(),
+        }
+    }
+
+    fn next(&mut self) -> Option<Block> {
+        match self.stack.pop() {
+            None => match &mut self.latest {
+                Some((_, latest)) if !latest.is_empty() => latest.pop_front(),
+                _ => {
+                    let next = self.clients.pop()?;
+                    self.latest = self.store.clients.remove_entry(&next);
+                    self.next()
+                }
+            },
+            block => block,
+        }
+    }
+
+    /// Switch iterator to blocks belonging to `missing` client.
+    fn switch(
+        &mut self,
+        stack_head: Block,
+        missing: &ClientID,
+        missing_clock: impl Fn(&ClientID) -> u32,
+    ) -> Option<Block> {
+        self.stack.push(stack_head);
+        match self.store.clients.get_mut(missing) {
+            Some(struct_refs)
+                if !struct_refs.is_empty() && !self.stack.iter().any(|s| s.client() == missing) =>
+            {
+                let stack_head = struct_refs.pop_front();
+                stack_head
+            }
+            _ => {
+                // This update message causally depends on another update message that doesn't exist yet
+                self.missing.set_min(*missing, missing_clock(missing));
+                for item in self.stack.drain(..) {
+                    let client = *item.client();
+                    let unapplicable_blocks = match self.store.clients.remove(&client) {
+                        Some(mut blocks) => {
+                            blocks.push_front(item);
+                            blocks
+                        }
+                        // item was the last item on clientsStructRefs and the field was already cleared. Add item to restStructs and continue
+                        None => VecDeque::from([item]),
+                    };
+                    self.unapplicable
+                        .clients
+                        .insert(client, unapplicable_blocks);
+                }
+                self.next()
+            }
+        }
+    }
+
+    fn pending(self) -> Option<PendingUpdate> {
+        if self.unapplicable.is_empty() {
+            None
+        } else {
+            Some(PendingUpdate {
+                update: Update {
+                    blocks: self.unapplicable,
+                    delete_set: IdSet::new(),
+                },
+                missing: self.missing,
+            })
+        }
     }
 }
 

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -117,7 +117,7 @@ impl Update {
             let mut iter = blocks.iter();
             while let Some(block) = iter.next() {
                 let range = block.range();
-                if range.id.clock <= clock && range.id.clock + range.len > clock {
+                if range.clock <= clock && range.clock + range.len > clock {
                     // this block overlaps or extends current state. It must NOT be Skip
                     // in order to introduce any new changes
                     if !block.is_skip() {
@@ -182,7 +182,7 @@ impl Update {
                         insertions.insert(item.id, item.len);
                     }
                     BlockCarrier::GC(range) if include_deleted => {
-                        insertions.insert(range.id, range.len);
+                        insertions.insert(range.id(), range.len);
                     }
                     _ => {}
                 }
@@ -276,7 +276,7 @@ impl Update {
 
             while let Some(mut block) = stack_head {
                 if !block.is_skip() {
-                    let id = *block.id();
+                    let id = block.id();
                     if local_sv.contains(&id) {
                         let offset = local_sv.get(&id.client) as i32 - id.clock as i32;
                         if let Some(dep) = Self::missing(&block, &local_sv) {
@@ -505,11 +505,11 @@ impl Update {
         match info {
             BLOCK_SKIP_REF_NUMBER => {
                 let len: u32 = decoder.read_var()?;
-                Ok(Some(BlockCarrier::Skip(BlockRange { id, len })))
+                Ok(Some(BlockCarrier::Skip(BlockRange::new(id, len))))
             }
             BLOCK_GC_REF_NUMBER => {
                 let len: u32 = decoder.read_len()?;
-                Ok(Some(BlockCarrier::GC(BlockRange { id, len })))
+                Ok(Some(BlockCarrier::GC(BlockRange::new(id, len))))
             }
             info => {
                 let cant_copy_parent_info = info & (HAS_ORIGIN | HAS_RIGHT_ORIGIN) == 0;
@@ -712,7 +712,7 @@ impl Update {
                     let skip = match curr_write.unwrap_or_else(|| unreachable!()) {
                         BlockCarrier::Skip(mut skip) => {
                             // extend existing skip
-                            skip.len = curr_block.id().clock + curr_block.len() - skip.id.clock;
+                            skip.len = curr_block.id().clock + curr_block.len() - skip.clock;
                             skip
                         }
                         other => {
@@ -892,11 +892,11 @@ impl BlockCarrier {
             (_, _) => false,
         }
     }
-    pub(crate) fn id(&self) -> &ID {
+    pub(crate) fn id(&self) -> ID {
         match self {
-            BlockCarrier::Item(x) => x.id(),
-            BlockCarrier::Skip(x) => &x.id,
-            BlockCarrier::GC(x) => &x.id,
+            BlockCarrier::Item(x) => *x.id(),
+            BlockCarrier::Skip(x) => x.id(),
+            BlockCarrier::GC(x) => x.id(),
         }
     }
 

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -496,6 +496,9 @@ pub struct DocOptions {
 
     #[serde(alias = "shouldLoad", default)]
     pub should_load: Option<bool>,
+
+    #[serde(alias = "isSuggestionDoc", default)]
+    pub is_suggestion_doc: Option<bool>,
 }
 
 impl DocOptions {
@@ -517,6 +520,9 @@ impl DocOptions {
         }
         if let Some(value) = self.should_load {
             options.should_load = value;
+        }
+        if let Some(value) = self.is_suggestion_doc {
+            options.cleanup_formatting = !value;
         }
     }
 }


### PR DESCRIPTION
- `BlockCell`/`BlockCarrier` are now merged into one enum `Block`.
-  Heavily modified `apply_update` and `Block::integrate` logic. It also now matches yjs v14 behaviour.
- `Store.skips`: now out of order blocks can be integrated (the missing spaces will be automatically filled with `Block::Skip`.
- `Transaction.insert_set` to represent inserted elements.