### PR TITLE
UndoManager now works over multiple documents

### DIFF
--- a/tests-ffi/include/libyrs.h
+++ b/tests-ffi/include/libyrs.h
@@ -2575,7 +2575,7 @@ void yevent_keys_destroy(struct YEventKeyChange *keys, uint32_t len);
  *
  * This object can be deallocated via `yundo_manager_destroy`.
  */
-YUndoManager *yundo_manager(const YDoc *doc, const struct YUndoManagerOptions *options);
+YUndoManager *yundo_manager(const struct YUndoManagerOptions *options);
 
 /**
  * Deallocated undo manager instance created via `yundo_manager`.
@@ -2598,7 +2598,7 @@ void yundo_manager_remove_origin(YUndoManager *mgr, uint32_t origin_len, const c
 /**
  * Add specific shared type to be tracked by this instance of an undo manager.
  */
-void yundo_manager_add_scope(YUndoManager *mgr, const Branch *ytype);
+void yundo_manager_add_scope(YUndoManager *mgr, const YDoc *doc, const Branch *ytype);
 
 /**
  * Removes all the undo/redo stack changes tracked by current undo manager. This also cleans up

--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -1732,8 +1732,8 @@ TEST_CASE("YUndoManager undo redo") {
     YDoc *d2 = ydoc_new_with_id(2);
     Branch *txt1 = ytext(d1, "test");
     Branch *txt2 = ytext(d2, "test");
-    YUndoManager *mgr = yundo_manager(d1, NULL);
-    yundo_manager_add_scope(mgr, txt1);
+    YUndoManager *mgr = yundo_manager(NULL);
+    yundo_manager_add_scope(mgr, d1, txt1);
 
     YTransaction *txn = ydoc_write_transaction(d1, 0, NULL);
     ytext_insert(txt1, txn, 0, "test", NULL);

--- a/tests-wasm/y-undo.tests.js
+++ b/tests-wasm/y-undo.tests.js
@@ -11,7 +11,8 @@ export const testUndoText = tc => {
     const d1 = new Y.YDoc({clientID: 2})
     const text0 = d0.getText("test")
     const text1 = d1.getText("test")
-    const undoManager = new Y.YUndoManager(d0, text0)
+    const undoManager = new Y.YUndoManager()
+    undoManager.addToScope([text0])
 
     // items that are added & deleted in the same transaction won't be undo
     text0.insert(0, 'test')
@@ -61,7 +62,8 @@ export const testDoubleUndo = tc => {
     const text = doc.getText("test")
     text.insert(0, '1221')
 
-    const manager = new Y.YUndoManager(doc, text)
+    const manager = new Y.YUndoManager()
+    manager.addToScope([text])
 
     text.insert(2, '3')
     text.insert(3, '3')
@@ -83,7 +85,8 @@ export const testUndoMap = tc => {
     const map0 = d0.getMap("test")
     const map1 = d1.getMap("test")
     map0.set('a', 0)
-    const undoManager = new Y.YUndoManager(d0, map0)
+    const undoManager = new Y.YUndoManager()
+    undoManager.addToScope([map0])
     map0.set('a', 1)
     undoManager.undo()
     t.assert(map0.get('a') === 0)
@@ -125,7 +128,8 @@ export const testUndoArray = tc => {
     const d1 = new Y.YDoc({clientID: 2})
     const array0 = d0.getArray("test")
     const array1 = d1.getArray("test")
-    const undoManager = new Y.YUndoManager(d0, array0)
+    const undoManager = new Y.YUndoManager()
+    undoManager.addToScope([array0])
     array0.insert(0, [1, 2, 3])
     array1.insert(0, [4, 5, 6])
     exchangeUpdates([d0, d1])
@@ -177,7 +181,8 @@ export const testUndoArray = tc => {
 export const testUndoXml = tc => {
     const d0 = new Y.YDoc({clientID: 1})
     const xml0 = d0.getXmlFragment("undefined")
-    const undoManager = new Y.YUndoManager(d0, xml0)
+    const undoManager = new Y.YUndoManager()
+    undoManager.addToScope([xml0])
     const textchild = new Y.YXmlText('content')
     xml0.push(new Y.YXmlElement('p', {}, [
         textchild
@@ -203,7 +208,8 @@ export const testUndoXml = tc => {
 export const testUndoEvents = tc => {
     const d0 = new Y.YDoc({clientID: 1})
     const text0 = d0.getText("text")
-    const undoManager = new Y.YUndoManager(d0, text0)
+    const undoManager = new Y.YUndoManager()
+    undoManager.addToScope([text0])
     let counter = 0
     let receivedMetadata = -1
     undoManager.on('stack-item-added', event => {

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -614,12 +614,9 @@ pub unsafe extern "C" fn ydoc_load(doc: *mut Doc, parent_txn: *mut Transaction) 
 #[no_mangle]
 pub unsafe extern "C" fn ydoc_clear(doc: *mut Doc, parent_txn: *mut Transaction) {
     let doc = doc.as_mut().unwrap();
-    let txn = parent_txn.as_mut().unwrap();
-    if let Some(txn) = txn.as_mut() {
-        doc.destroy(txn)
-    } else {
-        panic!("ydoc_clear: passed read-only parent transaction, where read-write one was expected")
-    }
+    let txn = parent_txn.as_mut();
+    let txn = txn.and_then(|tx| tx.as_mut());
+    doc.destroy(txn);
 }
 
 /// Starts a new read-only transaction on a given document. All other operations happen in context
@@ -4679,19 +4676,14 @@ pub struct YUndoManagerOptions {
 ///
 /// This object can be deallocated via `yundo_manager_destroy`.
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager(
-    doc: *const Doc,
-    options: *const YUndoManagerOptions,
-) -> *mut YUndoManager {
-    let doc = doc.as_ref().unwrap();
-
+pub unsafe extern "C" fn yundo_manager(options: *const YUndoManagerOptions) -> *mut YUndoManager {
     let mut o = yrs::undo::Options::default();
     if let Some(options) = options.as_ref() {
         if options.capture_timeout_millis >= 0 {
             o.capture_timeout_millis = options.capture_timeout_millis as u64;
         }
     };
-    let boxed = Box::new(yrs::undo::UndoManager::with_options(doc, o));
+    let boxed = Box::new(yrs::undo::UndoManager::with_options(o));
     Box::into_raw(boxed)
 }
 
@@ -4730,10 +4722,15 @@ pub unsafe extern "C" fn yundo_manager_remove_origin(
 
 /// Add specific shared type to be tracked by this instance of an undo manager.
 #[no_mangle]
-pub unsafe extern "C" fn yundo_manager_add_scope(mgr: *mut YUndoManager, ytype: *const Branch) {
+pub unsafe extern "C" fn yundo_manager_add_scope(
+    mgr: *mut YUndoManager,
+    doc: *const Doc,
+    ytype: *const Branch,
+) {
     let mgr = mgr.as_mut().unwrap();
+    let doc = doc.as_ref().unwrap();
     let branch = ytype.as_ref().unwrap();
-    mgr.expand_scope(&BranchPtr::from(branch));
+    mgr.expand_scope(doc, &BranchPtr::from(branch));
 }
 
 /// Removes all the undo/redo stack changes tracked by current undo manager. This also cleans up
@@ -4772,10 +4769,10 @@ pub unsafe extern "C" fn yundo_manager_stop(mgr: *mut YUndoManager) {
 pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
 
-    match mgr.try_undo() {
-        Ok(true) => Y_TRUE,
-        Ok(false) => Y_FALSE,
-        Err(_) => Y_FALSE,
+    if mgr.undo_blocking() {
+        Y_TRUE
+    } else {
+        Y_FALSE
     }
 }
 
@@ -4787,10 +4784,10 @@ pub unsafe extern "C" fn yundo_manager_undo(mgr: *mut YUndoManager) -> u8 {
 #[no_mangle]
 pub unsafe extern "C" fn yundo_manager_redo(mgr: *mut YUndoManager) -> u8 {
     let mgr = mgr.as_mut().unwrap();
-    match mgr.try_redo() {
-        Ok(true) => Y_TRUE,
-        Ok(false) => Y_FALSE,
-        Err(_) => Y_FALSE,
+    if mgr.redo_blocking() {
+        Y_TRUE
+    } else {
+        Y_FALSE
     }
 }
 

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -361,8 +361,11 @@ impl Doc {
     );
 
     define_doc_observer!(
-        observe_after_transaction, observe_after_transaction_with, unobserve_after_transaction,
-        after_transaction_events, FnMut(&mut TransactionMut)
+        observe_after_transaction,
+        observe_after_transaction_with,
+        unobserve_after_transaction,
+        after_transaction_events,
+        FnMut(&mut TransactionMut)
     );
 
     define_doc_observer!(
@@ -407,35 +410,34 @@ impl Doc {
 
     /// Starts destroy procedure for a current document, triggering an "destroy" callback and
     /// invalidating all event callback subscriptions.
-    pub fn destroy<T>(&self, parent_txn: &mut T)
-    where
-        T: WriteTxn,
-    {
+    pub fn destroy(&self, parent_txn: Option<&mut TransactionMut<'_>>) {
         let mut txn = self.transact_mut();
         let store = txn.store_mut();
         let subdocs: Vec<_> = store.subdocs.values().cloned().collect();
         for subdoc in subdocs {
-            subdoc.destroy(&mut txn);
+            subdoc.destroy(Some(&mut txn));
         }
-        if let Some(mut item) = txn.store.parent.take() {
-            let parent_ref = item.clone();
-            let is_deleted = item.is_deleted();
-            if let ItemContent::Doc(_, content) = &mut item.content {
-                let mut options = (**content.store.options()).clone();
-                options.should_load = false;
-                let new_ref = Doc::subdoc(parent_ref, options);
-                if !is_deleted {
+        if let Some(parent_txn) = parent_txn {
+            if let Some(mut item) = txn.store.parent.take() {
+                let parent_ref = item.clone();
+                let is_deleted = item.is_deleted();
+                if let ItemContent::Doc(_, content) = &mut item.content {
+                    let mut options = (**content.store.options()).clone();
+                    options.should_load = false;
+                    let new_ref = Doc::subdoc(parent_ref, options);
+                    if !is_deleted {
+                        parent_txn
+                            .subdocs_mut()
+                            .added
+                            .insert(new_ref.addr(), new_ref.clone());
+                    }
                     parent_txn
                         .subdocs_mut()
-                        .added
+                        .removed
                         .insert(new_ref.addr(), new_ref.clone());
-                }
-                parent_txn
-                    .subdocs_mut()
-                    .removed
-                    .insert(new_ref.addr(), new_ref.clone());
 
-                *content = new_ref;
+                    *content = new_ref;
+                }
             }
         }
         // super.destroy(): cleanup the events
@@ -1510,7 +1512,7 @@ mod test {
         {
             let mut txn = doc.transact_mut();
             let doc_a_ref = subdocs.get(&txn, "a").unwrap().cast::<Doc>().unwrap();
-            doc_a_ref.destroy(&mut txn);
+            doc_a_ref.destroy(Some(&mut txn));
         }
         let actual = event.swap(None);
         assert_eq!(
@@ -1667,7 +1669,7 @@ mod test {
         );
 
         // destroy and check whether lastEvent adds it again to added (it shouldn't)
-        doc_ref.destroy(&mut doc.transact_mut());
+        doc_ref.destroy(Some(&mut doc.transact_mut()));
         let doc_ref_2 = array
             .get(&doc.transact(), 0)
             .unwrap()
@@ -1771,7 +1773,7 @@ mod test {
         );
 
         // destroy and check whether lastEvent adds it again to added (it shouldn't)
-        subdoc_1.destroy(&mut doc.transact_mut());
+        subdoc_1.destroy(Some(&mut doc.transact_mut()));
 
         let subdoc_2 = array
             .get(&doc.transact(), 0)

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -315,7 +315,8 @@
 //!
 //! let local = Doc::with_client_id(123);
 //! let text1 = local.get_or_insert_text("article");
-//! let mut mgr = UndoManager::with_scope_and_options(&local, &text1, Options::default());
+//! let mut mgr = UndoManager::with_options(Options::default());
+//! mgr.expand_scope(&local, &text1);
 //! mgr.include_origin(local.client_id()); // only track changes originating from local peer
 //!
 //! let remote = Doc::with_client_id(321);

--- a/yrs/src/transaction.rs
+++ b/yrs/src/transaction.rs
@@ -1126,7 +1126,7 @@ impl<'doc> TransactionMut<'doc> {
             };
 
             for (_, subdoc) in removed.iter_mut() {
-                subdoc.destroy(self);
+                subdoc.destroy(Some(self));
             }
         }
     }

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -5,10 +5,10 @@ use crate::iter::TxnIterator;
 use crate::slice::BlockSlice;
 use crate::sync::Clock;
 use crate::transaction::Origin;
-use crate::{Doc, IdSet, Observer, ReadTxn, Transact, TransactionAcqError, TransactionMut, ID};
-use serde::ser::SerializeStruct;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::collections::HashSet;
+use crate::{Doc, IdSet, Observer, Transact, TransactionMut, Uuid, ID};
+use serde::{Deserialize, Serialize};
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicPtr, Ordering};
@@ -88,7 +88,6 @@ macro_rules! define_undo_observer {
 ///    manager as a result of calling either [UndoManager::undo] or [UndoManager::redo] method.
 pub struct UndoManager<M> {
     state: Arc<Inner<M>>,
-    doc: Doc,
 }
 
 #[cfg(feature = "sync")]
@@ -114,6 +113,7 @@ pub trait Meta: Default {}
 impl<M> Meta for M where M: Default {}
 
 struct Inner<M> {
+    docs: HashMap<Arc<str>, Doc>,
     scope: HashSet<BranchPtr>,
     options: Options<M>,
     undo_stack: UndoStack<M>,
@@ -135,30 +135,18 @@ where
     /// type and document. While it's possible for undo manager to observe multiple shared types
     /// (see: [UndoManager::expand_scope]), it can only work with a single document at the same time.
     #[cfg(not(target_family = "wasm"))]
-    pub fn new<T>(doc: &Doc, scope: &T) -> Self
-    where
-        T: AsRef<Branch>,
-    {
-        Self::with_scope_and_options(doc, scope, Options::default())
-    }
-
-    #[inline]
-    pub fn doc(&self) -> &Doc {
-        &self.doc
-    }
-
-    fn inner_mut(&mut self) -> &mut Inner<M> {
-        Arc::get_mut(&mut self.state).unwrap()
+    pub fn new() -> Self {
+        Self::with_options(Options::default())
     }
 
     /// Creates a new instance of the [UndoManager] working in a context of a given document, but
     /// without any pre-initialize scope. While it's possible for undo manager to observe multiple
     /// shared types (see: [UndoManager::expand_scope]), it can only work with a single document
     /// at the same time.
-    pub fn with_options(doc: &Doc, mut options: Options<M>) -> Self {
+    pub fn with_options(mut options: Options<M>) -> Self {
         let undo_stack = UndoStack(std::mem::take(&mut options.init_undo_stack));
         let redo_stack = UndoStack(std::mem::take(&mut options.init_redo_stack));
-        let mut inner = Arc::new(Inner {
+        let mut state = Arc::new(Inner {
             scope: HashSet::new(),
             options,
             undo_stack,
@@ -170,43 +158,52 @@ where
             observer_updated: Observer::new(),
             observer_popped: Observer::new(),
             observer_cleared: Observer::new(),
+            docs: HashMap::new(),
         });
-        let origin = Origin::from(Arc::as_ptr(&inner) as usize);
-        let inner_mut = Arc::get_mut(&mut inner).unwrap();
-        inner_mut.options.tracked_origins.insert(origin.clone());
-        let ptr = AtomicPtr::new(inner_mut as *mut Inner<M>);
 
-        doc.observe_destroy_with(origin.clone(), move |txn, _| {
-            let ptr = ptr.load(Ordering::Acquire);
-            let inner = unsafe { ptr.as_mut().unwrap() };
-            Self::handle_destroy(txn, inner)
-        })
-        .unwrap();
-        let ptr = AtomicPtr::new(inner_mut as *mut Inner<M>);
-
-        doc.observe_after_transaction_with(origin, move |txn| {
-            let ptr = ptr.load(Ordering::Acquire);
-            let inner = unsafe { ptr.as_mut().unwrap() };
-            Self::handle_after_transaction(inner, txn);
-        })
-        .unwrap();
-
-        UndoManager {
-            state: inner,
-            doc: doc.clone(),
-        }
+        UndoManager { state }
     }
 
-    /// Creates a new instance of the [UndoManager] working in a `scope` of a particular shared
-    /// type and document. While it's possible for undo manager to observe multiple shared types
-    /// (see: [UndoManager::expand_scope]), it can only work with a single document at the same time.
-    pub fn with_scope_and_options<T>(doc: &Doc, scope: &T, options: Options<M>) -> Self
+    /// Extends a list of shared types tracked by current undo manager by a given `scope`.
+    pub fn expand_scope<T>(&mut self, doc: &Doc, scope: &T)
     where
         T: AsRef<Branch>,
     {
-        let mut mgr = Self::with_options(doc, options);
-        mgr.expand_scope(scope);
-        mgr
+        let origin = Origin::from(Arc::as_ptr(&self.state) as usize);
+        let inner_mut = Arc::get_mut(&mut self.state).unwrap();
+        let ptr1 = AtomicPtr::new(inner_mut as *mut Inner<M>);
+        let ptr2 = AtomicPtr::new(inner_mut as *mut Inner<M>);
+
+        if let Entry::Vacant(e) = inner_mut.docs.entry(doc.guid()) {
+            inner_mut.options.tracked_origins.insert(origin.clone());
+
+            doc.observe_destroy_with(origin.clone(), move |txn, _| {
+                let ptr = ptr1.load(Ordering::Acquire);
+                let inner = unsafe { ptr.as_mut().unwrap() };
+                Self::handle_destroy(txn, inner)
+            })
+            .unwrap();
+
+            doc.observe_after_transaction_with(origin, move |txn| {
+                let ptr = ptr2.load(Ordering::Acquire);
+                let inner = unsafe { ptr.as_mut().unwrap() };
+                Self::handle_after_transaction(inner, txn);
+            })
+            .unwrap();
+
+            e.insert(doc.clone());
+        }
+        let ptr = BranchPtr::from(scope.as_ref());
+        let inner = Arc::get_mut(&mut self.state).unwrap();
+        inner.scope.insert(ptr);
+    }
+
+    pub fn docs(&self) -> impl Iterator<Item = &Doc> {
+        self.state.docs.values()
+    }
+
+    fn inner_mut(&mut self) -> &mut Inner<M> {
+        Arc::get_mut(&mut self.state).unwrap()
     }
 
     fn should_skip(inner: &Inner<M>, txn: &TransactionMut) -> bool {
@@ -235,7 +232,23 @@ where
             inner.last_change = 0; // next undo should not be appended to last stack item
         } else if !redoing {
             // neither undoing nor redoing: delete redoStack
-            Self::clear_stack(&inner.scope, &mut inner.redo_stack, txn);
+            let target = txn.doc().guid();
+            let scope = &inner.scope;
+            inner.redo_stack.0.retain_mut(|stack_item| {
+                if stack_item.doc != target {
+                    true // retain stack items from other docs
+                } else {
+                    let mut deleted = stack_item.deletions.blocks();
+                    while let Some(slice) = deleted.next(txn) {
+                        if let Some(item) = slice.as_item() {
+                            if scope.iter().any(|b| b.is_parent_of(Some(item))) {
+                                item.keep(false);
+                            }
+                        }
+                    }
+                    false
+                }
+            });
         }
 
         let insertions = txn.insert_set.clone();
@@ -259,7 +272,8 @@ where
             last_op.insertions.merge_with(insertions);
         } else {
             // create a new stack op
-            let item = StackItem::new(txn.delete_set.clone(), insertions);
+            let doc = txn.doc().guid();
+            let item = StackItem::new(doc, txn.delete_set.clone(), insertions);
             stack.push(item);
         }
 
@@ -296,11 +310,21 @@ where
         last_op.meta = event.meta;
     }
 
-    fn handle_destroy(_txn: &TransactionMut, inner: &mut Inner<M>) {
+    fn handle_destroy(txn: &TransactionMut, inner: &mut Inner<M>) {
         let origin = Origin::from(inner as *mut Inner<M> as usize);
         // Just remove from tracked origins. The observer subscriptions will be cleaned up
         // when the Observer itself is dropped (the doc is being destroyed).
         inner.options.tracked_origins.remove(&origin);
+        let doc_id = txn.doc().guid();
+        inner.docs.remove(&doc_id);
+        inner
+            .undo_stack
+            .0
+            .retain_mut(|stack_item| stack_item.doc != doc_id);
+        inner
+            .redo_stack
+            .0
+            .retain_mut(|stack_item| stack_item.doc != doc_id);
     }
 
     define_undo_observer!(
@@ -328,16 +352,6 @@ where
         observe_stack_cleared, observe_stack_cleared_with, unobserve_stack_cleared,
         observer_cleared, FnMut(&StackClearedEvent)
     );
-
-    /// Extends a list of shared types tracked by current undo manager by a given `scope`.
-    pub fn expand_scope<T>(&mut self, scope: &T)
-    where
-        T: AsRef<Branch>,
-    {
-        let ptr = BranchPtr::from(scope.as_ref());
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        inner.scope.insert(ptr);
-    }
 
     /// Extends a list of origins tracked by current undo manager by given `origin`. Origin markers
     /// can be assigned to updates executing in a scope of a particular transaction
@@ -370,11 +384,14 @@ where
     /// read-write transaction is in progress), it will hold current thread until, acquisition is
     /// available.
     pub fn clear_all(&mut self) {
-        let txn = self.doc.transact();
+        self.clear_internal(true, true)
+    }
+
+    fn clear_internal(&mut self, clear_undo: bool, clear_redo: bool) {
         let inner = Arc::get_mut(&mut self.state).unwrap();
 
-        let undo_cleared = Self::clear_stack(&inner.scope, &mut inner.undo_stack, &txn);
-        let redo_cleared = Self::clear_stack(&inner.scope, &mut inner.redo_stack, &txn);
+        let undo_cleared = Self::clear_stack(&inner.scope, &inner.docs, &mut inner.undo_stack);
+        let redo_cleared = Self::clear_stack(&inner.scope, &inner.docs, &mut inner.redo_stack);
 
         if undo_cleared || redo_cleared {
             let e = StackClearedEvent::new(undo_cleared, redo_cleared);
@@ -393,13 +410,7 @@ where
     /// read-write transaction is in progress), it will hold current thread until, acquisition is
     /// available.
     pub fn clear_undo(&mut self) {
-        let txn = self.doc.transact();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-
-        if Self::clear_stack(&inner.scope, &mut inner.undo_stack, &txn) {
-            let e = StackClearedEvent::new(true, false);
-            inner.observer_cleared.trigger(|f| f(&e));
-        }
+        self.clear_internal(true, false)
     }
 
     /// Clears all [StackItem]s stored within current UndoManager redo stack alone, leaving undo
@@ -413,27 +424,24 @@ where
     /// read-write transaction is in progress), it will hold current thread until, acquisition is
     /// available.
     pub fn clear_redo(&mut self) {
-        let txn = self.doc.transact();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-
-        if Self::clear_stack(&inner.scope, &mut inner.redo_stack, &txn) {
-            let e = StackClearedEvent::new(true, false);
-            inner.observer_cleared.trigger(|f| f(&e));
-        }
+        self.clear_internal(false, true)
     }
 
-    fn clear_stack<T: ReadTxn>(
+    fn clear_stack(
         scope: &HashSet<BranchPtr>,
+        docs: &HashMap<Uuid, Doc>,
         stack: &mut UndoStack<M>,
-        txn: &T,
     ) -> bool {
         let len = stack.len();
         for stack_item in stack.drain(0..len) {
             let mut deleted = stack_item.deletions.blocks();
-            while let Some(slice) = deleted.next(txn) {
-                if let Some(item) = slice.as_item() {
-                    if scope.iter().any(|b| b.is_parent_of(Some(item))) {
-                        item.keep(false);
+            if let Some(doc) = docs.get(&stack_item.doc) {
+                let txn = doc.transact();
+                while let Some(slice) = deleted.next(&txn) {
+                    if let Some(item) = slice.as_item() {
+                        if scope.iter().any(|b| b.is_parent_of(Some(item))) {
+                            item.keep(false);
+                        }
                     }
                 }
             }
@@ -508,10 +516,8 @@ where
     ///
     /// See also: [UndoManager::try_undo] and [UndoManager::undo_blocking].
     pub async fn undo(&mut self) -> bool {
-        let origin = self.as_origin();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        let txn = crate::AsyncTransact::transact_mut_with(&self.doc, origin.clone()).await;
-        Self::undo_inner(inner, txn, origin)
+        let inner = self.inner_mut();
+        Self::pop(inner, true).await
     }
 
     /// Undo last action tracked by current undo manager. Actions (a.k.a. [StackItem]s) are groups
@@ -528,53 +534,8 @@ where
     ///
     /// See also: [UndoManager::try_undo] and [UndoManager::undo].
     pub fn undo_blocking(&mut self) -> bool {
-        let origin = self.as_origin();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        let txn = self.doc.transact_mut_with(origin.clone());
-        Self::undo_inner(inner, txn, origin)
-    }
-
-    /// Undo last action tracked by current undo manager. Actions (a.k.a. [StackItem]s) are groups
-    /// of updates performed in a given time range - they also can be separated explicitly by
-    /// calling [UndoManager::reset].
-    ///
-    /// Successful execution returns a boolean value telling if an undo call has performed any changes.
-    ///
-    /// See also: [UndoManager::undo] and [UndoManager::undo_blocking].
-    ///
-    /// # Errors
-    ///
-    /// This method requires exclusive access to underlying document store. This means that
-    /// no other transaction on that same document can be active while calling this method.
-    /// Otherwise, an error will be returned.
-    pub fn try_undo(&mut self) -> Result<bool, TransactionAcqError> {
-        let origin = self.as_origin();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        let txn = self.doc.try_transact_mut_with(origin.clone())?;
-        let changed = Self::undo_inner(inner, txn, origin);
-        Ok(changed)
-    }
-
-    fn undo_inner(inner: &mut Inner<M>, mut txn: TransactionMut, origin: Origin) -> bool {
-        inner.undoing = true;
-        let result = Self::pop(
-            &mut inner.undo_stack,
-            &inner.redo_stack,
-            &mut txn,
-            &inner.scope,
-        );
-        txn.commit();
-        let changed = if let Some(item) = result {
-            let mut e = Event::undo(item.meta, Some(origin), txn.changed_parent_types.clone());
-            if inner.observer_popped.has_subscribers() {
-                inner.observer_popped.trigger(|fun| fun(&txn, &mut e));
-            }
-            true
-        } else {
-            false
-        };
-        inner.undoing = false;
-        changed
+        let inner = self.inner_mut();
+        Self::pop_blocking(inner, true)
     }
 
     /// Are there any redo steps available?
@@ -596,11 +557,8 @@ where
     ///
     /// See also: [UndoManager::try_redo] and [UndoManager::redo_blocking].
     pub async fn redo(&mut self) -> bool {
-        let origin = self.as_origin();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        let txn = crate::AsyncTransact::transact_mut_with(&self.doc, origin.clone()).await;
-        let changed = Self::redo_inner(inner, txn, origin);
-        changed
+        let inner = self.inner_mut();
+        Self::pop(inner, false).await
     }
 
     /// Redo'es last action previously undo'ed by current undo manager. Actions
@@ -617,115 +575,153 @@ where
     ///
     /// See also: [UndoManager::try_redo] and [UndoManager::redo_blocking].
     pub fn redo_blocking(&mut self) -> bool {
-        let origin = self.as_origin();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        let txn = self.doc.transact_mut_with(origin.clone());
-        let changed = Self::redo_inner(inner, txn, origin);
+        let inner = self.inner_mut();
+        Self::pop_blocking(inner, false)
+    }
+
+    async fn pop(state: &mut Inner<M>, undoing: bool) -> bool {
+        state.undoing = undoing;
+        state.redoing = !undoing;
+        let origin = Origin::from(state as *mut Inner<M> as usize);
+        let (stack, other) = if undoing {
+            (&mut state.undo_stack, &state.redo_stack)
+        } else {
+            (&mut state.redo_stack, &state.undo_stack)
+        };
+        let mut changed = false;
+        while let Some(item) = stack.pop() {
+            if let Some(doc) = state.docs.get(&item.doc) {
+                let txn = crate::AsyncTransact::transact_mut_with(doc, origin.clone()).await;
+
+                if Self::try_process(
+                    item,
+                    txn,
+                    stack,
+                    other,
+                    &state.scope,
+                    &mut state.observer_popped,
+                    undoing,
+                    origin.clone(),
+                ) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        state.undoing = false;
+        state.redoing = false;
         changed
     }
 
-    /// Redo'es last action previously undo'ed by current undo manager. Actions
-    /// (a.k.a. [StackItem]s) are groups of updates performed in a given time range - they also can
-    /// be separated explicitly by calling [UndoManager::reset].
-    ///
-    /// Successful execution returns a boolean value telling if an undo call has performed any changes.
-    ///
-    /// # Errors
-    ///
-    /// This method requires exclusive access to underlying document store. This means that
-    /// no other transaction on that same document can be active while calling this method.
-    /// Otherwise, an error will be returned.
-    pub fn try_redo(&mut self) -> Result<bool, TransactionAcqError> {
-        let origin = self.as_origin();
-        let inner = Arc::get_mut(&mut self.state).unwrap();
-        let txn = self.doc.try_transact_mut_with(origin.clone())?;
-        let changed = Self::redo_inner(inner, txn, origin);
-        Ok(changed)
+    fn pop_blocking(state: &mut Inner<M>, undoing: bool) -> bool {
+        state.undoing = undoing;
+        state.redoing = !undoing;
+        let origin = Origin::from(state as *mut Inner<M> as usize);
+        let (stack, other) = if undoing {
+            (&mut state.undo_stack, &state.redo_stack)
+        } else {
+            (&mut state.redo_stack, &state.undo_stack)
+        };
+        let mut changed = false;
+        while let Some(item) = stack.pop() {
+            if let Some(doc) = state.docs.get(&item.doc) {
+                let txn = doc.transact_mut_with(origin.clone());
+
+                if Self::try_process(
+                    item,
+                    txn,
+                    stack,
+                    other,
+                    &state.scope,
+                    &mut state.observer_popped,
+                    undoing,
+                    origin.clone(),
+                ) {
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        state.undoing = false;
+        state.redoing = false;
+        changed
     }
 
-    fn redo_inner(inner: &mut Inner<M>, mut txn: TransactionMut, origin: Origin) -> bool {
-        inner.redoing = true;
-        let result = Self::pop(
-            &mut inner.redo_stack,
-            &inner.undo_stack,
-            &mut txn,
-            &inner.scope,
-        );
+    fn try_process(
+        item: StackItem<M>,
+        mut txn: TransactionMut,
+        stack: &mut UndoStack<M>,
+        other: &UndoStack<M>,
+        scope: &HashSet<BranchPtr>,
+        observer_popped: &mut Observer<UndoFn<M>>,
+        undoing: bool,
+        origin: Origin,
+    ) -> bool {
+        let mut to_redo = HashSet::<ItemPtr>::new();
+        let mut to_delete = Vec::<ItemPtr>::new();
+        let mut change_performed = false;
+
+        let deleted: Vec<_> = item.insertions.blocks().collect(&txn);
+        for slice in deleted {
+            if let BlockSlice::Item(slice) = slice {
+                let mut item = txn.store.materialize(slice);
+                if item.redone.is_some() {
+                    let slice = match txn.store_mut().follow_redone(item.id()) {
+                        Some(slice) => slice,
+                        None => return false,
+                    };
+                    item = txn.store.materialize(slice);
+                }
+
+                if !item.is_deleted() && scope.iter().any(|b| b.is_parent_of(Some(item))) {
+                    to_delete.push(item);
+                }
+            }
+        }
+
+        let mut deleted = item.deletions.blocks();
+        while let Some(slice) = deleted.next(&txn) {
+            if let BlockSlice::Item(slice) = slice {
+                let ptr = txn.store.materialize(slice);
+                if scope.iter().any(|b| b.is_parent_of(Some(ptr)))
+                    && !item.insertions.contains(ptr.id())
+                // Never redo structs in stackItem.insertions because they were created and deleted in the same capture interval.
+                {
+                    to_redo.insert(ptr);
+                }
+            }
+        }
+
+        for &ptr in to_redo.iter() {
+            let mut ptr = ptr;
+            change_performed |= ptr
+                .redo(&mut txn, &to_redo, &item.insertions, stack, other)
+                .is_some();
+        }
+
+        // We want to delete in reverse order so that children are deleted before
+        // parents, so we have more information available when items are filtered.
+        for &item in to_delete.iter().rev() {
+            // if self.options.delete_filter(item) {
+            txn.delete(item);
+            change_performed = true;
+        }
+
         txn.commit();
-        let changed = if let Some(item) = result {
-            let mut e = Event::redo(item.meta, Some(origin), txn.changed_parent_types.clone());
-            if inner.observer_popped.has_subscribers() {
-                inner.observer_popped.trigger(|fun| fun(&txn, &mut e));
+        if change_performed {
+            txn.commit();
+            let mut e = if undoing {
+                Event::undo(item.meta, Some(origin), txn.changed_parent_types.clone())
+            } else {
+                Event::redo(item.meta, Some(origin), txn.changed_parent_types.clone())
+            };
+            if observer_popped.has_subscribers() {
+                observer_popped.trigger(|fun| fun(&txn, &mut e));
             }
             true
         } else {
             false
-        };
-        inner.redoing = false;
-        changed
-    }
-
-    fn pop(
-        stack: &mut UndoStack<M>,
-        other: &UndoStack<M>,
-        txn: &mut TransactionMut,
-        scope: &HashSet<BranchPtr>,
-    ) -> Option<StackItem<M>> {
-        let mut result = None;
-        while let Some(item) = stack.pop() {
-            let mut to_redo = HashSet::<ItemPtr>::new();
-            let mut to_delete = Vec::<ItemPtr>::new();
-            let mut change_performed = false;
-
-            let deleted: Vec<_> = item.insertions.blocks().collect(txn);
-            for slice in deleted {
-                if let BlockSlice::Item(slice) = slice {
-                    let mut item = txn.store.materialize(slice);
-                    if item.redone.is_some() {
-                        let slice = txn.store_mut().follow_redone(item.id())?;
-                        item = txn.store.materialize(slice);
-                    }
-
-                    if !item.is_deleted() && scope.iter().any(|b| b.is_parent_of(Some(item))) {
-                        to_delete.push(item);
-                    }
-                }
-            }
-
-            let mut deleted = item.deletions.blocks();
-            while let Some(slice) = deleted.next(txn) {
-                if let BlockSlice::Item(slice) = slice {
-                    let ptr = txn.store.materialize(slice);
-                    if scope.iter().any(|b| b.is_parent_of(Some(ptr)))
-                        && !item.insertions.contains(ptr.id())
-                    // Never redo structs in stackItem.insertions because they were created and deleted in the same capture interval.
-                    {
-                        to_redo.insert(ptr);
-                    }
-                }
-            }
-
-            for &ptr in to_redo.iter() {
-                let mut ptr = ptr;
-                change_performed |= ptr
-                    .redo(txn, &to_redo, &item.insertions, stack, other)
-                    .is_some();
-            }
-
-            // We want to delete in reverse order so that children are deleted before
-            // parents, so we have more information available when items are filtered.
-            for &item in to_delete.iter().rev() {
-                // if self.options.delete_filter(item) {
-                txn.delete(item);
-                change_performed = true;
-            }
-
-            if change_performed {
-                result = Some(item);
-                break;
-            }
         }
-        result
     }
 }
 
@@ -748,8 +744,10 @@ impl<M: std::fmt::Debug> std::fmt::Debug for UndoManager<M> {
 impl<M> Drop for UndoManager<M> {
     fn drop(&mut self) {
         let origin = Origin::from(Arc::as_ptr(&self.state) as usize);
-        self.doc.unobserve_destroy(origin.clone()).unwrap();
-        self.doc.unobserve_after_transaction(origin).unwrap();
+        for doc in self.state.docs.values() {
+            doc.unobserve_destroy(origin.clone()).unwrap();
+            doc.unobserve_after_transaction(origin.clone()).unwrap();
+        }
     }
 }
 
@@ -836,6 +834,7 @@ impl<M> Default for Options<M> {
 /// the end of the last stack item batch.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct StackItem<T> {
+    doc: Uuid,
     deletions: IdSet,
     insertions: IdSet,
 
@@ -846,8 +845,9 @@ pub struct StackItem<T> {
 }
 
 impl<M> StackItem<M> {
-    pub fn with_meta(deletions: IdSet, insertions: IdSet, meta: M) -> Self {
+    pub fn with_meta(doc: Uuid, deletions: IdSet, insertions: IdSet, meta: M) -> Self {
         StackItem {
+            doc,
             deletions,
             insertions,
             meta,
@@ -884,8 +884,8 @@ impl<M> StackItem<M> {
 }
 
 impl<M: Default> StackItem<M> {
-    pub fn new(deletions: IdSet, insertions: IdSet) -> Self {
-        Self::with_meta(deletions, insertions, M::default())
+    pub fn new(doc_id: Uuid, deletions: IdSet, insertions: IdSet) -> Self {
+        Self::with_meta(doc_id, deletions, insertions, M::default())
     }
 }
 
@@ -902,7 +902,7 @@ impl<M> std::fmt::Display for StackItem<M> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct StackClearedEvent {
     pub undo_stack_cleared: bool,
     pub redo_stack_cleared: bool,
@@ -1008,7 +1008,8 @@ mod test {
     fn undo_text() {
         let d1 = Doc::with_client_id(1);
         let txt1 = d1.get_or_insert_text("test");
-        let mut mgr = UndoManager::new(&d1, &txt1);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&d1, &txt1);
 
         let d2 = Doc::with_client_id(2);
         let txt2 = d2.get_or_insert_text("test");
@@ -1084,7 +1085,8 @@ mod test {
         let txt = doc.get_or_insert_text("test");
         txt.insert(&mut doc.transact_mut(), 0, "1221");
 
-        let mut mgr = UndoManager::new(&doc, &txt);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&doc, &txt);
         txt.insert(&mut doc.transact_mut(), 2, "3");
         txt.insert(&mut doc.transact_mut(), 3, "3");
 
@@ -1104,7 +1106,8 @@ mod test {
         let map2 = d2.get_or_insert_map("test");
 
         map1.insert(&mut d1.transact_mut(), "a", 0);
-        let mut mgr = UndoManager::new(&d1, &map1);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&d1, &map1);
         map1.insert(&mut d1.transact_mut(), "a", 1);
         mgr.undo_blocking();
         assert_eq!(map1.get(&d1.transact(), "a").unwrap(), 0.into());
@@ -1156,7 +1159,8 @@ mod test {
         let d2 = Doc::with_client_id(2);
         let array2 = d2.get_or_insert_array("test");
 
-        let mut mgr = UndoManager::new(&d1, &array1);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&d1, &array1);
         array1.insert_range(&mut d1.transact_mut(), 0, [1, 2, 3]);
         array2.insert_range(&mut d2.transact_mut(), 0, [4, 5, 6]);
 
@@ -1258,7 +1262,8 @@ mod test {
             XmlElementPrelim::empty("undefined"),
         );
 
-        let mut mgr = UndoManager::new(&d1, &xml1);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&d1, &xml1);
         let child = xml1.insert(&mut d1.transact_mut(), 0, XmlElementPrelim::empty("p"));
         let text_child = child.insert(&mut d1.transact_mut(), 0, XmlTextPrelim::new("content"));
 
@@ -1304,7 +1309,8 @@ mod test {
 
         let doc = Doc::with_client_id(1);
         let txt = doc.get_or_insert_text("test");
-        let mut mgr: UndoManager<Metadata> = UndoManager::new(&doc, &txt);
+        let mut mgr: UndoManager<Metadata> = UndoManager::new();
+        mgr.expand_scope(&doc, &txt);
 
         let result = Arc::new(AtomicUsize::new(0));
         let counter = AtomicUsize::new(1);
@@ -1338,9 +1344,14 @@ mod test {
         use crate::undo::UndoManager;
         type Metadata = HashMap<String, usize>;
         let (undo_stack_json, redo_stack_json, state) = {
-            let d1 = Doc::with_client_id(1);
+            let d1 = Doc::with_options(crate::Options {
+                client_id: ClientID::new(1),
+                guid: "A".into(),
+                ..crate::Options::default()
+            });
             let txt = d1.get_or_insert_text("test");
-            let mut m1: UndoManager<Metadata> = UndoManager::new(&d1, &txt);
+            let mut m1: UndoManager<Metadata> = UndoManager::new();
+            m1.expand_scope(&d1, &txt);
 
             let txt_clone = txt.clone();
             let _sub1 = m1.observe_item_added(move |_, e| {
@@ -1365,10 +1376,14 @@ mod test {
         };
 
         let undo_stack: Vec<StackItem<Metadata>> = serde_json::from_str(&undo_stack_json).unwrap();
-        let redo_stack: Vec<StackItem<Metadata>> = serde_json::from_str(&undo_stack_json).unwrap();
+        let redo_stack: Vec<StackItem<Metadata>> = serde_json::from_str(&redo_stack_json).unwrap();
 
         // try to recreate the stack
-        let d2 = Doc::with_client_id(1);
+        let d2 = Doc::with_options(crate::Options {
+            client_id: ClientID::new(2),
+            guid: "A".into(),
+            ..crate::Options::default()
+        });
         let txt = d2.get_or_insert_text("test");
         let undo_options = Options {
             init_undo_stack: undo_stack,
@@ -1378,8 +1393,8 @@ mod test {
         d2.transact_mut()
             .apply_update(Update::decode_v1(&state).unwrap())
             .unwrap();
-        let mut m2: UndoManager<Metadata> = UndoManager::with_options(&d2, undo_options);
-        m2.expand_scope(&txt);
+        let mut m2: UndoManager<Metadata> = UndoManager::with_options(undo_options);
+        m2.expand_scope(&d2, &txt);
 
         m2.undo_blocking();
         assert_eq!(txt.get_string(&d2.transact()), "bc");
@@ -1407,10 +1422,12 @@ mod test {
 
         exchange_updates(&[&d1, &d2]);
 
-        let mut mgr1 = UndoManager::new(&d1, &arr1);
+        let mut mgr1 = UndoManager::new();
+        mgr1.expand_scope(&d1, &arr1);
         mgr1.include_origin(d1.client_id());
 
-        let mut mgr2 = UndoManager::new(&d2, &arr2);
+        let mut mgr2 = UndoManager::new();
+        mgr2.expand_scope(&d2, &arr2);
         mgr2.include_origin(d2.client_id());
 
         map1b.insert(
@@ -1451,11 +1468,12 @@ mod test {
             ..crate::doc::Options::default()
         });
         let design = doc.get_or_insert_map("map");
-        let mut mgr = UndoManager::with_scope_and_options(&doc, &design, {
+        let mut mgr = UndoManager::with_options({
             let mut o = Options::default();
             o.capture_timeout_millis = 0;
             o
         });
+        mgr.expand_scope(&doc, &design);
         {
             let mut txn = doc.transact_mut();
             design.insert(
@@ -1528,7 +1546,8 @@ mod test {
         // https://github.com/yjs/yjs/issues/355
         let doc = Doc::with_client_id(1);
         let root = doc.get_or_insert_map("root");
-        let mut mgr = UndoManager::new(&doc, &root);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&doc, &root);
 
         root.insert(
             &mut doc.transact_mut(),
@@ -1600,11 +1619,12 @@ mod test {
         const ORIGIN: &str = "origin";
         let doc = Doc::with_client_id(1);
         let f = doc.get_or_insert_xml_fragment("t");
-        let mut mgr = UndoManager::with_scope_and_options(&doc, &f, {
+        let mut mgr = UndoManager::with_options({
             let mut o = Options::default();
             o.capture_timeout_millis = 0;
             o
         });
+        mgr.expand_scope(&doc, &f);
         mgr.include_origin(ORIGIN);
 
         // create element
@@ -1655,11 +1675,12 @@ mod test {
             o
         });
         let design = doc.get_or_insert_map("map");
-        let mut mgr = UndoManager::with_scope_and_options(&doc, &design, {
+        let mut mgr = UndoManager::with_options({
             let mut o = Options::default();
             o.capture_timeout_millis = 0;
             o
         });
+        mgr.expand_scope(&doc, &design);
         let text = {
             let mut txn = doc.transact_mut();
             design.insert(
@@ -1734,7 +1755,8 @@ mod test {
         let txt2 = doc2.get_or_insert_text("test");
 
         send(&doc1, &doc2); // D2: 'Attack ships on fire off the shoulder of Orion.'
-        let mut mgr = UndoManager::new(&doc1, &txt);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&doc1, &txt);
 
         let attrs = Attrs::from([("bold".into(), true.into())]);
         txt.format(&mut doc1.transact_mut(), 13, 7, attrs.clone()); // D1: 'Attack ships <b>on fire</b> off the shoulder of Orion.'
@@ -1777,7 +1799,8 @@ mod test {
         const ORIGIN: &str = "undoable";
         let doc = Doc::with_client_id(1);
         let f = doc.get_or_insert_xml_fragment("test");
-        let mut mgr = UndoManager::new(&doc, &f);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&doc, &f);
         mgr.include_origin(ORIGIN);
         {
             let mut txn = doc.transact_mut();
@@ -1805,7 +1828,8 @@ mod test {
     fn undo_in_embed() {
         let d1 = Doc::with_client_id(1);
         let txt1 = d1.get_or_insert_text("test");
-        let mut mgr = UndoManager::new(&d1, &txt1);
+        let mut mgr = UndoManager::new();
+        mgr.expand_scope(&d1, &txt1);
 
         let d2 = Doc::with_client_id(2);
         let txt2 = d2.get_or_insert_text("test");
@@ -1852,7 +1876,8 @@ mod test {
         // https://github.com/y-crdt/y-crdt/issues/345
         let doc = Doc::new();
         let map = doc.get_or_insert_map("r");
-        let mut mgr = UndoManager::with_scope_and_options(&doc, &map, Options::default());
+        let mut mgr = UndoManager::with_options(Options::default());
+        mgr.expand_scope(&doc, &map);
         mgr.include_origin(doc.client_id());
 
         let s1 = map.insert(
@@ -1930,7 +1955,8 @@ mod test {
 
         let s1 = r.insert(&mut d.transact_mut(), "s1", MapPrelim::default());
 
-        let mut mgr = UndoManager::with_scope_and_options(&d, &r, Options::default());
+        let mut mgr = UndoManager::with_options(Options::default());
+        mgr.expand_scope(&d, &r);
         {
             let mut txn = d.transact_mut();
             let b1 = s1.insert(&mut txn, "b1", MapPrelim::default());
@@ -1973,7 +1999,8 @@ mod test {
         el1.insert(&mut doc.transact_mut(), "f1", 8); // { s1: { b1: [{ f1: 8 }] } }
         el1.insert(&mut doc.transact_mut(), "f2", true); // { s1: { b1: [{ f1: 8, f2: true }] } }
 
-        let mut mgr = UndoManager::with_scope_and_options(&doc, &r, Options::default());
+        let mut mgr = UndoManager::with_options(Options::default());
+        mgr.expand_scope(&doc, &r);
         {
             let mut txn = doc.transact_mut();
             let el0 = b1_arr.insert(&mut txn, 0, MapPrelim::default()); // { s1: { b1: [{}, { f1: 8, f2: true }] } }
@@ -2017,7 +2044,8 @@ mod test {
         s1.insert(&mut doc.transact_mut(), "f2", "AAA"); // { s1: { f2: AAA } }
         s1.insert(&mut doc.transact_mut(), "f1", false); // { s1: { f1: false, f2: AAA } }
 
-        let mut mgr = UndoManager::with_scope_and_options(&doc, &r, Options::default());
+        let mut mgr = UndoManager::with_options(Options::default());
+        mgr.expand_scope(&doc, &r);
         s1.remove(&mut doc.transact_mut(), "f2"); // { s1: { f1: false } }
         mgr.reset();
 
@@ -2055,7 +2083,8 @@ mod test {
         b2_arr_nest.insert(&mut d.transact_mut(), 0, 232291652); // {r:{s1:{b1:[{b2:[[232291652]]}]}}
         b2_arr_nest.insert(&mut d.transact_mut(), 1, -30); // {r:{s1:{b1:[{b2:[[232291652, -30]]}]}}
 
-        let mut mgr = UndoManager::with_scope_and_options(&d, &r, Options::default());
+        let mut mgr = UndoManager::with_options(Options::default());
+        mgr.expand_scope(&d, &r);
 
         let mut txn = d.transact_mut();
         b2_arr_nest.remove(&mut txn, 1); // {r:{s1:{b1:[{b2:[[232291652]]}]}}

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -470,7 +470,8 @@ where
     ///
     /// // without UndoManager::stop
     /// let txt = doc.get_or_insert_text("no-stop");
-    /// let mut mgr = UndoManager::new(&doc, &txt);
+    /// let mut mgr = UndoManager::new();
+    /// mgr.expand_scope(&doc, &txt);
     /// txt.insert(&mut doc.transact_mut(), 0, "a");
     /// txt.insert(&mut doc.transact_mut(), 1, "b");
     /// mgr.undo_blocking();
@@ -478,7 +479,8 @@ where
     ///
     /// // with UndoManager::stop
     /// let txt = doc.get_or_insert_text("with-stop");
-    /// let mut mgr = UndoManager::new(&doc, &txt);
+    /// let mut mgr = UndoManager::new();
+    /// mgr.expand_scope(&doc, &txt);
     /// txt.insert(&mut doc.transact_mut(), 0, "a");
     /// mgr.reset();
     /// txt.insert(&mut doc.transact_mut(), 1, "b");

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -226,13 +226,13 @@ where
         if Self::should_skip(inner, txn) {
             return;
         }
+        let target = txn.doc().guid();
         let undoing = inner.undoing;
         let redoing = inner.redoing;
         if undoing {
             inner.last_change = 0; // next undo should not be appended to last stack item
         } else if !redoing {
             // neither undoing nor redoing: delete redoStack
-            let target = txn.doc().guid();
             let scope = &inner.scope;
             inner.redo_stack.0.retain_mut(|stack_item| {
                 if stack_item.doc != target {
@@ -258,13 +258,18 @@ where
         } else {
             &mut inner.undo_stack
         };
-        // should we extend the last stack item or create a new one?
+        // Does current change and the last one belong to the same doc?
+        let same_doc = match stack.last() {
+            None => false,
+            Some(item) => item.doc == target,
+        };
         let extend = !undoing
             && !redoing
-            && !stack.is_empty()
+            && same_doc
             && inner.last_change > 0
             && now - inner.last_change < inner.options.capture_timeout_millis;
 
+        // should we extend the last stack item or create a new one?
         if extend {
             // append change to last stack op
             let last_op = stack.last_mut().unwrap(); // always true - we checked if stack is empty above
@@ -2124,4 +2129,111 @@ mod test {
             any!({"s1":{"b1":[{"b2":[[232291652, -30]]}]}})
         );
     }
+
+    #[test]
+    fn multi_doc_undo() {
+        let mut um = UndoManager::new();
+        let d1 = Doc::new();
+        let d2 = Doc::new();
+        let txt1 = d1.get_or_insert_text("text");
+        let txt2 = d2.get_or_insert_text("text");
+
+        um.expand_scope(&d1, &txt1);
+        um.expand_scope(&d2, &txt2);
+
+        txt1.insert(&mut d1.transact_mut(), 0, "abc");
+        txt2.insert(&mut d2.transact_mut(), 0, "xyz");
+
+        assert_eq!(um.undo_stack().len(), 2);
+        assert!(um.can_undo(), "should be undoable (1)");
+        assert!(!um.can_redo(), "should not be redoable (1)");
+
+        um.undo_blocking();
+
+        assert!(um.can_undo(), "should be undoable (2)");
+        assert!(um.can_redo(), "should be redoable (2)");
+        assert_eq!(txt1.get_string(&d1.transact()), "abc");
+        assert_eq!(txt2.get_string(&d2.transact()), "");
+
+        um.undo_blocking();
+
+        assert!(!um.can_undo(), "should not be undoable (3)");
+        assert!(um.can_redo(), "should be redoable (3)");
+        assert_eq!(txt1.get_string(&d1.transact()), "");
+        assert_eq!(txt2.get_string(&d2.transact()), "");
+
+        // shouldn't have any effect
+        assert!(!um.undo_blocking(), "undo should have no effect");
+        assert!(!um.can_undo(), "should not be undoable (4)");
+        assert!(um.can_redo(), "should be redoable (4)");
+        assert_eq!(txt1.get_string(&d1.transact()), "");
+        assert_eq!(txt2.get_string(&d2.transact()), "");
+
+        um.redo_blocking();
+
+        assert!(um.can_undo(), "should be undoable (5)");
+        assert!(um.can_redo(), "should be redoable (5)");
+        assert_eq!(txt1.get_string(&d1.transact()), "abc");
+        assert_eq!(txt2.get_string(&d2.transact()), "");
+
+        um.redo_blocking();
+
+        assert_eq!(um.undo_stack().len(), 2);
+        assert!(um.can_undo(), "should be undoable (6)");
+        assert!(!um.can_redo(), "should not be redoable (6)");
+        assert_eq!(txt1.get_string(&d1.transact()), "abc");
+        assert_eq!(txt2.get_string(&d2.transact()), "xyz");
+    }
+
+    #[test]
+    fn multi_doc_after_destroy() {
+        let mut um = UndoManager::with_options({
+            let mut o = Options::default();
+            o.capture_timeout_millis = 0;
+            o
+        });
+        let d1 = Doc::new();
+        let d2 = Doc::new();
+        let txt1 = d1.get_or_insert_text("text");
+        let txt2 = d2.get_or_insert_text("text");
+
+        um.expand_scope(&d1, &txt1);
+        um.expand_scope(&d2, &txt2);
+        um.expand_scope(&d1, &txt1); // doing this twice for test-coverage
+
+        txt1.insert(&mut d1.transact_mut(), 0, "a");
+        txt2.insert(&mut d2.transact_mut(), 0, "b");
+
+        assert_eq!(txt1.get_string(&d1.transact()), "a");
+        d2.destroy(None);
+        assert!(um.docs().all(|d| d.guid() != d2.guid()));
+
+        um.undo_blocking();
+        assert_eq!(txt1.get_string(&d1.transact()), "");
+    }
+
+    /*
+
+    /**
+     * @param {t.TestCase} _tc
+     */
+    export const testAfterDestroy = _tc => {
+      const um = new YMultiDocUndoManager([], { captureTimeout: -1 })
+      const ydoc1 = new Y.Doc()
+      const ytype1 = ydoc1.getText()
+      const ydoc2 = new Y.Doc()
+      const ytype2 = ydoc2.getText()
+      um.addToScope([ytype1])
+      um.addToScope([ytype2])
+      um.addToScope(ytype1) // doing this twice for test-coverage
+      ytype1.insert(0, 'a')
+      ytype2.insert(0, 'b')
+      t.assert(ytype1.toString() === 'a')
+      ydoc2.destroy()
+      t.assert(!um.docs.has(ydoc2))
+      um.undo()
+      t.assert(ytype1.toString() === '')
+      um.destroy()
+    }
+         */
 }

