### PR TITLE
FnMut observer callbacks

### DIFF
--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -32,7 +32,7 @@ unsafe impl Sync for BranchPtr {}
 
 impl BranchPtr {
     pub(crate) fn trigger(
-        &self,
+        &mut self,
         txn: &TransactionMut,
         subs: HashSet<Option<Arc<str>>>,
     ) -> Option<Event> {
@@ -41,7 +41,7 @@ impl BranchPtr {
         Some(e)
     }
 
-    pub(crate) fn trigger_deep(&self, txn: &TransactionMut, e: &Events) {
+    pub(crate) fn trigger_deep(&mut self, txn: &TransactionMut, e: &Events) {
         self.deep_observers.trigger(|fun| fun(txn, e));
     }
 }
@@ -217,14 +217,14 @@ pub struct Branch {
 }
 
 #[cfg(feature = "sync")]
-type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + Send + Sync + 'static>;
+type ObserveFn = Box<dyn FnMut(&TransactionMut, &Event) + Send + Sync + 'static>;
 #[cfg(feature = "sync")]
-type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + Send + Sync + 'static>;
+type DeepObserveFn = Box<dyn FnMut(&TransactionMut, &Events) + Send + Sync + 'static>;
 
 #[cfg(not(feature = "sync"))]
-type ObserveFn = Box<dyn Fn(&TransactionMut, &Event) + 'static>;
+type ObserveFn = Box<dyn FnMut(&TransactionMut, &Event) + 'static>;
 #[cfg(not(feature = "sync"))]
-type DeepObserveFn = Box<dyn Fn(&TransactionMut, &Events) + 'static>;
+type DeepObserveFn = Box<dyn FnMut(&TransactionMut, &Events) + 'static>;
 
 impl std::fmt::Debug for Branch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -526,7 +526,7 @@ impl Branch {
     #[cfg(feature = "sync")]
     pub fn observe<F>(&mut self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Event) + Send + Sync + 'static,
     {
         self.observers.subscribe(Box::new(f))
     }
@@ -534,16 +534,15 @@ impl Branch {
     #[cfg(not(feature = "sync"))]
     pub fn observe<F>(&mut self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Event) + 'static,
+        F: FnMut(&TransactionMut, &Event) + 'static,
     {
         self.observers.subscribe(Box::new(f))
     }
 
     #[cfg(feature = "sync")]
-
     pub fn observe_with<F>(&mut self, key: Origin, f: F)
     where
-        F: Fn(&TransactionMut, &Event) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Event) + Send + Sync + 'static,
     {
         self.observers.subscribe_with(key, Box::new(f))
     }
@@ -551,43 +550,43 @@ impl Branch {
     #[cfg(not(feature = "sync"))]
     pub fn observe_with<F>(&mut self, key: Origin, f: F)
     where
-        F: Fn(&TransactionMut, &Event) + 'static,
+        F: FnMut(&TransactionMut, &Event) + 'static,
     {
         self.observers.subscribe_with(key, Box::new(f))
     }
 
     pub fn unobserve(&mut self, key: &Origin) -> bool {
-        self.observers.unsubscribe(&key)
+        self.observers.unsubscribe(key)
     }
 
     #[cfg(feature = "sync")]
-    pub fn observe_deep<F>(&self, f: F) -> Subscription
+    pub fn observe_deep<F>(&mut self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Events) + Send + Sync + 'static,
     {
         self.deep_observers.subscribe(Box::new(f))
     }
 
     #[cfg(not(feature = "sync"))]
-    pub fn observe_deep<F>(&self, f: F) -> Subscription
+    pub fn observe_deep<F>(&mut self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Events) + 'static,
+        F: FnMut(&TransactionMut, &Events) + 'static,
     {
         self.deep_observers.subscribe(Box::new(f))
     }
 
     #[cfg(feature = "sync")]
-    pub fn observe_deep_with<F>(&self, key: Origin, f: F)
+    pub fn observe_deep_with<F>(&mut self, key: Origin, f: F)
     where
-        F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Events) + Send + Sync + 'static,
     {
         self.deep_observers.subscribe_with(key, Box::new(f))
     }
 
     #[cfg(not(feature = "sync"))]
-    pub fn observe_deep_with<F>(&self, key: Origin, f: F)
+    pub fn observe_deep_with<F>(&mut self, key: Origin, f: F)
     where
-        F: Fn(&TransactionMut, &Events) + 'static,
+        F: FnMut(&TransactionMut, &Events) + 'static,
     {
         self.deep_observers.subscribe_with(key, Box::new(f))
     }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -601,6 +601,111 @@ impl Doc {
         Ok(events.after_transaction_events.unsubscribe(&key.into()))
     }
 
+    /// Subscribe a callback that fires after the transaction body completes but before
+    /// type-level observers are triggered. This is used by attribution managers to update
+    /// their internal state before any observer reads attribution data.
+    #[cfg(feature = "sync")]
+    pub fn observe_before_observer_calls<F>(
+        &self,
+        f: F,
+    ) -> Result<Subscription, TransactionAcqError>
+    where
+        F: Fn(&TransactionMut) + Send + Sync + 'static,
+    {
+        let mut store = self
+            .store
+            .try_write()
+            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+        let events = store.events.get_or_init();
+        Ok(events
+            .before_observer_calls_events
+            .subscribe(Box::new(f)))
+    }
+
+    /// Subscribe a callback that fires after the transaction body completes but before
+    /// type-level observers are triggered. This is used by attribution managers to update
+    /// their internal state before any observer reads attribution data.
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_before_observer_calls<F>(
+        &self,
+        f: F,
+    ) -> Result<Subscription, TransactionAcqError>
+    where
+        F: Fn(&TransactionMut) + 'static,
+    {
+        let mut store = self
+            .store
+            .try_write()
+            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+        let events = store.events.get_or_init();
+        Ok(events
+            .before_observer_calls_events
+            .subscribe(Box::new(f)))
+    }
+
+    /// Subscribe a keyed callback that fires after the transaction body completes but before
+    /// type-level observers are triggered.
+    #[cfg(feature = "sync")]
+    pub fn observe_before_observer_calls_with<K, F>(
+        &self,
+        key: K,
+        f: F,
+    ) -> Result<(), TransactionAcqError>
+    where
+        K: Into<Origin>,
+        F: Fn(&TransactionMut) + Send + Sync + 'static,
+    {
+        let mut store = self
+            .store
+            .try_write()
+            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+        let events = store.events.get_or_init();
+        events
+            .before_observer_calls_events
+            .subscribe_with(key.into(), Box::new(f));
+        Ok(())
+    }
+
+    /// Subscribe a keyed callback that fires after the transaction body completes but before
+    /// type-level observers are triggered.
+    #[cfg(not(feature = "sync"))]
+    pub fn observe_before_observer_calls_with<K, F>(
+        &self,
+        key: K,
+        f: F,
+    ) -> Result<(), TransactionAcqError>
+    where
+        K: Into<Origin>,
+        F: Fn(&TransactionMut) + 'static,
+    {
+        let mut store = self
+            .store
+            .try_write()
+            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+        let events = store.events.get_or_init();
+        events
+            .before_observer_calls_events
+            .subscribe_with(key.into(), Box::new(f));
+        Ok(())
+    }
+
+    pub fn unobserve_before_observer_calls<K>(
+        &self,
+        key: K,
+    ) -> Result<bool, TransactionAcqError>
+    where
+        K: Into<Origin>,
+    {
+        let mut store = self
+            .store
+            .try_write()
+            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+        let events = store.events.get_or_init();
+        Ok(events
+            .before_observer_calls_events
+            .unsubscribe(&key.into()))
+    }
+
     /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
     /// [Doc] will request a load.
     #[cfg(feature = "sync")]

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -341,7 +341,7 @@ impl Doc {
         /// if necessary or passed to remote peers right away. This callback is triggered on
         /// function commit.
         observe_update_v1, observe_update_v1_with, unobserve_update_v1,
-        update_v1_events, Fn(&TransactionMut, &UpdateEvent)
+        update_v1_events, FnMut(&TransactionMut, &UpdateEvent)
     );
 
     define_doc_observer!(
@@ -350,19 +350,19 @@ impl Doc {
         /// if necessary or passed to remote peers right away. This callback is triggered on
         /// function commit.
         observe_update_v2, observe_update_v2_with, unobserve_update_v2,
-        update_v2_events, Fn(&TransactionMut, &UpdateEvent)
+        update_v2_events, FnMut(&TransactionMut, &UpdateEvent)
     );
 
     define_doc_observer!(
         /// Subscribe callback function to updates on the `Doc`. The callback will receive state
         /// updates and deletions when a document transaction is committed.
         observe_transaction_cleanup, observe_transaction_cleanup_with, unobserve_transaction_cleanup,
-        transaction_cleanup_events, Fn(&TransactionMut, &TransactionCleanupEvent)
+        transaction_cleanup_events, FnMut(&TransactionMut, &TransactionCleanupEvent)
     );
 
     define_doc_observer!(
         observe_after_transaction, observe_after_transaction_with, unobserve_after_transaction,
-        after_transaction_events, Fn(&mut TransactionMut)
+        after_transaction_events, FnMut(&mut TransactionMut)
     );
 
     define_doc_observer!(
@@ -370,21 +370,21 @@ impl Doc {
         /// type-level observers are triggered. This is used by attribution managers to update
         /// their internal state before any observer reads attribution data.
         observe_before_observer_calls, observe_before_observer_calls_with, unobserve_before_observer_calls,
-        before_observer_calls_events, Fn(&TransactionMut)
+        before_observer_calls_events, FnMut(&TransactionMut)
     );
 
     define_doc_observer!(
         /// Subscribe callback function, that will be called whenever a subdocuments inserted in
         /// this [Doc] will request a load.
         observe_subdocs, observe_subdocs_with, unobserve_subdocs,
-        subdocs_events, Fn(&TransactionMut, &SubdocsEvent)
+        subdocs_events, FnMut(&TransactionMut, &SubdocsEvent)
     );
 
     define_doc_observer!(
         /// Subscribe callback function, that will be called whenever a [Doc::destroy] has been
         /// called.
         observe_destroy, observe_destroy_with, unobserve_destroy,
-        destroy_events, Fn(&TransactionMut, &Doc)
+        destroy_events, FnMut(&TransactionMut, &Doc)
     );
 
     /// Sends a load request to a parent document. Works only if current document is a sub-document
@@ -439,7 +439,7 @@ impl Doc {
             }
         }
         // super.destroy(): cleanup the events
-        if let Some(events) = txn.store_mut().events.take() {
+        if let Some(mut events) = txn.store_mut().events.take() {
             events.destroy_events.trigger(|cb| cb(&txn, self));
         }
     }

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -70,6 +70,87 @@ impl TryFrom<Out> for Doc {
     }
 }
 
+/// Generates `observe_*`, `observe_*_with`, and `unobserve_*` methods on [`Doc`] for a given
+/// event. Each event group produces 5 method definitions: sync and non-sync variants of `observe`
+/// and `observe_with`, plus a single `unobserve`.
+macro_rules! define_doc_observer {
+    (
+        $(#[doc = $doc:literal])*
+        $observe:ident, $observe_with:ident, $unobserve:ident,
+        $field:ident, $($bound:tt)+
+    ) => {
+        $(#[doc = $doc])*
+        #[cfg(feature = "sync")]
+        pub fn $observe<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
+        where
+            F: $($bound)+ + Send + Sync + 'static,
+        {
+            let mut store = self
+                .store
+                .try_write()
+                .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+            let events = store.events.get_or_init();
+            Ok(events.$field.subscribe(Box::new(f)))
+        }
+
+        $(#[doc = $doc])*
+        #[cfg(not(feature = "sync"))]
+        pub fn $observe<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
+        where
+            F: $($bound)+ + 'static,
+        {
+            let mut store = self
+                .store
+                .try_write()
+                .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+            let events = store.events.get_or_init();
+            Ok(events.$field.subscribe(Box::new(f)))
+        }
+
+        #[cfg(feature = "sync")]
+        pub fn $observe_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
+        where
+            K: Into<Origin>,
+            F: $($bound)+ + Send + Sync + 'static,
+        {
+            let mut store = self
+                .store
+                .try_write()
+                .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+            let events = store.events.get_or_init();
+            events.$field.subscribe_with(key.into(), Box::new(f));
+            Ok(())
+        }
+
+        #[cfg(not(feature = "sync"))]
+        pub fn $observe_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
+        where
+            K: Into<Origin>,
+            F: $($bound)+ + 'static,
+        {
+            let mut store = self
+                .store
+                .try_write()
+                .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+            let events = store.events.get_or_init();
+            events.$field.subscribe_with(key.into(), Box::new(f));
+            Ok(())
+        }
+
+        pub fn $unobserve<K>(&self, key: K) -> Result<bool, TransactionAcqError>
+        where
+            K: Into<Origin>,
+        {
+            let mut store = self
+                .store
+                .try_write()
+                .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
+            let events = store.events.get_or_init();
+            Ok(events.$field.unsubscribe(&key.into()))
+        }
+    };
+}
+
 impl Doc {
     /// Creates a new document with a randomized client identifier.
     pub fn new() -> Self {
@@ -254,613 +335,57 @@ impl Doc {
         XmlFragmentRef::root(name).get_or_create(&mut self.transact_mut())
     }
 
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v1 encoding and can be decoded using [Update::decode_v1] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Returns a subscription, which will unsubscribe function when dropped.
-    #[cfg(feature = "sync")]
-    pub fn observe_update_v1<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.update_v1_events.subscribe(Box::new(f)))
-    }
+    define_doc_observer!(
+        /// Subscribe callback function for any changes performed within transaction scope. These
+        /// changes are encoded using lib0 v1 encoding and can be decoded using [Update::decode_v1]
+        /// if necessary or passed to remote peers right away. This callback is triggered on
+        /// function commit.
+        observe_update_v1, observe_update_v1_with, unobserve_update_v1,
+        update_v1_events, Fn(&TransactionMut, &UpdateEvent)
+    );
 
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v1 encoding and can be decoded using [Update::decode_v1] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Returns a subscription, which will unsubscribe function when dropped.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_update_v1<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &UpdateEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.update_v1_events.subscribe(Box::new(f)))
-    }
+    define_doc_observer!(
+        /// Subscribe callback function for any changes performed within transaction scope. These
+        /// changes are encoded using lib0 v2 encoding and can be decoded using [Update::decode_v2]
+        /// if necessary or passed to remote peers right away. This callback is triggered on
+        /// function commit.
+        observe_update_v2, observe_update_v2_with, unobserve_update_v2,
+        update_v2_events, Fn(&TransactionMut, &UpdateEvent)
+    );
 
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v1 encoding and can be decoded using [Update::decode_v1] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(feature = "sync")]
-    pub fn observe_update_v1_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .update_v1_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
+    define_doc_observer!(
+        /// Subscribe callback function to updates on the `Doc`. The callback will receive state
+        /// updates and deletions when a document transaction is committed.
+        observe_transaction_cleanup, observe_transaction_cleanup_with, unobserve_transaction_cleanup,
+        transaction_cleanup_events, Fn(&TransactionMut, &TransactionCleanupEvent)
+    );
 
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v1 encoding and can be decoded using [Update::decode_v1] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_update_v1_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &UpdateEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .update_v1_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
+    define_doc_observer!(
+        observe_after_transaction, observe_after_transaction_with, unobserve_after_transaction,
+        after_transaction_events, Fn(&mut TransactionMut)
+    );
 
-    pub fn unobserve_update_v1<K>(&self, key: K) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.update_v1_events.unsubscribe(&key.into()))
-    }
+    define_doc_observer!(
+        /// Subscribe a callback that fires after the transaction body completes but before
+        /// type-level observers are triggered. This is used by attribution managers to update
+        /// their internal state before any observer reads attribution data.
+        observe_before_observer_calls, observe_before_observer_calls_with, unobserve_before_observer_calls,
+        before_observer_calls_events, Fn(&TransactionMut)
+    );
 
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v2 encoding and can be decoded using [Update::decode_v2] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Returns a subscription, which will unsubscribe function when dropped.
-    #[cfg(feature = "sync")]
-    pub fn observe_update_v2<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.update_v2_events.subscribe(Box::new(f)))
-    }
+    define_doc_observer!(
+        /// Subscribe callback function, that will be called whenever a subdocuments inserted in
+        /// this [Doc] will request a load.
+        observe_subdocs, observe_subdocs_with, unobserve_subdocs,
+        subdocs_events, Fn(&TransactionMut, &SubdocsEvent)
+    );
 
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v2 encoding and can be decoded using [Update::decode_v2] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Returns a subscription, which will unsubscribe function when dropped.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_update_v2<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &UpdateEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.update_v2_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v2 encoding and can be decoded using [Update::decode_v2] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(feature = "sync")]
-    pub fn observe_update_v2_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .update_v2_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    /// Subscribe callback function for any changes performed within transaction scope. These
-    /// changes are encoded using lib0 v2 encoding and can be decoded using [Update::decode_v2] if
-    /// necessary or passed to remote peers right away. This callback is triggered on function
-    /// commit.
-    ///
-    /// Provided `key` will be used to identify a subscription, which will be used to unsubscribe.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_update_v2_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &UpdateEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .update_v2_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    pub fn unobserve_update_v2<K>(&self, key: K) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.update_v2_events.unsubscribe(&key.into()))
-    }
-
-    /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
-    /// deletions when a document transaction is committed.
-    #[cfg(feature = "sync")]
-    pub fn observe_transaction_cleanup<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &TransactionCleanupEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.transaction_cleanup_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
-    /// deletions when a document transaction is committed.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_transaction_cleanup<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &TransactionCleanupEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.transaction_cleanup_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
-    /// deletions when a document transaction is committed.
-    #[cfg(feature = "sync")]
-    pub fn observe_transaction_cleanup_with<K, F>(
-        &self,
-        key: K,
-        f: F,
-    ) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &TransactionCleanupEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .transaction_cleanup_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    /// Subscribe callback function to updates on the `Doc`. The callback will receive state updates and
-    /// deletions when a document transaction is committed.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_transaction_cleanup_with<K, F>(
-        &self,
-        key: K,
-        f: F,
-    ) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &TransactionCleanupEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .transaction_cleanup_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    pub fn unobserve_transaction_cleanup<K>(&self, key: K) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.transaction_cleanup_events.unsubscribe(&key.into()))
-    }
-
-    #[cfg(feature = "sync")]
-    pub fn observe_after_transaction<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&mut TransactionMut) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.after_transaction_events.subscribe(Box::new(f)))
-    }
-
-    #[cfg(feature = "sync")]
-    pub fn observe_after_transaction_with<K, F>(
-        &self,
-        key: K,
-        f: F,
-    ) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&mut TransactionMut) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .after_transaction_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_after_transaction_with<K, F>(
-        &self,
-        key: K,
-        f: F,
-    ) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&mut TransactionMut) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .after_transaction_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    pub fn unobserve_after_transaction<K>(&self, key: K) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.after_transaction_events.unsubscribe(&key.into()))
-    }
-
-    /// Subscribe a callback that fires after the transaction body completes but before
-    /// type-level observers are triggered. This is used by attribution managers to update
-    /// their internal state before any observer reads attribution data.
-    #[cfg(feature = "sync")]
-    pub fn observe_before_observer_calls<F>(
-        &self,
-        f: F,
-    ) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events
-            .before_observer_calls_events
-            .subscribe(Box::new(f)))
-    }
-
-    /// Subscribe a callback that fires after the transaction body completes but before
-    /// type-level observers are triggered. This is used by attribution managers to update
-    /// their internal state before any observer reads attribution data.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_before_observer_calls<F>(
-        &self,
-        f: F,
-    ) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events
-            .before_observer_calls_events
-            .subscribe(Box::new(f)))
-    }
-
-    /// Subscribe a keyed callback that fires after the transaction body completes but before
-    /// type-level observers are triggered.
-    #[cfg(feature = "sync")]
-    pub fn observe_before_observer_calls_with<K, F>(
-        &self,
-        key: K,
-        f: F,
-    ) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .before_observer_calls_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    /// Subscribe a keyed callback that fires after the transaction body completes but before
-    /// type-level observers are triggered.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_before_observer_calls_with<K, F>(
-        &self,
-        key: K,
-        f: F,
-    ) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .before_observer_calls_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    pub fn unobserve_before_observer_calls<K>(
-        &self,
-        key: K,
-    ) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events
-            .before_observer_calls_events
-            .unsubscribe(&key.into()))
-    }
-
-    /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
-    /// [Doc] will request a load.
-    #[cfg(feature = "sync")]
-    pub fn observe_subdocs<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &SubdocsEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.subdocs_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
-    /// [Doc] will request a load.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_subdocs<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &SubdocsEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.subdocs_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
-    /// [Doc] will request a load.
-    #[cfg(feature = "sync")]
-    pub fn observe_subdocs_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &SubdocsEvent) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .subdocs_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    /// Subscribe callback function, that will be called whenever a subdocuments inserted in this
-    /// [Doc] will request a load.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_subdocs_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &SubdocsEvent) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .subdocs_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    pub fn unobserve_subdocs<K>(&self, key: K) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.subdocs_events.unsubscribe(&key.into()))
-    }
-
-    /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(feature = "sync")]
-    pub fn observe_destroy<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &Doc) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.destroy_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_destroy<F>(&self, f: F) -> Result<Subscription, TransactionAcqError>
-    where
-        F: Fn(&TransactionMut, &Doc) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.destroy_events.subscribe(Box::new(f)))
-    }
-
-    /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(feature = "sync")]
-    pub fn observe_destroy_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &Doc) + Send + Sync + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .destroy_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
-
-    pub fn unobserve_destroy<K>(&self, key: K) -> Result<bool, TransactionAcqError>
-    where
-        K: Into<Origin>,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        Ok(events.destroy_events.unsubscribe(&key.into()))
-    }
-
-    /// Subscribe callback function, that will be called whenever a [DocRef::destroy] has been called.
-    #[cfg(not(feature = "sync"))]
-    pub fn observe_destroy_with<K, F>(&self, key: K, f: F) -> Result<(), TransactionAcqError>
-    where
-        K: Into<Origin>,
-        F: Fn(&TransactionMut, &Doc) + 'static,
-    {
-        let mut store = self
-            .store
-            .try_write()
-            .ok_or(TransactionAcqError::ExclusiveAcqFailed)?;
-        let events = store.events.get_or_init();
-        events
-            .destroy_events
-            .subscribe_with(key.into(), Box::new(f));
-        Ok(())
-    }
+    define_doc_observer!(
+        /// Subscribe callback function, that will be called whenever a [Doc::destroy] has been
+        /// called.
+        observe_destroy, observe_destroy_with, unobserve_destroy,
+        destroy_events, Fn(&TransactionMut, &Doc)
+    );
 
     /// Sends a load request to a parent document. Works only if current document is a sub-document
     /// of a document.

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -565,7 +565,7 @@
 //!
 //! struct MyProtocol;
 //! impl Protocol for MyProtocol {
