### PR TITLE
release v0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "yffi"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "serde_json",
  "yrs",
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "arc-swap",
  "assert_matches2",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "ywasm"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "base64_light",
  "console_error_panic_hook",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.26.0",
+      "version": "0.27.0",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/Cargo.toml
+++ b/yffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yffi"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "c-ffi", "yrs"]
 edition = "2018"
@@ -12,7 +12,7 @@ description = "Bindings for the Yrs native C foreign function interface"
 [dev-dependencies]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.26.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.27.0", features = ["weak"] }
 serde_json = { version = "1.0" }
 
 [lib]

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrs"
-version = "0.26.0"
+version = "0.27.0"
 description = "High performance implementation of the Yjs CRDT"
 license = "MIT"
 authors = ["Kevin Jahns <kevin.jahns@pm.me>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]

--- a/ywasm/Cargo.toml
+++ b/ywasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ywasm"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Kevin Jahns <kevin.jahns@protonmail.com>", "Bartosz Sypytkowski <b.sypytkowski@gmail.com>"]
 keywords = ["crdt", "wasm", "yrs"]
 edition = "2018"
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-yrs = { path = "../yrs", version = "0.26.0", features = ["weak"] }
+yrs = { path = "../yrs", version = "0.27.0", features = ["weak"] }
 wasm-bindgen = { version = "0.2" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
- New type: `IdMap` (#616) - works similar to `IdSet` but allows for attribution of individual ranges it describes.
- `UndoManager` now works across multiple documents (#620, #621):
    - **breaking**: `UndoManager::new` and other constructors don't take initial doc/type anymore.
    - **breaking**: `UndoManager::expand_scope` now required `&Doc` parameter (since it can operate over multiple documents).
    - **breaking**: `StackItem.doc` field to define `Doc::guid` of the document the stack item refers to.
    - **breaking**: `UndoManager::clear` method has been replaced by more granular `clear_undo`, `clear_redo`, `clear_all` methods.
    - New API: `UndoManager.stack_cleared` event handler, 
- Removed `move_to`/`move_range` related API (#617). Article describing workaround: https://www.bartoszsypytkowski.com/replacing-yjs-move-feature/
- Observer callbacks now accepts `FnMut` instead of `Fn` (#619)
- Transaction related logic has been updated to match yjs v14 (#618):
    - introduction of `Transaction.insert_set`.
    - `Transaction.local`
    - support for cleanup formatting
    - now it's possible to integrate out-of-order updates if they don't have dependency over missing data
    