--- a/ywasm/src/array.rs
+++ b/ywasm/src/array.rs
@@ -59,6 +59,14 @@ impl YArray {
         self.0.id()
     }
 
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> Option<crate::Doc> {
+        match &self.0 {
+            SharedCollection::Integrated(i) => Some(crate::Doc(i.doc.clone())),
+            SharedCollection::Prelim(_) => None,
+        }
+    }
+
     /// Returns true if this is a preliminary instance of `YArray`.
     ///
     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.

--- a/ywasm/src/doc.rs
+++ b/ywasm/src/doc.rs
@@ -291,16 +291,12 @@ impl YDoc {
     pub fn destroy(&self, parent_txn: &ImplicitTransaction) -> Result<()> {
         match YTransaction::from_implicit_mut(parent_txn)? {
             Some(mut parent_txn) => {
-                self.0.destroy(parent_txn.as_mut()?);
+                self.0.destroy(Some(parent_txn.as_mut()?));
             }
             None => {
-                let parent_doc = if let Some(parent_doc) = self.0.parent_doc() {
-                    parent_doc
-                } else {
-                    return Ok(());
-                };
-                let mut parent_txn = parent_doc.transact_mut();
-                self.0.destroy(&mut parent_txn);
+                let parent_doc = self.0.parent_doc();
+                let mut parent_txn = parent_doc.as_ref().map(|doc| doc.transact_mut());
+                self.0.destroy(parent_txn.as_mut());
             }
         }
         Ok(())

--- a/ywasm/src/map.rs
+++ b/ywasm/src/map.rs
@@ -61,6 +61,14 @@ impl YMap {
         self.0.id()
     }
 
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> Option<crate::Doc> {
+        match &self.0 {
+            SharedCollection::Integrated(i) => Some(crate::Doc(i.doc.clone())),
+            SharedCollection::Prelim(_) => None,
+        }
+    }
+
     /// Returns true if this is a preliminary instance of `YMap`.
     ///
     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.

--- a/ywasm/src/text.rs
+++ b/ywasm/src/text.rs
@@ -52,6 +52,14 @@ impl YText {
         self.0.id()
     }
 
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> Option<crate::Doc> {
+        match &self.0 {
+            SharedCollection::Integrated(i) => Some(crate::Doc(i.doc.clone())),
+            SharedCollection::Prelim(_) => None,
+        }
+    }
+
     /// Returns true if this is a preliminary instance of `YArray`.
     ///
     /// Preliminary instances can be nested into other shared data types such as `YArray` and `YMap`.

--- a/ywasm/src/undo.rs
+++ b/ywasm/src/undo.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use js_sys::Reflect;
+use wasm_bindgen::convert::TryFromJsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -37,9 +38,7 @@ impl YUndoManager {
 #[wasm_bindgen]
 impl YUndoManager {
     #[wasm_bindgen(constructor)]
-    pub fn new(doc: &YDoc, scope: JsValue, options: JsValue) -> Result<YUndoManager> {
-        let doc = &doc.0;
-        let scope = Self::get_scope(doc, &scope)?;
+    pub fn new(options: JsValue) -> Result<YUndoManager> {
         let mut o = yrs::undo::Options {
             capture_timeout_millis: 500,
             tracked_origins: HashSet::new(),
@@ -64,16 +63,16 @@ impl YUndoManager {
                 }
             }
         }
-        Ok(YUndoManager(UndoManager::with_scope_and_options(
-            doc, &scope, o,
-        )))
+        Ok(YUndoManager(UndoManager::with_options(o)))
     }
 
     #[wasm_bindgen(js_name = addToScope)]
     pub fn add_to_scope(&mut self, ytypes: js_sys::Array) -> Result<()> {
         for js in ytypes.iter() {
-            let scope = Self::get_scope(self.0.doc(), &js)?;
-            self.0.expand_scope(&scope);
+            let doc = js_sys::Reflect::get(&js, &JsValue::from_str("doc"))?;
+            let doc = crate::Doc::try_from_js_value(doc)?;
+            let scope = Self::get_scope(&doc.0, &js)?;
+            self.0.expand_scope(&doc.0, &scope);
         }
         Ok(())
     }
@@ -106,21 +105,13 @@ impl YUndoManager {
     }
 
     #[wasm_bindgen(js_name = undo)]
-    pub fn undo(&mut self) -> Result<()> {
-        if let Err(_) = self.0.try_undo() {
-            Err(JsValue::from_str(crate::js::errors::ANOTHER_TX))
-        } else {
-            Ok(())
-        }
+    pub fn undo(&mut self) {
+        self.0.undo_blocking();
     }
 
     #[wasm_bindgen(js_name = redo)]
-    pub fn redo(&mut self) -> Result<()> {
-        if let Err(_) = self.0.try_redo() {
-            Err(JsValue::from_str(crate::js::errors::ANOTHER_TX))
-        } else {
-            Ok(())
-        }
+    pub fn redo(&mut self) {
+        self.0.redo_blocking();
     }
 
     #[wasm_bindgen(getter, js_name = canUndo)]

--- a/ywasm/src/xml_elem.rs
+++ b/ywasm/src/xml_elem.rs
@@ -83,6 +83,14 @@ impl YXmlElement {
         self.0.id()
     }
 
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> Option<crate::Doc> {
+        match &self.0 {
+            SharedCollection::Integrated(i) => Some(crate::Doc(i.doc.clone())),
+            SharedCollection::Prelim(_) => None,
+        }
+    }
+
     /// Returns true if this is a preliminary instance of `YXmlElement`.
     ///
     /// Preliminary instances can be nested into other shared data types.

--- a/ywasm/src/xml_frag.rs
+++ b/ywasm/src/xml_frag.rs
@@ -42,6 +42,14 @@ impl YXmlFragment {
         self.0.id()
     }
 
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> Option<crate::Doc> {
+        match &self.0 {
+            SharedCollection::Integrated(i) => Some(crate::Doc(i.doc.clone())),
+            SharedCollection::Prelim(_) => None,
+        }
+    }
+
     /// Returns true if this is a preliminary instance of `YXmlFragment`.
     ///
     /// Preliminary instances can be nested into other shared data types.

--- a/ywasm/src/xml_text.rs
+++ b/ywasm/src/xml_text.rs
@@ -64,6 +64,14 @@ impl YXmlText {
         self.0.id()
     }
 
+    #[wasm_bindgen(getter, js_name = doc)]
+    pub fn doc(&self) -> Option<crate::Doc> {
+        match &self.0 {
+            SharedCollection::Integrated(i) => Some(crate::Doc(i.doc.clone())),
+            SharedCollection::Prelim(_) => None,
+        }
+    }
+
     /// Returns true if this is a preliminary instance of `YXmlText`.
     ///
     /// Preliminary instances can be nested into other shared data types.


### PR DESCRIPTION
Modified API of `UndoManager` to make it possible for it to work across different documents:
1. `UndoManager::new` no longer accepts initial doc+type. Now you need to add them explicitly.
2. `UndoManager::extend_scope` now takes `&Doc` as a parameter to identify the document context of the type that is added. Calling `Doc::destroy` will remove it from the context.
3. `Doc::destroy` now takes a parent transaction as an optional parameter and can be called without parent doc.
4. `StackItem` now has `doc` property, which points to `Doc::guid` so that we can identify undo/redo elements coming from different documents. **This is breaking change** as applying `StackItem` now requires `Doc` with stack item's guid to be present in UndoManager scope, otherwise they will be silently dropped.
5. No more `UndoManager::try_undo`/`try_redo` methods. If you really need them, the async variant (`undo`/`redo`) returns a Promise, which when polled will return `Poll::Ready` when transaction could have been obtained right away, and `Poll::Pending` if the transaction was already locked.