-//!     fn missing_handle(&self, awareness: &Awareness, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
+//!     fn missing_handle(&self, awareness: &mut Awareness, tag: u8, data: Vec<u8>) -> Result<Option<Message>, Error> {
 //!         // you can not only override existing message handlers but also define your own
 //!         Ok(Some(Message::Custom(tag, data))) // echo
 //!     }

--- a/yrs/src/observer.rs
+++ b/yrs/src/observer.rs
@@ -1,283 +1,178 @@
-use std::sync::{Arc, Weak};
-
-use arc_swap::{ArcSwapOption, AsRaw, Guard};
+use std::collections::HashMap;
 
 use crate::Origin;
 
-/// Data structure used to handle publish/subscribe callbacks of specific type. Observers perform
-/// subscriber changes in thread-safe manner, using atomic hardware intrinsics.
-pub struct Observer<F> {
-    inner: ArcSwapOption<Inner<F>>,
+#[cfg(feature = "sync")]
+mod pending {
+    use crate::Origin;
+    use std::sync::{Arc, Mutex, Weak};
+
+    #[derive(Clone)]
+    pub(crate) struct PendingRemovals(Arc<Mutex<Vec<Origin>>>);
+
+    impl Default for PendingRemovals {
+        fn default() -> Self {
+            PendingRemovals(Arc::new(Mutex::new(Vec::new())))
+        }
+    }
+
+    impl PendingRemovals {
+        pub fn push(&self, id: Origin) {
+            if let Ok(mut queue) = self.0.lock() {
+                queue.push(id);
+            }
+        }
+
+        pub fn drain(&self) -> Vec<Origin> {
+            match self.0.lock() {
+                Ok(mut queue) => std::mem::take(&mut *queue),
+                Err(_) => Vec::new(),
+            }
+        }
+
+        pub fn downgrade(&self) -> WeakRemovals {
+            WeakRemovals(Arc::downgrade(&self.0))
+        }
+    }
+
+    pub(crate) struct WeakRemovals(Weak<Mutex<Vec<Origin>>>);
+
+    impl WeakRemovals {
+        pub fn push(&self, id: Origin) {
+            if let Some(arc) = self.0.upgrade() {
+                if let Ok(mut queue) = arc.lock() {
+                    queue.push(id);
+                }
+            }
+        }
+    }
 }
 
-impl<F> Observer<F>
-where
-    F: 'static,
-{
+#[cfg(not(feature = "sync"))]
+mod pending {
+    use crate::Origin;
+    use std::cell::RefCell;
+    use std::rc::{Rc, Weak};
+
+    #[derive(Clone)]
+    pub(crate) struct PendingRemovals(Rc<RefCell<Vec<Origin>>>);
+
+    impl Default for PendingRemovals {
+        fn default() -> Self {
+            PendingRemovals(Rc::new(RefCell::new(Vec::new())))
+        }
+    }
+
+    impl PendingRemovals {
+        pub fn push(&self, id: Origin) {
+            self.0.borrow_mut().push(id);
+        }
+
+        pub fn drain(&self) -> Vec<Origin> {
+            std::mem::take(&mut *self.0.borrow_mut())
+        }
+
+        pub fn downgrade(&self) -> WeakRemovals {
+            WeakRemovals(Rc::downgrade(&self.0))
+        }
+    }
+
+    pub(crate) struct WeakRemovals(Weak<RefCell<Vec<Origin>>>);
+
+    impl WeakRemovals {
+        pub fn push(&self, id: Origin) {
+            if let Some(rc) = self.0.upgrade() {
+                rc.borrow_mut().push(id);
+            }
+        }
+    }
+}
+
+use pending::{PendingRemovals, WeakRemovals};
+
+/// Subscription handle returned by [Observer::subscribe], which will unsubscribe the
+/// corresponding callback when dropped.
+pub struct Subscription {
+    id: Origin,
+    pending: WeakRemovals,
+}
+
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        self.pending.push(std::mem::take(&mut self.id));
+    }
+}
+
+#[cfg(feature = "sync")]
+unsafe impl Send for Subscription {}
+#[cfg(feature = "sync")]
+unsafe impl Sync for Subscription {}
+
+/// Data structure used to handle publish/subscribe callbacks of a specific type.
+pub struct Observer<F> {
+    callbacks: HashMap<Origin, F>,
+    pending: PendingRemovals,
+}
+
+impl<F> Observer<F> {
     /// Creates a new [Observer] with no active callbacks.
     pub fn new() -> Self {
         Observer {
-            inner: ArcSwapOption::new(None),
+            callbacks: HashMap::new(),
+            pending: PendingRemovals::default(),
         }
     }
 
+    /// Returns `true` if this observer has any active subscribers.
     pub fn has_subscribers(&self) -> bool {
-        if let Some(inner) = &*self.inner.load() {
-            inner.head.load().is_some()
-        } else {
-            false
+        !self.callbacks.is_empty()
+    }
+
+    /// Subscribes a callback to this observer with an auto-generated key.
+    /// Returns a [Subscription] which will unsubscribe the callback when dropped.
+    pub fn subscribe(&mut self, callback: F) -> Subscription {
+        self.drain_pending();
+        let id = Origin::from(fastrand::usize(0..usize::MAX));
+        self.callbacks.insert(id.clone(), callback);
+        Subscription {
+            id,
+            pending: self.pending.downgrade(),
         }
     }
 
-    /// Cleanup already released subscriptions. Whenever a [Subscription] is dropped, the callback is released. However,
-    /// the weak reference to callback may still be kept around until it becomes touched by operations such as
-    /// [Observer::subscribe] or [Observer::callbacks].
-    ///
-    /// This method allows to perform stale callback cleanup without waiting for callbacks to be visited.
-    pub fn clean(&self) {
-        self.inner.swap(None);
+    /// Subscribes a callback with a specific key. If a callback with the same key already
+    /// exists, it will be replaced.
+    pub fn subscribe_with(&mut self, id: impl Into<Origin>, callback: F) {
+        self.drain_pending();
+        self.callbacks.insert(id.into(), callback);
     }
 
-    fn inner(&self) -> Arc<Inner<F>> {
-        let cur = self.inner.load_full();
-        match cur {
-            Some(inner) => inner,
-            None => {
-                // inner was not initialized yet, we need to create a new one
-                let inner = Arc::new(Inner {
-                    head: ArcSwapOption::new(None),
-                });
-                let old: Option<Arc<Inner<F>>> = None;
-                let prev = self.inner.compare_and_swap(&old, Some(inner.clone()));
-                // there's a slight possibility that inner was initialized twice, in that case
-                // return first swapped inner
-                Guard::into_inner(prev).unwrap_or(inner)
-            }
+    /// Removes a callback by its key. Returns `true` if the callback was found and removed.
+    pub fn unsubscribe(&mut self, id: &Origin) -> bool {
+        self.callbacks.remove(id).is_some()
+    }
+
+    /// Calls `each` for every registered callback, giving mutable access to the callback.
+    pub fn trigger<E: FnMut(&mut F)>(&mut self, mut each: E) {
+        self.drain_pending();
+        for callback in self.callbacks.values_mut() {
+            each(callback);
         }
     }
 
-    fn remove(mut prev: Arc<Node<F>>, id: &Origin) -> bool {
-        while let Some(next) = prev.next.load_full() {
-            if &next.uid == id {
-                prev.next.store(next.next.load_full());
-                return true;
-            }
-            prev = next;
+    fn drain_pending(&mut self) {
+        for id in self.pending.drain() {
+            self.callbacks.remove(&id);
         }
-        false
-    }
-
-    pub fn unsubscribe(&self, id: &Origin) -> bool {
-        if let Some(inner) = &*self.inner.load() {
-            inner.remove(id)
-        } else {
-            false
-        }
-    }
-
-    /// Returns a snapshot of callbacks subscribed to this observer at the moment when this method
-    /// has been called. This snapshot can be iterated over to get access to individual callbacks
-    /// and trigger them.
-    pub fn trigger<E>(&self, mut each: E)
-    where
-        E: FnMut(&F),
-    {
-        if let Some(inner) = &*self.inner.load() {
-            let mut next = inner.head.load();
-            while let Some(node) = &*next {
-                each(&node.callback);
-                next = node.next.load();
-            }
-        }
-    }
-
-    /// Subscribes a callback parameter to a current [Observer].
-    /// Returns a subscription object which - when dropped - will unsubscribe current callback.
-    /// If the `id` was already present in the observer, current callback will be ignored.
-    pub fn subscribe_with(&self, id: Origin, callback: F) {
-        let inner = self.inner();
-        let mut node = Arc::new(Node::new(id.clone(), callback));
-        let cur = inner.head.load();
-        let head = loop {
-            {
-                // update new node next pointer to point to current head
-                // it's safe to unwrap, since until current node is successfully inserted
-                // there will be no more that a single Arc reference to it
-                let n = Arc::get_mut(&mut node).unwrap();
-                n.next.store(cur.clone());
-            }
-
-            let prev = inner.head.compare_and_swap(&*cur, Some(node.clone()));
-            let swapped = std::ptr::eq(prev.as_raw(), cur.as_raw());
-            if swapped {
-                // we successfully swapped the head, we can exit the loop
-                break node;
-            }
-        };
-        // remove all previous nodes that share the same ID
-        Self::remove(head.clone(), &id);
     }
 }
 
-#[cfg(feature = "sync")]
-impl<F> Observer<F>
-where
-    F: Send + Sync + 'static,
-{
-    pub fn subscribe(&self, callback: F) -> Subscription {
-        let mut rng = fastrand::Rng::new();
-        let id = rng.usize(0..usize::MAX);
-        let origin = Origin::from(id);
-        self.subscribe_with(origin.clone(), callback);
-        Arc::new(Cancel {
-            id: origin,
-            inner: Arc::downgrade(&self.inner()),
-        })
-    }
-}
-
-#[cfg(not(feature = "sync"))]
-impl<F> Observer<F>
-where
-    F: 'static,
-{
-    pub fn subscribe(&self, callback: F) -> Subscription {
-        let mut rng = fastrand::Rng::new();
-        let id = rng.usize(0..usize::MAX);
-        let origin = Origin::from(id);
-        self.subscribe_with(origin.clone(), callback);
-        Arc::new(Cancel {
-            id: origin,
-            inner: Arc::downgrade(&self.inner()),
-        })
-    }
-}
-
-#[cfg(feature = "sync")]
-impl<F> Default for Observer<F>
-where
-    F: Send + Sync + 'static,
-{
+impl<F> Default for Observer<F> {
     fn default() -> Self {
-        Observer::new()
+        Self::new()
     }
 }
 
-#[cfg(not(feature = "sync"))]
-impl<F> Default for Observer<F>
-where
-    F: 'static,
-{
-    fn default() -> Self {
-        Observer::new()
-    }
-}
-
-struct Inner<F> {
-    head: ArcSwapOption<Node<F>>,
-}
-
-impl<F> Inner<F>
-where
-    F: 'static,
-{
-    fn remove(&self, id: &Origin) -> bool {
-        while let Some(head) = self.head.load_full() {
-            if &head.uid == id {
-                // the element to remove is the head of the list
-                // we need to swap head pointer of self to the next element
-                let next = head.next.load_full();
-                let prev = self.head.compare_and_swap(&head, next);
-                if !std::ptr::eq(prev.as_raw(), Arc::as_ptr(&head)) {
-                    // head changed, retry
-                    continue;
-                } else {
-                    return true;
-                }
-            } else {
-                // the element to remove is somewhere in the middle of the list
-                // we need to find it and repoint its predecessor's next pointer
-                // to its successor
-                return Observer::remove(head.clone(), id);
-            }
-        }
-        false
-    }
-}
-
-struct Node<T> {
-    uid: Origin,
-    callback: T,
-    next: ArcSwapOption<Node<T>>,
-}
-
-impl<F> Node<F> {
-    fn new(uid: Origin, callback: F) -> Self {
-        Node {
-            uid,
-            callback,
-            next: Default::default(),
-        }
-    }
-}
-
-#[cfg(feature = "sync")]
-struct Cancel<F>
-where
-    F: Send + Sync + 'static,
-{
-    id: Origin,
-    inner: Weak<Inner<F>>,
-}
-
-#[cfg(feature = "sync")]
-impl<F> Drop for Cancel<F>
-where
-    F: Send + Sync + 'static,
-{
-    fn drop(&mut self) {
-        if let Some(inner) = self.inner.upgrade() {
-            inner.remove(&self.id);
-        }
-    }
-}
-
-#[cfg(not(feature = "sync"))]
-struct Cancel<F>
-where
-    F: 'static,
-{
-    id: Origin,
-    inner: Weak<Inner<F>>,
-}
-
-#[cfg(not(feature = "sync"))]
-impl<F> Drop for crate::observer::Cancel<F>
-where
-    F: 'static,
-{
-    fn drop(&mut self) {
-        if let Some(inner) = self.inner.upgrade() {
-            inner.remove(&self.id);
-        }
-    }
-}
-
-/// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
-/// callback when dropped.
-///
-/// If you need to send the Subscription handle to another thread, you may wish to enable
-/// the `sync` feature such that Subscription implements `Send+Sync`.
-#[cfg(feature = "sync")]
-pub type Subscription = Arc<dyn Drop + Send + Sync + 'static>;
-
-/// Subscription handle returned by [Observer::subscribe] methods, which will unsubscribe corresponding
-/// callback when dropped.
-///
-/// If you need to send the Subscription handle to another thread, you may wish to enable
-/// the `sync` feature such that Subscription implements `Send+Sync`.
-#[cfg(not(feature = "sync"))]
-pub type Subscription = Arc<dyn Drop + 'static>;
 
 #[cfg(test)]
 mod test {
@@ -285,10 +180,11 @@ mod test {
     use std::sync::Arc;
 
     use crate::observer::Observer;
+    use crate::Origin;
 
     #[test]
     fn subscription() {
-        let o: Observer<Box<dyn Fn(&u32) + Send + Sync + 'static>> = Observer::new();
+        let mut o: Observer<Box<dyn FnMut(&u32) + Send + Sync + 'static>> = Observer::new();
         let s1_state = Arc::new(AtomicU32::new(0));
         let s2_state = Arc::new(AtomicU32::new(0));
 
@@ -312,8 +208,8 @@ mod test {
             assert_eq!(s2_state.load(Ordering::Acquire), 4);
         }
 
-        // subscriptions were dropped, we don't expect updates to be propagated
-
+        // subscriptions were dropped, pending removals queued
+        // next trigger will drain them
         o.trigger(|fun| fun(&3));
         assert_eq!(s1_state.load(Ordering::Acquire), 2);
         assert_eq!(s2_state.load(Ordering::Acquire), 4);
@@ -321,58 +217,32 @@ mod test {
 
     #[test]
     fn subscribers_predicate() {
-        let o: Observer<Box<dyn Fn(&u32) + Send + Sync + 'static>> = Observer::new();
+        let mut o: Observer<Box<dyn FnMut(&u32) + Send + Sync + 'static>> = Observer::new();
         assert!(!o.has_subscribers());
 
-        let _sub = o.subscribe(Box::new(move |_| {}));
+        let sub = o.subscribe(Box::new(move |_| {}));
         assert!(o.has_subscribers());
 
-        drop(_sub);
-        o.clean();
-
+        drop(sub);
+        o.drain_pending();
         assert!(!o.has_subscribers());
-    }
-
-    #[test]
-    #[cfg(feature = "sync")]
-    fn multi_threading() {
-        let o: Observer<Box<dyn Fn(u32) + Send + Sync + 'static>> = Observer::new();
-
-        let s1_state = Arc::new(AtomicU32::new(0));
-        let a = s1_state.clone();
-        let sub1 = o.subscribe(Box::new(move |v| a.store(v, Ordering::Release)));
-
-        let s2_state = Arc::new(AtomicU32::new(0));
-        let b = s2_state.clone();
-        let sub2 = o.subscribe(Box::new(move |v| b.store(v, Ordering::Release)));
-
-        let handle = std::thread::spawn(move || {
-            o.trigger(|fun| fun(1));
-            drop(sub1);
-            drop(sub2);
-        });
-
-        handle.join().unwrap();
-
-        assert_eq!(s1_state.load(Ordering::Acquire), 1);
-        assert_eq!(s2_state.load(Ordering::Acquire), 1);
     }
 
     #[test]
     fn subscribe_with_replaced_old_callback() {
         let (tx, rx) = std::sync::mpsc::channel();
-        let o: Observer<Box<dyn Fn(u32) + Send + Sync + 'static>> = Observer::new();
+        let mut o: Observer<Box<dyn FnMut(u32) + Send + Sync + 'static>> = Observer::new();
         let ta = tx.clone();
-        let _a = o.subscribe_with(
-            123.into(),
+        o.subscribe_with(
+            123usize,
             Box::new(move |i| ta.send(format!("a-{i}")).unwrap()),
         );
         o.trigger(|fun| fun(1));
         assert_eq!(rx.try_recv().unwrap(), "a-1");
 
         // override the callback with the same key
-        let _b = o.subscribe_with(
-            123.into(),
+        o.subscribe_with(
+            123usize,
             Box::new(move |i| tx.send(format!("b-{i}")).unwrap()),
         );
         o.trigger(|fun| fun(2));
@@ -397,19 +267,20 @@ mod test {
     #[test]
     fn drop_subscription() {
         let counter = Arc::new(AtomicI32::new(0));
-        let o: Observer<DropCounter> = Observer::new();
+        let mut o: Observer<DropCounter> = Observer::new();
         for _ in 0..100 {
             assert_eq!(counter.load(Ordering::SeqCst), 0);
-            let _sub = o.subscribe(DropCounter::new(counter.clone()));
+            let sub = o.subscribe(DropCounter::new(counter.clone()));
             assert_eq!(counter.load(Ordering::SeqCst), 1);
-            // drop subscription
+            drop(sub);
+            o.drain_pending(); // flush deferred removals
         }
     }
 
     #[test]
     fn drop_subscription2() {
         let counter = Arc::new(AtomicI32::new(0));
-        let o: Observer<DropCounter> = Observer::new();
+        let mut o: Observer<DropCounter> = Observer::new();
         let mut subscriptions = Vec::new();
         for _ in 0..100 {
             let sub = o.subscribe(DropCounter::new(counter.clone()));
@@ -417,21 +288,22 @@ mod test {
         }
         assert_eq!(counter.load(Ordering::SeqCst), 100);
         drop(subscriptions);
+        o.drain_pending();
         assert_eq!(counter.load(Ordering::SeqCst), 0);
     }
 
     #[test]
     fn unsubscribe() {
         let counter = Arc::new(AtomicI32::new(0));
-        let o: Observer<DropCounter> = Observer::new();
+        let mut o: Observer<DropCounter> = Observer::new();
         for i in 0..100 {
             assert_eq!(counter.load(Ordering::SeqCst), 0);
 
-            o.subscribe_with(i.into(), DropCounter::new(counter.clone()));
+            o.subscribe_with(i, DropCounter::new(counter.clone()));
 
             assert_eq!(counter.load(Ordering::SeqCst), 1);
 
-            let unsubscribed = o.unsubscribe(&i.into());
+            let unsubscribed = o.unsubscribe(&Origin::from(i));
             assert!(unsubscribed, "unsubscribe failed for {}", i);
         }
     }
@@ -439,31 +311,17 @@ mod test {
     #[test]
     fn unsubscribe2() {
         let counter = Arc::new(AtomicI32::new(0));
-        let o: Observer<DropCounter> = Observer::new();
+        let mut o: Observer<DropCounter> = Observer::new();
         for i in 0..100 {
-            o.subscribe_with(i.into(), DropCounter::new(counter.clone()));
+            o.subscribe_with(i, DropCounter::new(counter.clone()));
         }
 
         assert_eq!(counter.load(Ordering::SeqCst), 100);
 
         for i in 0..100 {
-            let unsubscribed = o.unsubscribe(&i.into());
+            let unsubscribed = o.unsubscribe(&Origin::from(i));
             assert!(unsubscribed, "unsubscribe failed for {}", i);
         }
-        assert_eq!(counter.load(Ordering::SeqCst), 0);
-    }
-
-    #[test]
-    fn clean() {
-        let counter = Arc::new(AtomicI32::new(0));
-        let o: Observer<DropCounter> = Observer::new();
-        let mut subscriptions = Vec::new();
-        for _ in 0..100 {
-            let sub = o.subscribe(DropCounter::new(counter.clone()));
-            subscriptions.push(sub);
-        }
-        assert_eq!(counter.load(Ordering::SeqCst), 100);
-        o.clean();
         assert_eq!(counter.load(Ordering::SeqCst), 0);
     }
 }

--- a/yrs/src/slice.rs
+++ b/yrs/src/slice.rs
@@ -24,7 +24,7 @@ impl BlockSlice {
     pub fn clock_end(&self) -> u32 {
         match self {
             BlockSlice::Item(s) => s.clock_end(),
-            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.clock,
+            BlockSlice::GC(s) | BlockSlice::Skip(s) => s.clock + s.len - 1,
         }
     }
 

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -545,6 +545,8 @@ pub type UpdateFn = Box<dyn Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 's
 pub type SubdocsFn = Box<dyn Fn(&TransactionMut, &SubdocsEvent) + Send + Sync + 'static>;
 #[cfg(feature = "sync")]
 pub type DestroyFn = Box<dyn Fn(&TransactionMut, &Doc) + Send + Sync + 'static>;
+#[cfg(feature = "sync")]
+pub type BeforeObserverCallsFn = Box<dyn Fn(&TransactionMut) + Send + Sync + 'static>;
 
 #[cfg(not(feature = "sync"))]
 pub type TransactionCleanupFn = Box<dyn Fn(&TransactionMut, &TransactionCleanupEvent) + 'static>;
@@ -556,6 +558,8 @@ pub type UpdateFn = Box<dyn Fn(&TransactionMut, &UpdateEvent) + 'static>;
 pub type SubdocsFn = Box<dyn Fn(&TransactionMut, &SubdocsEvent) + 'static>;
 #[cfg(not(feature = "sync"))]
 pub type DestroyFn = Box<dyn Fn(&TransactionMut, &Doc) + 'static>;
+#[cfg(not(feature = "sync"))]
+pub type BeforeObserverCallsFn = Box<dyn Fn(&TransactionMut) + 'static>;
 
 #[derive(Default)]
 pub struct StoreEvents {
@@ -579,6 +583,10 @@ pub struct StoreEvents {
     pub subdocs_events: Observer<SubdocsFn>,
 
     pub destroy_events: Observer<DestroyFn>,
+
+    /// Handles subscriptions for the `beforeObserverCalls` event. Callbacks are called after
+    /// the transaction body completes but before type-level observers are triggered.
+    pub before_observer_calls_events: Observer<BeforeObserverCallsFn>,
 }
 
 impl StoreEvents {
@@ -613,5 +621,10 @@ impl StoreEvents {
             self.transaction_cleanup_events
                 .trigger(|fun| fun(txn, &event));
         }
+    }
+
+    pub fn emit_before_observer_calls(&self, txn: &TransactionMut) {
+        self.before_observer_calls_events
+            .trigger(|fun| fun(txn));
     }
 }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -537,13 +537,16 @@ impl<'doc> Iterator for SubdocGuids<'doc> {
 macro_rules! define_event_type {
     ($name:ident ($($args:tt)*)) => {
         #[cfg(feature = "sync")]
-        pub type $name = Box<dyn Fn($($args)*) + Send + Sync + 'static>;
+        pub type $name = Box<dyn FnMut($($args)*) + Send + Sync + 'static>;
         #[cfg(not(feature = "sync"))]
-        pub type $name = Box<dyn Fn($($args)*) + 'static>;
+        pub type $name = Box<dyn FnMut($($args)*) + 'static>;
     };
 }
 
-define_event_type!(TransactionCleanupFn(&TransactionMut, &TransactionCleanupEvent));
+define_event_type!(TransactionCleanupFn(
+    &TransactionMut,
+    &TransactionCleanupEvent
+));
 define_event_type!(AfterTransactionFn(&mut TransactionMut));
 define_event_type!(UpdateFn(&TransactionMut, &UpdateEvent));
 define_event_type!(SubdocsFn(&TransactionMut, &SubdocsEvent));
@@ -579,10 +582,9 @@ pub struct StoreEvents {
 }
 
 impl StoreEvents {
-    pub fn emit_update_v1(&self, txn: &TransactionMut) {
+    pub fn emit_update_v1(&mut self, txn: &TransactionMut) {
         if self.update_v1_events.has_subscribers() {
             if !txn.delete_set.is_empty() || txn.after_state() != txn.before_state() {
-                // produce update only if anything changed
                 let update = UpdateEvent::new_v1(txn);
                 self.update_v1_events
                     .trigger(|callback| callback(txn, &update));
@@ -590,21 +592,20 @@ impl StoreEvents {
         }
     }
 
-    pub fn emit_update_v2(&self, txn: &TransactionMut) {
+    pub fn emit_update_v2(&mut self, txn: &TransactionMut) {
         if self.update_v2_events.has_subscribers() {
             if !txn.delete_set.is_empty() || txn.after_state() != txn.before_state() {
-                // produce update only if anything changed
                 let update = UpdateEvent::new_v2(txn);
                 self.update_v2_events.trigger(|fun| fun(txn, &update));
             }
         }
     }
 
-    pub fn emit_after_transaction(&self, txn: &mut TransactionMut) {
+    pub fn emit_after_transaction(&mut self, txn: &mut TransactionMut) {
         self.after_transaction_events.trigger(|fun| fun(txn));
     }
 
-    pub fn emit_transaction_cleanup(&self, txn: &TransactionMut) {
+    pub fn emit_transaction_cleanup(&mut self, txn: &TransactionMut) {
         if self.transaction_cleanup_events.has_subscribers() {
             let event = TransactionCleanupEvent::new(txn);
             self.transaction_cleanup_events
@@ -612,8 +613,7 @@ impl StoreEvents {
         }
     }
 
-    pub fn emit_before_observer_calls(&self, txn: &TransactionMut) {
-        self.before_observer_calls_events
-            .trigger(|fun| fun(txn));
+    pub fn emit_before_observer_calls(&mut self, txn: &TransactionMut) {
+        self.before_observer_calls_events.trigger(|fun| fun(txn));
     }
 }

--- a/yrs/src/store.rs
+++ b/yrs/src/store.rs
@@ -534,32 +534,21 @@ impl<'doc> Iterator for SubdocGuids<'doc> {
     }
 }
 
-#[cfg(feature = "sync")]
-pub type TransactionCleanupFn =
-    Box<dyn Fn(&TransactionMut, &TransactionCleanupEvent) + Send + Sync + 'static>;
-#[cfg(feature = "sync")]
-pub type AfterTransactionFn = Box<dyn Fn(&mut TransactionMut) + Send + Sync + 'static>;
-#[cfg(feature = "sync")]
-pub type UpdateFn = Box<dyn Fn(&TransactionMut, &UpdateEvent) + Send + Sync + 'static>;
-#[cfg(feature = "sync")]
-pub type SubdocsFn = Box<dyn Fn(&TransactionMut, &SubdocsEvent) + Send + Sync + 'static>;
-#[cfg(feature = "sync")]
-pub type DestroyFn = Box<dyn Fn(&TransactionMut, &Doc) + Send + Sync + 'static>;
-#[cfg(feature = "sync")]
-pub type BeforeObserverCallsFn = Box<dyn Fn(&TransactionMut) + Send + Sync + 'static>;
+macro_rules! define_event_type {
+    ($name:ident ($($args:tt)*)) => {
+        #[cfg(feature = "sync")]
+        pub type $name = Box<dyn Fn($($args)*) + Send + Sync + 'static>;
+        #[cfg(not(feature = "sync"))]
+        pub type $name = Box<dyn Fn($($args)*) + 'static>;
+    };
+}
 
-#[cfg(not(feature = "sync"))]
-pub type TransactionCleanupFn = Box<dyn Fn(&TransactionMut, &TransactionCleanupEvent) + 'static>;
-#[cfg(not(feature = "sync"))]
-pub type AfterTransactionFn = Box<dyn Fn(&mut TransactionMut) + 'static>;
-#[cfg(not(feature = "sync"))]
-pub type UpdateFn = Box<dyn Fn(&TransactionMut, &UpdateEvent) + 'static>;
-#[cfg(not(feature = "sync"))]
-pub type SubdocsFn = Box<dyn Fn(&TransactionMut, &SubdocsEvent) + 'static>;
-#[cfg(not(feature = "sync"))]
-pub type DestroyFn = Box<dyn Fn(&TransactionMut, &Doc) + 'static>;
-#[cfg(not(feature = "sync"))]
-pub type BeforeObserverCallsFn = Box<dyn Fn(&TransactionMut) + 'static>;
+define_event_type!(TransactionCleanupFn(&TransactionMut, &TransactionCleanupEvent));
+define_event_type!(AfterTransactionFn(&mut TransactionMut));
+define_event_type!(UpdateFn(&TransactionMut, &UpdateEvent));
+define_event_type!(SubdocsFn(&TransactionMut, &SubdocsEvent));
+define_event_type!(DestroyFn(&TransactionMut, &Doc));
+define_event_type!(BeforeObserverCallsFn(&TransactionMut));
 
 #[derive(Default)]
 pub struct StoreEvents {

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -15,10 +15,11 @@ use crate::{Doc, Observer, Origin};
 const NULL_STR: &str = "null";
 
 #[cfg(feature = "sync")]
-type AwarenessUpdateFn = Box<dyn Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static>;
+type AwarenessUpdateFn =
+    Box<dyn FnMut(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static>;
 
 #[cfg(not(feature = "sync"))]
-type AwarenessUpdateFn = Box<dyn Fn(&Awareness, &Event, Option<&Origin>) + 'static>;
+type AwarenessUpdateFn = Box<dyn FnMut(&Awareness, &Event, Option<&Origin>) + 'static>;
 
 /// The Awareness class implements a simple shared state protocol that can be used for non-persistent
 /// data like awareness information (cursor, username, status, ..). Each client can update its own
@@ -65,92 +66,86 @@ impl Awareness {
         }
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    /// Subscribe to awareness update events.
     #[cfg(feature = "sync")]
-    pub fn on_update<F>(&self, f: F) -> crate::Subscription
+    pub fn on_update<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
         self.on_update.subscribe(Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    /// Subscribe to awareness update events.
     #[cfg(not(feature = "sync"))]
-    pub fn on_update<F>(&self, f: F) -> crate::Subscription
+    pub fn on_update<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + 'static,
     {
         self.on_update.subscribe(Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
     #[cfg(feature = "sync")]
-    pub fn on_update_with<K, F>(&self, key: K, f: F)
+    pub fn on_update_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
         self.on_update.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
     #[cfg(not(feature = "sync"))]
-    pub fn on_update_with<K, F>(&self, key: K, f: F)
+    pub fn on_update_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + 'static,
     {
         self.on_update.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    pub fn unobserve_update<K>(&self, key: K) -> bool
+    pub fn unobserve_update<K>(&mut self, key: K) -> bool
     where
         K: Into<Origin>,
     {
         self.on_update.unsubscribe(&key.into())
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    /// Subscribe to awareness change events.
     #[cfg(feature = "sync")]
-    pub fn on_change<F>(&self, f: F) -> crate::Subscription
+    pub fn on_change<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
         self.on_change.subscribe(Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
+    /// Subscribe to awareness change events.
     #[cfg(not(feature = "sync"))]
-    pub fn on_change<F>(&self, f: F) -> crate::Subscription
+    pub fn on_change<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + 'static,
     {
         self.on_change.subscribe(Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
     #[cfg(feature = "sync")]
-    pub fn on_change_with<K, F>(&self, key: K, f: F)
+    pub fn on_change_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + Send + Sync + 'static,
     {
         self.on_change.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
     #[cfg(not(feature = "sync"))]
-    pub fn on_change_with<K, F>(&self, key: K, f: F)
+    pub fn on_change_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&Awareness, &Event, Option<&Origin>) + 'static,
+        F: FnMut(&Awareness, &Event, Option<&Origin>) + 'static,
     {
         self.on_change.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Returns a channel receiver for an incoming awareness events. This channel can be cloned.
-    pub fn unobserve_change<K>(&self, key: K) -> bool
+    pub fn unobserve_change<K>(&mut self, key: K) -> bool
     where
         K: Into<Origin>,
     {
@@ -193,7 +188,7 @@ impl Awareness {
     }
 
     /// Clears out a state of a given client, effectively marking it as disconnected.
-    pub fn remove_state(&self, client_id: ClientID) {
+    pub fn remove_state(&mut self, client_id: ClientID) {
         let is_removed = match self.states.entry(client_id) {
             Entry::Occupied(mut e) => {
                 let state = e.get_mut();
@@ -208,8 +203,12 @@ impl Awareness {
         };
         if is_removed && self.on_update.has_subscribers() || self.on_change.has_subscribers() {
             let e = Event::new(Vec::default(), Vec::default(), vec![client_id]);
-            self.on_change.trigger(|fun| fun(self, &e, None));
-            self.on_update.trigger(|fun| fun(self, &e, None));
+            let mut on_change = std::mem::take(&mut self.on_change);
+            on_change.trigger(|fun| fun(self, &e, None));
+            self.on_change = on_change;
+            let mut on_update = std::mem::take(&mut self.on_update);
+            on_update.trigger(|fun| fun(self, &e, None));
+            self.on_update = on_update;
         }
     }
 
@@ -228,7 +227,7 @@ impl Awareness {
 
     /// Clears out a state of a current client (see: [Awareness::client_id]),
     /// effectively marking it as disconnected.
-    pub fn clean_local_state(&self) {
+    pub fn clean_local_state(&mut self) {
         let client_id = self.doc.client_id();
         self.remove_state(client_id);
     }
@@ -236,7 +235,7 @@ impl Awareness {
     /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
     /// be replicated to other clients as part of the [AwarenessUpdate] and it will trigger an event
     /// to be emitted if current instance was created using [Awareness::with_observer] method.
-    pub fn set_local_state<S: Serialize>(&self, state: S) -> Result<(), Error> {
+    pub fn set_local_state<S: Serialize>(&mut self, state: S) -> Result<(), Error> {
         let json = serde_json::to_string(&state)?;
         self.set_local_state_raw(json);
         Ok(())
@@ -245,7 +244,7 @@ impl Awareness {
     /// Sets a current [Awareness] instance state to a corresponding JSON string. This state will
     /// be replicated to other clients as part of the [AwarenessUpdate] and it will trigger an event
     /// to be emitted if current instance was created using [Awareness::with_observer] method.
-    pub fn set_local_state_raw<S: Into<Arc<str>>>(&self, json: S) {
+    pub fn set_local_state_raw<S: Into<Arc<str>>>(&mut self, json: S) {
         let client_id = self.doc.client_id();
         let now = self.clock.now();
         let json = json.into();
@@ -265,7 +264,7 @@ impl Awareness {
     }
 
     fn notify_subscribers(
-        &self,
+        &mut self,
         client_id: ClientID,
         prev_state: Option<Arc<str>>,
         curr_state: Arc<str>,
@@ -285,11 +284,15 @@ impl Awareness {
             }
             let mut e = Event::new(added, changed, Vec::default());
             if !e.is_empty() {
-                self.on_change.trigger(|fun| fun(self, &e, None));
+                let mut on_change = std::mem::take(&mut self.on_change);
+                on_change.trigger(|fun| fun(self, &e, None));
+                self.on_change = on_change;
             }
             e.summary.updated = updated;
             if !e.is_empty() {
-                self.on_update.trigger(|fun| fun(self, &e, None));
+                let mut on_update = std::mem::take(&mut self.on_update);
+                on_update.trigger(|fun| fun(self, &e, None));
+                self.on_update = on_update;
             }
         }
     }
@@ -337,7 +340,7 @@ impl Awareness {
     ///
     /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
     /// changes will also be emitted as events.
-    pub fn apply_update(&self, update: AwarenessUpdate) -> Result<(), Error> {
+    pub fn apply_update(&mut self, update: AwarenessUpdate) -> Result<(), Error> {
         let gen_summary = self.on_update.has_subscribers() || self.on_change.has_subscribers();
         self.apply_update_internal(update, None, gen_summary)?;
         Ok(())
@@ -349,7 +352,7 @@ impl Awareness {
     /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
     /// changes will also be emitted as events.
     pub fn apply_update_with<O: Into<Origin>>(
-        &self,
+        &mut self,
         update: AwarenessUpdate,
         origin: O,
     ) -> Result<(), Error> {
@@ -365,7 +368,7 @@ impl Awareness {
     /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
     /// changes will also be emitted as events.
     pub fn apply_update_summary(
-        &self,
+        &mut self,
         update: AwarenessUpdate,
     ) -> Result<Option<AwarenessUpdateSummary>, Error> {
         self.apply_update_internal(update, None, true)
@@ -378,7 +381,7 @@ impl Awareness {
     /// If current instance has an observer channel (see: [Awareness::with_observer]), applied
     /// changes will also be emitted as events.
     pub fn apply_update_summary_with<O: Into<Origin>>(
-        &self,
+        &mut self,
         update: AwarenessUpdate,
         origin: O,
     ) -> Result<Option<AwarenessUpdateSummary>, Error> {
@@ -386,7 +389,7 @@ impl Awareness {
     }
 
     fn apply_update_internal(
-        &self,
+        &mut self,
         update: AwarenessUpdate,
         origin: Option<Origin>,
         generate_summary: bool,
@@ -460,10 +463,14 @@ impl Awareness {
             let summary = if self.on_update.has_subscribers() || self.on_change.has_subscribers() {
                 let mut e = Event::new(added, changed, removed);
                 if !e.is_empty() {
-                    self.on_change.trigger(|fun| fun(self, &e, origin.as_ref()));
+                    let mut on_change = std::mem::take(&mut self.on_change);
+                    on_change.trigger(|fun| fun(self, &e, origin.as_ref()));
+                    self.on_change = on_change;
                 }
                 e.summary.updated = updated;
-                self.on_update.trigger(|fun| fun(self, &e, origin.as_ref()));
+                let mut on_update = std::mem::take(&mut self.on_update);
+                on_update.trigger(|fun| fun(self, &e, origin.as_ref()));
+                self.on_update = on_update;
                 e.summary
             } else {
                 AwarenessUpdateSummary {
@@ -673,7 +680,7 @@ mod test {
             }
         }
 
-        let local = Awareness::new(Doc::with_client_id(1));
+        let mut local = Awareness::new(Doc::with_client_id(1));
         let last_change_local = Arc::new(ArcSwapOption::default());
         let update = Arc::new(ArcSwapOption::default());
         let _sub_update = {
@@ -748,8 +755,8 @@ mod test {
 
     #[test]
     fn awareness_summary() -> Result<(), Box<dyn std::error::Error>> {
-        let local = Awareness::new(Doc::with_client_id(1));
-        let remote = Awareness::new(Doc::with_client_id(2));
+        let mut local = Awareness::new(Doc::with_client_id(1));
+        let mut remote = Awareness::new(Doc::with_client_id(2));
 
         local.set_local_state(json!({"x":3})).unwrap();
         let update = local.update_with_clients([local.client_id()])?;

--- a/yrs/src/sync/protocol.rs
+++ b/yrs/src/sync/protocol.rs
@@ -66,7 +66,11 @@ pub trait Protocol {
     }
 
     /// Y-sync protocol message handler.
-    fn handle(&self, awareness: &Awareness, data: &[u8]) -> Result<SmallVec<[Message; 1]>, Error> {
+    fn handle(
+        &self,
+        awareness: &mut Awareness,
+        data: &[u8],
+    ) -> Result<SmallVec<[Message; 1]>, Error> {
         let mut decoder = DecoderV1::new(Cursor::new(data));
         let mut reader = MessageReader::new(&mut decoder);
         let mut responses = SmallVec::new();
@@ -83,7 +87,7 @@ pub trait Protocol {
     /// Returns an optional reply message that should be sent back to message sender.
     fn handle_message(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         message: Message,
     ) -> Result<Option<Message>, Error> {
         match message {
@@ -109,7 +113,7 @@ pub trait Protocol {
     /// updates. Returns a sync-step-2 message containing a calculated update.
     fn handle_sync_step1(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         sv: StateVector,
     ) -> Result<Option<Message>, Error> {
         use crate::Transact;
@@ -121,7 +125,7 @@ pub trait Protocol {
     /// an update to current `awareness` document instance.
     fn handle_sync_step2(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         update: Update,
     ) -> Result<Option<Message>, Error> {
         use crate::Transact;
@@ -134,7 +138,7 @@ pub trait Protocol {
     /// `awareness` document instance.
     fn handle_update(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         update: Update,
     ) -> Result<Option<Message>, Error> {
         self.handle_sync_step2(awareness, update)
@@ -144,7 +148,7 @@ pub trait Protocol {
     /// send back [Error::PermissionDenied].
     fn handle_auth(
         &self,
-        _awareness: &Awareness,
+        _awareness: &mut Awareness,
         deny_reason: Option<String>,
     ) -> Result<Option<Message>, Error> {
         if let Some(reason) = deny_reason {
@@ -156,7 +160,10 @@ pub trait Protocol {
 
     /// Returns an [AwarenessUpdate] which is a serializable representation of a current `awareness`
     /// instance.
-    fn handle_awareness_query(&self, awareness: &Awareness) -> Result<Option<Message>, Error> {
+    fn handle_awareness_query(
+        &self,
+        awareness: &mut Awareness,
+    ) -> Result<Option<Message>, Error> {
         let update = awareness.update()?;
         Ok(Some(Message::Awareness(update)))
     }
@@ -165,7 +172,7 @@ pub trait Protocol {
     /// instance is being updated with incoming data.
     fn handle_awareness_update(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         update: AwarenessUpdate,
     ) -> Result<Option<Message>, Error> {
         awareness.apply_update(update)?;
@@ -176,7 +183,7 @@ pub trait Protocol {
     /// implemented here. By default, it returns an [Error::Unsupported].
     fn missing_handle(
         &self,
-        _awareness: &Awareness,
+        _awareness: &mut Awareness,
         tag: u8,
         _data: Vec<u8>,
     ) -> Result<Option<Message>, Error> {
@@ -212,7 +219,7 @@ pub trait AsyncProtocol {
     /// Y-sync protocol message handler.
     async fn handle(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         data: &[u8],
     ) -> Result<SmallVec<[Message; 1]>, Error> {
         let mut decoder = DecoderV1::new(Cursor::new(data));
@@ -231,7 +238,7 @@ pub trait AsyncProtocol {
     /// Returns an optional reply message that should be sent back to message sender.
     async fn handle_message(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         message: Message,
     ) -> Result<Option<Message>, Error> {
         match message {
@@ -257,7 +264,7 @@ pub trait AsyncProtocol {
     /// updates. Returns a sync-step-2 message containing a calculated update.
     async fn handle_sync_step1(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         sv: StateVector,
     ) -> Result<Option<Message>, Error> {
         use crate::AsyncTransact;
@@ -270,7 +277,7 @@ pub trait AsyncProtocol {
     /// an update to current `awareness` document instance.
     async fn handle_sync_step2(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         update: Update,
     ) -> Result<Option<Message>, Error> {
         use crate::AsyncTransact;
@@ -283,7 +290,7 @@ pub trait AsyncProtocol {
     /// `awareness` document instance.
     async fn handle_update(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         update: Update,
     ) -> Result<Option<Message>, Error> {
         self.handle_sync_step2(awareness, update).await
@@ -293,7 +300,7 @@ pub trait AsyncProtocol {
     /// send back [Error::PermissionDenied].
     async fn handle_auth(
         &self,
-        _awareness: &Awareness,
+        _awareness: &mut Awareness,
         deny_reason: Option<String>,
     ) -> Result<Option<Message>, Error> {
         if let Some(reason) = deny_reason {
@@ -307,7 +314,7 @@ pub trait AsyncProtocol {
     /// instance.
     async fn handle_awareness_query(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
     ) -> Result<Option<Message>, Error> {
         let update = awareness.update()?;
         Ok(Some(Message::Awareness(update)))
@@ -317,7 +324,7 @@ pub trait AsyncProtocol {
     /// instance is being updated with incoming data.
     async fn handle_awareness_update(
         &self,
-        awareness: &Awareness,
+        awareness: &mut Awareness,
         update: AwarenessUpdate,
     ) -> Result<Option<Message>, Error> {
         awareness.apply_update(update)?;
@@ -328,7 +335,7 @@ pub trait AsyncProtocol {
     /// implemented here. By default it returns an [Error::Unsupported].
     async fn missing_handle(
         &self,
-        _awareness: &Awareness,
+        _awareness: &mut Awareness,
         tag: u8,
         _data: Vec<u8>,
     ) -> Result<Option<Message>, Error> {
@@ -544,7 +551,7 @@ mod test {
         let doc = Doc::new();
         let txt = doc.get_or_insert_text("text");
         txt.push(&mut doc.transact_mut(), "hello world");
-        let awareness = Awareness::new(doc);
+        let mut awareness = Awareness::new(doc);
         awareness
             .set_local_state(json!({
               "user":{
@@ -620,7 +627,7 @@ mod test {
         };
 
         let result = protocol
-            .handle_sync_step1(&a1, a2.doc().transact().state_vector())
+            .handle_sync_step1(&mut a1, a2.doc().transact().state_vector())
             .unwrap();
 
         assert_eq!(
@@ -670,11 +677,11 @@ mod test {
     fn protocol_awareness_sync() {
         let protocol = crate::sync::DefaultProtocol;
 
-        let a1 = Awareness::new(Doc::with_client_id(1));
-        let a2 = Awareness::new(Doc::with_client_id(2));
+        let mut a1 = Awareness::new(Doc::with_client_id(1));
+        let mut a2 = Awareness::new(Doc::with_client_id(2));
 
         a1.set_local_state(json!({"x":3})).unwrap();
-        let result = protocol.handle_awareness_query(&a1).unwrap();
+        let result = protocol.handle_awareness_query(&mut a1).unwrap();
 
         assert_eq!(
             result,
@@ -682,7 +689,7 @@ mod test {
         );
 
         if let Some(crate::sync::Message::Awareness(u)) = result {
-            let result = protocol.handle_awareness_update(&a2, u).unwrap();
+            let result = protocol.handle_awareness_update(&mut a2, u).unwrap();
             assert!(result.is_none());
         }
 

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -984,12 +984,13 @@ impl<'doc> TransactionMut<'doc> {
                 if branch.has_formatting && !self.local {
                     self.needs_cleanup = true;
                 }
+                let mut branch = *branch;
                 if let Some(e) = branch.trigger(self, subs.clone()) {
                     event_cache.push(e);
                     Self::call_type_observers(
                         &mut self.changed_parent_types,
                         &self.store.linked_by,
-                        *branch,
+                        branch,
                         &mut changed_parents,
                         &event_cache,
                         &mut HashSet::default(),
@@ -1015,6 +1016,7 @@ impl<'doc> TransactionMut<'doc> {
             // We don't need to check for events.length
             // because we know it has at least one element
             let events = Events::new(&mut unsorted);
+            let mut branch = branch;
             branch.trigger_deep(self, &events);
         }
     }
@@ -1033,8 +1035,9 @@ impl<'doc> TransactionMut<'doc> {
         self.committed = true;
 
         // 2. emit 'beforeObserverCalls'
-        if let Some(events) = self.store.events.as_ref() {
+        if let Some(mut events) = self.store.events.take() {
             events.emit_before_observer_calls(self);
+            self.store.events = Some(events);
         }
         // 3. for each change observed by the transaction call type observers
         if !self.changed.is_empty() {
@@ -1045,20 +1048,21 @@ impl<'doc> TransactionMut<'doc> {
             self.cleanup_fmt();
         }
 
-        if let Some(events) = self.store.events.take() {
+        // 4. emit 'afterTransaction'
+        if let Some(mut events) = self.store.events.take() {
             events.emit_after_transaction(self);
             self.store.events = Some(events);
         }
 
-        // 4. try GC delete set
+        // 5. try GC delete set
         if !self.store.skip_gc {
             GCCollector::collect(self);
         }
 
-        // 5. try merge delete set
+        // 6. try merge delete set
         self.delete_set.try_squash_with(&mut self.store);
 
-        // 6. on all affected store.clients props, try to merge
+        // 7. on all affected store.clients props, try to merge
         for (client, ids) in self.insert_set.iter() {
             if let Some(first_clock) = ids.clock_start() {
                 let blocks = unsafe { self.store.blocks.get_client_mut(client).unwrap_unchecked() };
@@ -1071,7 +1075,7 @@ impl<'doc> TransactionMut<'doc> {
             }
         }
 
-        // 7. get merge_structs and try to merge to left
+        // 8. get merge_structs and try to merge to left
         for id in self.merge_blocks.iter() {
             if let Some(blocks) = self.store.blocks.get_client_mut(&id.client) {
                 if let Some(replaced_pos) = blocks.find_index(id.clock) {
@@ -1084,40 +1088,39 @@ impl<'doc> TransactionMut<'doc> {
             }
         }
 
-        if let Some(events) = self.store.events.as_ref() {
-            // 8. emit 'afterTransactionCleanup'
+        // 9. emit 'afterTransactionCleanup', 'update', 'updateV2'
+        if let Some(mut events) = self.store.events.take() {
             events.emit_transaction_cleanup(self);
-            // 9. emit 'update'
             events.emit_update_v1(self);
-            // 10. emit 'updateV2'
             events.emit_update_v2(self);
+            self.store.events = Some(events);
         }
 
-        // 11. add and remove subdocs
-        let store = self.store.deref_mut();
+        // 10. add and remove subdocs
         if let Some(mut subdocs) = self.subdocs.take() {
-            let client_id = store.client_id;
+            let client_id = self.store.client_id;
             for (guid, subdoc) in subdocs.added.iter_mut() {
                 let mut txn = subdoc.transact_mut();
                 txn.store.client_id = client_id;
                 txn.doc
                     .store()
                     .set_subdoc_data(client_id, self.doc.collection_id());
-                store.subdocs.insert(guid.clone(), subdoc.clone());
+                self.store.subdocs.insert(guid.clone(), subdoc.clone());
             }
             for guid in subdocs.removed.keys() {
-                store.subdocs.remove(guid);
+                self.store.subdocs.remove(guid);
             }
 
-            let store = self.store.deref();
-            let mut removed = if let Some(events) = store.events.as_ref() {
-                if events.subdocs_events.has_subscribers() {
+            let mut removed = if let Some(mut events) = self.store.events.take() {
+                let removed = if events.subdocs_events.has_subscribers() {
                     let e = SubdocsEvent::new(subdocs);
                     events.subdocs_events.trigger(|cb| cb(self, &e));
                     e.removed
                 } else {
                     subdocs.removed
-                }
+                };
+                self.store.events = Some(events);
+                removed
             } else {
                 subdocs.removed
             };
@@ -1405,7 +1408,7 @@ pub struct Subdocs {
 /// (it's **not persisted** in the document store itself), i.e. *you can use unique document client
 /// identifiers to differentiate updates incoming from remote nodes from those performed locally*.
 #[repr(transparent)]
-#[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Clone, Default, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Origin(SmallVec<[u8; std::mem::size_of::<usize>()]>);
 
 impl AsRef<[u8]> for Origin {

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1033,7 +1033,10 @@ impl<'doc> TransactionMut<'doc> {
         self.committed = true;
 
         // 2. emit 'beforeObserverCalls'
-        // 3. for each change observed by the transaction call 'afterTransaction'
+        if let Some(events) = self.store.events.as_ref() {
+            events.emit_before_observer_calls(self);
+        }
+        // 3. for each change observed by the transaction call type observers
         if !self.changed.is_empty() {
             self.call_observers();
         }

--- a/yrs/src/types/mod.rs
+++ b/yrs/src/types/mod.rs
@@ -296,9 +296,9 @@ pub trait Observable: AsRef<Branch> {
     /// All text-like event changes can be tracked by using [TextEvent::delta] method.
     ///
     /// Returns a [Subscription] which, when dropped, will unsubscribe current callback.
-    fn observe<F>(&self, f: F) -> Subscription
+    fn observe<F>(&self, mut f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Self::Event) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Self::Event) + Send + Sync + 'static,
         Event: AsRef<Self::Event>,
     {
         let mut branch = BranchPtr::from(self.as_ref());
@@ -308,19 +308,10 @@ pub trait Observable: AsRef<Branch> {
         })
     }
 
-    /// Subscribes a given callback to be triggered whenever current y-type is changed.
-    /// A callback is triggered whenever a transaction gets committed. This function does not
-    /// trigger if changes have been observed by nested shared collections.
-    ///
-    /// All array-like event changes can be tracked by using [Event::delta] method.
-    /// All map-like event changes can be tracked by using [Event::keys] method.
-    /// All text-like event changes can be tracked by using [TextEvent::delta] method.
-    ///
-    /// Provided key may be used later to unsubscribe from the event.
-    fn observe_with<K, F>(&self, key: K, f: F)
+    fn observe_with<K, F>(&self, key: K, mut f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &Self::Event) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Self::Event) + Send + Sync + 'static,
         Event: AsRef<Self::Event>,
     {
         let mut branch = BranchPtr::from(self.as_ref());
@@ -330,7 +321,6 @@ pub trait Observable: AsRef<Branch> {
         })
     }
 
-    /// Unsubscribes a given callback identified by key, that was previously subscribed using [Self::observe_with].
     fn unobserve<K: Into<Origin>>(&self, key: K) -> bool {
         let mut branch = BranchPtr::from(self.as_ref());
         branch.unobserve(&key.into())
@@ -341,18 +331,9 @@ pub trait Observable: AsRef<Branch> {
 pub trait Observable: AsRef<Branch> {
     type Event;
 
-    /// Subscribes a given callback to be triggered whenever current y-type is changed.
-    /// A callback is triggered whenever a transaction gets committed. This function does not
-    /// trigger if changes have been observed by nested shared collections.
-    ///
-    /// All array-like event changes can be tracked by using [Event::delta] method.
-    /// All map-like event changes can be tracked by using [Event::keys] method.
-    /// All text-like event changes can be tracked by using [TextEvent::delta] method.
-    ///
-    /// Returns a [Subscription] which, when dropped, will unsubscribe current callback.
-    fn observe<F>(&self, f: F) -> Subscription
+    fn observe<F>(&self, mut f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Self::Event) + 'static,
+        F: FnMut(&TransactionMut, &Self::Event) + 'static,
         Event: AsRef<Self::Event>,
     {
         let mut branch = BranchPtr::from(self.as_ref());
@@ -362,19 +343,10 @@ pub trait Observable: AsRef<Branch> {
         })
     }
 
-    /// Subscribes a given callback to be triggered whenever current y-type is changed.
-    /// A callback is triggered whenever a transaction gets committed. This function does not
-    /// trigger if changes have been observed by nested shared collections.
-    ///
-    /// All array-like event changes can be tracked by using [Event::delta] method.
-    /// All map-like event changes can be tracked by using [Event::keys] method.
-    /// All text-like event changes can be tracked by using [TextEvent::delta] method.
-    ///
-    /// Provided key may be used later to unsubscribe from the event.
-    fn observe_with<K, F>(&self, key: K, f: F)
+    fn observe_with<K, F>(&self, key: K, mut f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &Self::Event) + 'static,
+        F: FnMut(&TransactionMut, &Self::Event) + 'static,
         Event: AsRef<Self::Event>,
     {
         let mut branch = BranchPtr::from(self.as_ref());
@@ -384,7 +356,6 @@ pub trait Observable: AsRef<Branch> {
         })
     }
 
-    /// Unsubscribes a given callback identified by key, that was previously subscribed using [Self::observe_with].
     fn unobserve<K: Into<Origin>>(&self, key: K) -> bool {
         let mut branch = BranchPtr::from(self.as_ref());
         branch.unobserve(&key.into())
@@ -449,100 +420,50 @@ pub trait DefaultPrelim {
 /// nested types.
 #[cfg(feature = "sync")]
 pub trait DeepObservable: AsRef<Branch> {
-    /// Subscribe a callback `f` for all events emitted by this and nested collaborative types.
-    /// Callback is accepting transaction which triggered that event and event itself, wrapped
-    /// within an [Event] structure.
-    ///
-    /// In case when a nested shared type (e.g. [MapRef],[ArrayRef],[TextRef]) is being removed,
-    /// all of its contents will be removed first. So the observed value will be empty. For example,
-    /// The value wrapped in the [EntryChange::Removed] of the [Event::Map] will be empty.
-    ///
-    /// This method returns a subscription, which will automatically unsubscribe current callback
-    /// when dropped.
     fn observe_deep<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Events) + Send + Sync + 'static,
     {
-        let branch = self.as_ref();
-        branch.deep_observers.subscribe(Box::new(f))
+        let mut branch = BranchPtr::from(self.as_ref());
+        branch.observe_deep(f)
     }
 
-    /// Subscribe a callback `f` for all events emitted by this and nested collaborative types.
-    /// Callback is accepting transaction which triggered that event and event itself, wrapped
-    /// within an [Event] structure.
-    ///
-    /// In case when a nested shared type (e.g. [MapRef],[ArrayRef],[TextRef]) is being removed,
-    /// all of its contents will be removed first. So the observed value will be empty. For example,
-    /// The value wrapped in the [EntryChange::Removed] of the [Event::Map] will be empty.
-    ///
-    /// This method uses a subscription key, which can be later used to cancel this callback via
-    /// [Self::unobserve_deep].
     fn observe_deep_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &Events) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &Events) + Send + Sync + 'static,
     {
-        let branch = self.as_ref();
-        branch
-            .deep_observers
-            .subscribe_with(key.into(), Box::new(f))
+        let mut branch = BranchPtr::from(self.as_ref());
+        branch.observe_deep_with(key.into(), f)
     }
 
-    /// Unsubscribe a callback identified by a given key, that was previously subscribed using
-    /// [Self::observe_deep_with].
     fn unobserve_deep<K: Into<Origin>>(&self, key: K) -> bool {
-        let branch = self.as_ref();
+        let mut branch = BranchPtr::from(self.as_ref());
         branch.deep_observers.unsubscribe(&key.into())
     }
 }
 
-/// Trait implemented by all Y-types, allowing for observing events which are emitted by
-/// nested types.
 #[cfg(not(feature = "sync"))]
 pub trait DeepObservable: AsRef<Branch> {
-    /// Subscribe a callback `f` for all events emitted by this and nested collaborative types.
-    /// Callback is accepting transaction which triggered that event and event itself, wrapped
-    /// within an [Event] structure.
-    ///
-    /// In case when a nested shared type (e.g. [MapRef],[ArrayRef],[TextRef]) is being removed,
-    /// all of its contents will be removed first. So the observed value will be empty. For example,
-    /// The value wrapped in the [EntryChange::Removed] of the [Event::Map] will be empty.
-    ///
-    /// This method returns a subscription, which will automatically unsubscribe current callback
-    /// when dropped.
     fn observe_deep<F>(&self, f: F) -> Subscription
     where
-        F: Fn(&TransactionMut, &Events) + 'static,
+        F: FnMut(&TransactionMut, &Events) + Send + Sync + 'static,
     {
-        let branch = self.as_ref();
-        branch.deep_observers.subscribe(Box::new(f))
+        let mut branch = BranchPtr::from(self.as_ref());
+        branch.observe_deep(f)
     }
 
-    /// Subscribe a callback `f` for all events emitted by this and nested collaborative types.
-    /// Callback is accepting transaction which triggered that event and event itself, wrapped
-    /// within an [Event] structure.
-    ///
-    /// In case when a nested shared type (e.g. [MapRef],[ArrayRef],[TextRef]) is being removed,
-    /// all of its contents will be removed first. So the observed value will be empty. For example,
-    /// The value wrapped in the [EntryChange::Removed] of the [Event::Map] will be empty.
-    ///
-    /// This method uses a subscription key, which can be later used to cancel this callback via
-    /// [Self::unobserve_deep].
     fn observe_deep_with<K, F>(&self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &Events) + 'static,
+        F: FnMut(&TransactionMut, &Events) + 'static,
     {
-        let branch = self.as_ref();
-        branch
-            .deep_observers
-            .subscribe_with(key.into(), Box::new(f))
+        let mut branch = BranchPtr::from(self.as_ref());
+        branch.observe_deep_with(key.into(), f)
     }
 
-    /// Unsubscribe a callback identified by a given key, that was previously subscribed using
-    /// [Self::observe_deep_with].
     fn unobserve_deep<K: Into<Origin>>(&self, key: K) -> bool {
-        let branch = self.as_ref();
+        let mut branch = BranchPtr::from(self.as_ref());
         branch.deep_observers.unsubscribe(&key.into())
     }
 }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -41,10 +41,10 @@ pub struct UndoManager<M> {
 }
 
 #[cfg(feature = "sync")]
-type UndoFn<M> = Box<dyn Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static>;
+type UndoFn<M> = Box<dyn FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static>;
 
 #[cfg(not(feature = "sync"))]
-type UndoFn<M> = Box<dyn Fn(&TransactionMut, &mut Event<M>) + 'static>;
+type UndoFn<M> = Box<dyn FnMut(&TransactionMut, &mut Event<M>) + 'static>;
 
 #[cfg(feature = "sync")]
 pub trait Meta: Default + Send + Sync {}
@@ -87,6 +87,10 @@ where
     #[inline]
     pub fn doc(&self) -> &Doc {
         &self.doc
+    }
+
+    fn inner_mut(&mut self) -> &mut Inner<M> {
+        Arc::get_mut(&mut self.state).unwrap()
     }
 
     /// Creates a new instance of the [UndoManager] working in a context of a given document, but
@@ -244,215 +248,142 @@ where
         last_op.meta = event.meta;
     }
 
-    fn handle_destroy(txn: &TransactionMut, inner: &mut Inner<M>) {
+    fn handle_destroy(_txn: &TransactionMut, inner: &mut Inner<M>) {
         let origin = Origin::from(inner as *mut Inner<M> as usize);
-        if inner.options.tracked_origins.remove(&origin) {
-            if let Some(events) = txn.events() {
-                events.destroy_events.unsubscribe(&origin);
-                events.after_transaction_events.unsubscribe(&origin);
-            }
-        }
+        // Just remove from tracked origins. The observer subscriptions will be cleaned up
+        // when the Observer itself is dropped (the doc is being destroyed).
+        inner.options.tracked_origins.remove(&origin);
     }
 
-    /// Registers a callback function to be called every time a new [StackItem] is created. This
-    /// usually happens when a new update over an tracked shared type happened after capture timeout
-    /// threshold from the previous stack item occurence has been reached or [UndoManager::reset]
-    /// has been called.
-    ///
-    /// Returns a subscription object which - when dropped - will unregister provided callback.
+    /// Registers a callback to be called every time a new [StackItem] is created.
     #[cfg(feature = "sync")]
-    pub fn observe_item_added<F>(&self, f: F) -> crate::Subscription
+    pub fn observe_item_added<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.state.observer_added.subscribe(Box::new(f))
+        self.inner_mut().observer_added.subscribe(Box::new(f))
     }
 
-    /// Registers a callback function to be called every time a new [StackItem] is created. This
-    /// usually happens when a new update over an tracked shared type happened after capture timeout
-    /// threshold from the previous stack item occurence has been reached or [UndoManager::reset]
-    /// has been called.
-    ///
-    /// Returns a subscription object which - when dropped - will unregister provided callback.
+    /// Registers a callback to be called every time a new [StackItem] is created.
     #[cfg(not(feature = "sync"))]
-    pub fn observe_item_added<F>(&self, f: F) -> crate::Subscription
+    pub fn observe_item_added<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + 'static,
     {
-        self.state.observer_added.subscribe(Box::new(f))
+        self.inner_mut().observer_added.subscribe(Box::new(f))
     }
 
-    /// Registers a callback function to be called every time a new [StackItem] is created. This
-    /// usually happens when a new update over an tracked shared type happened after capture timeout
-    /// threshold from the previous stack item occurence has been reached or [UndoManager::reset]
-    /// has been called.
-    ///
-    /// Provided `key` is used to identify the origin of the callback. It can be used to unregister
-    /// the callback later on.
     #[cfg(feature = "sync")]
-    pub fn observe_item_added_with<K, F>(&self, key: K, f: F)
+    pub fn observe_item_added_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.state
-            .observer_added
-            .subscribe_with(key.into(), Box::new(f))
+        self.inner_mut().observer_added.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Registers a callback function to be called every time a new [StackItem] is created. This
-    /// usually happens when a new update over an tracked shared type happened after capture timeout
-    /// threshold from the previous stack item occurence has been reached or [UndoManager::reset]
-    /// has been called.
-    ///
-    /// Provided `key` is used to identify the origin of the callback. It can be used to unregister
-    /// the callback later on.
     #[cfg(not(feature = "sync"))]
-    pub fn observe_item_added_with<K, F>(&self, key: K, f: F)
+    pub fn observe_item_added_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &mut Event<M>) + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + 'static,
     {
-        self.state
-            .observer_added
-            .subscribe_with(key.into(), Box::new(f))
+        self.inner_mut().observer_added.subscribe_with(key.into(), Box::new(f))
     }
 
-    pub fn unobserve_item_added<K>(&self, key: K) -> bool
+    pub fn unobserve_item_added<K>(&mut self, key: K) -> bool
     where
         K: Into<Origin>,
     {
-        self.state.observer_added.unsubscribe(&key.into())
+        self.inner_mut().observer_added.unsubscribe(&key.into())
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// extended as a result of updates from tracked types which happened before a capture timeout
-    /// has passed.
-    ///
-    /// Returns a subscription object which - when dropped - will unregister provided callback.
+    /// Registers a callback to be called every time an existing [StackItem] is extended.
     #[cfg(feature = "sync")]
-    pub fn observe_item_updated<F>(&self, f: F) -> crate::Subscription
+    pub fn observe_item_updated<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.state.observer_updated.subscribe(Box::new(f))
+        self.inner_mut().observer_updated.subscribe(Box::new(f))
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// extended as a result of updates from tracked types which happened before a capture timeout
-    /// has passed.
-    ///
-    /// Returns a subscription object which - when dropped - will unregister provided callback.
+    /// Registers a callback to be called every time an existing [StackItem] is extended.
     #[cfg(not(feature = "sync"))]
-    pub fn observe_item_updated<F>(&self, f: F) -> crate::Subscription
+    pub fn observe_item_updated<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + 'static,
     {
-        self.state.observer_updated.subscribe(Box::new(f))
+        self.inner_mut().observer_updated.subscribe(Box::new(f))
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// extended as a result of updates from tracked types which happened before a capture timeout
-    /// has passed.
-    ///
-    /// Provided `key` is used to identify the origin of the callback. It can be used to unregister
-    /// the callback later on.
     #[cfg(feature = "sync")]
-    pub fn observe_item_updated_with<K, F>(&self, key: K, f: F)
+    pub fn observe_item_updated_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.state
-            .observer_updated
-            .subscribe_with(key.into(), Box::new(f))
+        self.inner_mut().observer_updated.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// extended as a result of updates from tracked types which happened before a capture timeout
-    /// has passed.
-    ///
-    /// Provided `key` is used to identify the origin of the callback. It can be used to unregister
-    /// the callback later on.
     #[cfg(not(feature = "sync"))]
-    pub fn observe_item_updated_with<K, F>(&self, key: K, f: F)
+    pub fn observe_item_updated_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &mut Event<M>) + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + 'static,
     {
-        self.state
-            .observer_updated
-            .subscribe_with(key.into(), Box::new(f))
+        self.inner_mut().observer_updated.subscribe_with(key.into(), Box::new(f))
     }
 
-    pub fn unobserve_item_updated<K>(&self, key: K) -> bool
+    pub fn unobserve_item_updated<K>(&mut self, key: K) -> bool
     where
         K: Into<Origin>,
     {
-        self.state.observer_updated.unsubscribe(&key.into())
+        self.inner_mut().observer_updated.unsubscribe(&key.into())
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// removed as a result of [UndoManager::undo] or [UndoManager::redo] method.
-    ///
-    /// Returns a subscription object which - when dropped - will unregister provided callback.
+    /// Registers a callback to be called every time a [StackItem] is popped
+    /// via [UndoManager::undo] or [UndoManager::redo].
     #[cfg(feature = "sync")]
-    pub fn observe_item_popped<F>(&self, f: F) -> crate::Subscription
+    pub fn observe_item_popped<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.state.observer_popped.subscribe(Box::new(f))
+        self.inner_mut().observer_popped.subscribe(Box::new(f))
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// removed as a result of [UndoManager::undo] or [UndoManager::redo] method.
-    ///
-    /// Returns a subscription object which - when dropped - will unregister provided callback.
+    /// Registers a callback to be called every time a [StackItem] is popped
+    /// via [UndoManager::undo] or [UndoManager::redo].
     #[cfg(not(feature = "sync"))]
-    pub fn observe_item_popped<F>(&self, f: F) -> crate::Subscription
+    pub fn observe_item_popped<F>(&mut self, f: F) -> crate::Subscription
     where
-        F: Fn(&TransactionMut, &mut Event<M>) + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + 'static,
     {
-        self.state.observer_popped.subscribe(Box::new(f))
+        self.inner_mut().observer_popped.subscribe(Box::new(f))
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// removed as a result of [UndoManager::undo] or [UndoManager::redo] method.
-    ///
-    /// Provided `key` is used to identify the origin of the callback. It can be used to unregister
-    /// the callback later on.
     #[cfg(feature = "sync")]
-    pub fn observe_item_popped_with<K, F>(&self, key: K, f: F)
+    pub fn observe_item_popped_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + Send + Sync + 'static,
     {
-        self.state
-            .observer_popped
-            .subscribe_with(key.into(), Box::new(f))
+        self.inner_mut().observer_popped.subscribe_with(key.into(), Box::new(f))
     }
 
-    /// Registers a callback function to be called every time an existing [StackItem] has been
-    /// removed as a result of [UndoManager::undo] or [UndoManager::redo] method.
-    ///
-    /// Provided `key` is used to identify the origin of the callback. It can be used to unregister
-    /// the callback later on.
     #[cfg(not(feature = "sync"))]
-    pub fn observe_item_popped_with<K, F>(&self, key: K, f: F)
+    pub fn observe_item_popped_with<K, F>(&mut self, key: K, f: F)
     where
         K: Into<Origin>,
-        F: Fn(&TransactionMut, &mut Event<M>) + 'static,
+        F: FnMut(&TransactionMut, &mut Event<M>) + 'static,
     {
-        self.state
-            .observer_popped
-            .subscribe_with(key.into(), Box::new(f))
+        self.inner_mut().observer_popped.subscribe_with(key.into(), Box::new(f))
     }
 
-    pub fn unobserve_item_popped<K>(&self, key: K) -> bool
+    pub fn unobserve_item_popped<K>(&mut self, key: K) -> bool
     where
         K: Into<Origin>,
     {
-        self.state.observer_popped.unsubscribe(&key.into())
+        self.inner_mut().observer_popped.unsubscribe(&key.into())
     }
 
     /// Extends a list of shared types tracked by current undo manager by a given `scope`.

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1285,6 +1285,7 @@ mod test {
         txt.apply_delta(&mut d0.transact_mut(), [Delta::insert("e")]);
         txt.apply_delta(&mut d0.transact_mut(), [Delta::insert("n")]);
         drop(sub);
+        drop(d0);
 
         let updates = Arc::into_inner(server_updates).unwrap();
         let updates = updates.into_inner().unwrap();

--- a/ywasm/src/awareness.rs
+++ b/ywasm/src/awareness.rs
@@ -1,5 +1,6 @@
 use js_sys::Uint8Array;
 use serde::Serialize;
+use std::cell::UnsafeCell;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -13,20 +14,28 @@ use crate::js::{Callback, Js};
 
 #[wasm_bindgen]
 pub struct Awareness {
-    inner: YAwareness,
+    inner: UnsafeCell<YAwareness>,
 }
 
 #[wasm_bindgen]
 impl Awareness {
     #[wasm_bindgen(constructor)]
     pub fn new(doc: YDoc) -> Awareness {
-        let inner = YAwareness::with_clock(doc.0.clone(), JsClock);
+        let inner = UnsafeCell::new(YAwareness::with_clock(doc.0.clone(), JsClock));
         Awareness { inner }
+    }
+
+    fn inner(&self) -> &YAwareness {
+        unsafe { &*self.inner.get() }
+    }
+
+    fn inner_mut(&self) -> &mut YAwareness {
+        unsafe { &mut *self.inner.get() }
     }
 
     #[wasm_bindgen(getter, js_name = doc)]
     pub fn doc(&self) -> YDoc {
-        YDoc(self.inner.doc().clone())
+        YDoc(self.inner().doc().clone())
     }
 
     #[wasm_bindgen(getter, js_name = meta)]
@@ -37,7 +46,7 @@ impl Awareness {
             last_updated: u64,
         }
         let result = js_sys::Map::new();
-        for (client_id, state) in self.inner.iter() {
+        for (client_id, state) in self.inner().iter() {
             let info = ClientStateMeta {
                 clock: state.clock,
                 last_updated: state.last_updated,
@@ -49,31 +58,32 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = destroy)]
-    pub fn destroy(&mut self) {
-        self.inner.clean_local_state();
+    pub fn destroy(&self) {
+        self.inner_mut().clean_local_state();
     }
 
     #[wasm_bindgen(js_name = getLocalState)]
     pub fn local_state(&self) -> crate::Result<JsValue> {
-        match self.inner.local_state_raw() {
+        match self.inner().local_state_raw() {
             None => Ok(JsValue::NULL),
             Some(js) => js_sys::JSON::parse(js.as_ref()),
         }
     }
 
     #[wasm_bindgen(js_name = setLocalState)]
-    pub fn set_local_state(&mut self, state: JsValue) -> crate::Result<()> {
+    pub fn set_local_state(&self, state: JsValue) -> crate::Result<()> {
+        let inner = self.inner_mut();
         if state.is_null() {
-            self.inner.clean_local_state();
+            inner.clean_local_state();
         } else {
             let json = js_sys::JSON::stringify(&state)?.as_string().unwrap();
-            self.inner.set_local_state_raw(json);
+            inner.set_local_state_raw(json);
         }
         Ok(())
     }
 
     #[wasm_bindgen(js_name = setLocalStateField)]
-    pub fn set_field(&mut self, key: &str, value: JsValue) -> crate::Result<()> {
+    pub fn set_field(&self, key: &str, value: JsValue) -> crate::Result<()> {
         let state = self.local_state()?;
         js_sys::Reflect::set(&state, &JsValue::from_str(key), &value)?;
         self.set_local_state(state)
@@ -82,7 +92,7 @@ impl Awareness {
     #[wasm_bindgen(js_name = getStates)]
     pub fn states(&self) -> crate::Result<js_sys::Map> {
         let result = js_sys::Map::new();
-        for (client_id, state) in self.inner.iter() {
+        for (client_id, state) in self.inner().iter() {
             if let Some(data) = &state.data {
                 let state = js_sys::JSON::parse(data.as_ref())?;
                 result.set(&JsValue::from_f64(client_id.get() as f64), &state);
@@ -92,10 +102,11 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = on)]
-    pub fn on(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
+    pub fn on(&self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
         let abi = callback.subscription_key();
+        let inner = self.inner_mut();
         match event {
-            "update" => self.inner.on_update_with(abi, move |_, e, origin| {
+            "update" => inner.on_update_with(abi, move |_, e, origin| {
                 let json = crate::js::to_js(e.summary()).unwrap();
                 let origin = match origin {
                     None => JsValue::UNDEFINED,
@@ -103,7 +114,7 @@ impl Awareness {
                 };
                 callback.call2(&JsValue::NULL, &json, &origin).unwrap();
             }),
-            "change" => self.inner.on_change_with(abi, move |_, e, origin| {
+            "change" => inner.on_change_with(abi, move |_, e, origin| {
                 let json = crate::js::to_js(e.summary()).unwrap();
                 let origin = match origin {
                     None => JsValue::UNDEFINED,
@@ -117,11 +128,12 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = off)]
-    pub fn off(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<bool> {
+    pub fn off(&self, event: &str, callback: js_sys::Function) -> crate::Result<bool> {
         let abi = callback.subscription_key();
+        let inner = self.inner_mut();
         match event {
-            "update" => Ok(self.inner.unobserve_update(abi)),
-            "change" => Ok(self.inner.unobserve_change(abi)),
+            "update" => Ok(inner.unobserve_update(abi)),
+            "change" => Ok(inner.unobserve_change(abi)),
             unknown => return Err(JsValue::from_str(&format!("Unknown event: {}", unknown))),
         }
     }
@@ -129,22 +141,22 @@ impl Awareness {
 
 #[wasm_bindgen(js_name = removeAwarenessStates)]
 pub fn remove_states(awareness: &mut Awareness, clients: Vec<u64>) -> crate::Result<()> {
+    let inner = awareness.inner_mut();
     for client_id in clients {
-        awareness.inner.remove_state(ClientID::new(client_id));
+        inner.remove_state(ClientID::new(client_id));
     }
     Ok(())
 }
 
 #[wasm_bindgen(js_name = encodeAwarenessUpdate)]
 pub fn encode_update(awareness: &Awareness, clients: JsValue) -> crate::Result<Uint8Array> {
+    let inner = awareness.inner();
     let res = if clients.is_null() || clients.is_undefined() {
-        awareness.inner.update()
+        inner.update()
     } else {
         let client_ids: Vec<u64> = serde_wasm_bindgen::from_value(clients)
             .map_err(|e| JsValue::from_str(&e.to_string()))?;
-        awareness
-            .inner
-            .update_with_clients(client_ids.into_iter().map(ClientID::new))
+        inner.update_with_clients(client_ids.into_iter().map(ClientID::new))
     };
 
     let update = res.map_err(|e| JsValue::from_str(&e.to_string()))?;
@@ -171,10 +183,10 @@ pub fn apply_update(
     update: Uint8Array,
     _origin: JsValue, //TODO: use origin in Awareness::apply_update
 ) -> crate::Result<()> {
+    let inner = awareness.inner_mut();
     let update = AwarenessUpdate::decode_v1(&update.to_vec())
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
-    awareness
-        .inner
+    inner
         .apply_update(update)
         .map_err(|e| JsValue::from_str(&e.to_string()))?;
     Ok(())

--- a/ywasm/src/awareness.rs
+++ b/ywasm/src/awareness.rs
@@ -49,7 +49,7 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = destroy)]
-    pub fn destroy(&self) {
+    pub fn destroy(&mut self) {
         self.inner.clean_local_state();
     }
 
@@ -62,7 +62,7 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = setLocalState)]
-    pub fn set_local_state(&self, state: JsValue) -> crate::Result<()> {
+    pub fn set_local_state(&mut self, state: JsValue) -> crate::Result<()> {
         if state.is_null() {
             self.inner.clean_local_state();
         } else {
@@ -73,7 +73,7 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = setLocalStateField)]
-    pub fn set_field(&self, key: &str, value: JsValue) -> crate::Result<()> {
+    pub fn set_field(&mut self, key: &str, value: JsValue) -> crate::Result<()> {
         let state = self.local_state()?;
         js_sys::Reflect::set(&state, &JsValue::from_str(key), &value)?;
         self.set_local_state(state)
@@ -92,7 +92,7 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = on)]
-    pub fn on(&self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
+    pub fn on(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<()> {
         let abi = callback.subscription_key();
         match event {
             "update" => self.inner.on_update_with(abi, move |_, e, origin| {
@@ -117,7 +117,7 @@ impl Awareness {
     }
 
     #[wasm_bindgen(js_name = off)]
-    pub fn off(&self, event: &str, callback: js_sys::Function) -> crate::Result<bool> {
+    pub fn off(&mut self, event: &str, callback: js_sys::Function) -> crate::Result<bool> {
         let abi = callback.subscription_key();
         match event {
             "update" => Ok(self.inner.unobserve_update(abi)),
@@ -128,7 +128,7 @@ impl Awareness {
 }
 
 #[wasm_bindgen(js_name = removeAwarenessStates)]
-pub fn remove_states(awareness: &Awareness, clients: Vec<u64>) -> crate::Result<()> {
+pub fn remove_states(awareness: &mut Awareness, clients: Vec<u64>) -> crate::Result<()> {
     for client_id in clients {
         awareness.inner.remove_state(ClientID::new(client_id));
     }
@@ -167,7 +167,7 @@ pub fn modify_update(update: Uint8Array, modify: js_sys::Function) -> crate::Res
 
 #[wasm_bindgen(js_name = applyAwarenessUpdate)]
 pub fn apply_update(
-    awareness: &Awareness,
+    awareness: &mut Awareness,
     update: Uint8Array,
     _origin: JsValue, //TODO: use origin in Awareness::apply_update
 ) -> crate::Result<()> {


### PR DESCRIPTION
- changed observer code to make use of `FnMut` instead of `Fn` callbacks.
- added `before_observer_calls` event handler (present in yjs).
- event observers have a lot of repeatable boilerplate code. It was extracted into macro.