### PR TITLE
fix: partial Skip replacement was incorrectly slicing Skip block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,15 +182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,7 +343,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -458,19 +448,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
-name = "libz-sys"
-version = "1.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
-dependencies = [
- "cc",
- "cmake",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,12 +545,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -984,12 +955,6 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "wait-timeout"

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42",
+        "yjs": "14.0.0-16",
         "ywasm": "file:../ywasm/pkg",
         "zlib": "^1.0.5"
       }
@@ -30,9 +31,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.108",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.108.tgz",
-      "integrity": "sha512-+3eK/B0SqYoZiQu9fNk4VEc6EX8cb0Li96tPGKgugzoGj/OdRdREtuTLvUW+mtinoB2mFiJjSqOJBIaMkAGhxQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
@@ -44,6 +45,23 @@
       },
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "14.0.0-16",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-14.0.0-16.tgz",
+      "integrity": "sha512-n7jMrQz4pgU/NFnf4qY53K2adR/fu6ViQ79qVIw6Og+BtuDs1hx3DjOi3iREVnA6tsxQXXVG3gvG0I2kpmAwoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.115-6"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "lib0": "^0.2.42",
-        "yjs": "14.0.0-16",
         "ywasm": "file:../ywasm/pkg",
         "zlib": "^1.0.5"
       }
@@ -45,23 +44,6 @@
       },
       "engines": {
         "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
-    "node_modules/yjs": {
-      "version": "14.0.0-16",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-14.0.0-16.tgz",
-      "integrity": "sha512-n7jMrQz4pgU/NFnf4qY53K2adR/fu6ViQ79qVIw6Og+BtuDs1hx3DjOi3iREVnA6tsxQXXVG3gvG0I2kpmAwoQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.115-6"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",

--- a/tests-wasm/package.json
+++ b/tests-wasm/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "lib0": "^0.2.42",
     "ywasm": "file:../ywasm/pkg",
-    "zlib": "^1.0.5"
+    "zlib": "^1.0.5",
+    "yjs": "14.0.0-16"
   }
 }

--- a/tests-wasm/package.json
+++ b/tests-wasm/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "lib0": "^0.2.42",
     "ywasm": "file:../ywasm/pkg",
-    "zlib": "^1.0.5",
-    "yjs": "14.0.0-16"
+    "zlib": "^1.0.5"
   }
 }

--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -469,17 +469,18 @@ export const testMergeUpdatesV2 = tc => {
  * @param {t.TestCase} tc
  */
 export const testApplyUpdates = tc => {
-
+    // reference issue: https://github.com/y-crdt/yn/issues/3
     const U = h => new Uint8Array(Buffer.from(h, 'hex'))
-    const txt = u => {
-        const d = new yjs.Doc();
-        yjs.applyUpdate(d, u);
-        const s = d.getText('t').toString();
-        d.destroy();
+    const txt = updates => {
+        const doc = new Y.YDoc({gc: false})
+        for (const update of updates) {
+            Y.applyUpdate(doc, update)
+        }
+        const s = doc.getText('t').toString()
+        doc.free()
         return s
     }
 
-    // --- Bug 1: panic ---
     const B1 = [
         '0101b690c589040004010174016d00',
         '010198b0ea9c0e038498b0ea9c0e00016300',
@@ -489,15 +490,12 @@ export const testApplyUpdates = tc => {
         '010198b0ea9c0e02c498b0ea9c0e0198b0ea9c0e00016e00',
         '0101b690c589040184b690c5890400016400'
     ].map(U)
-    const expected = 'mddpc'
-    const actual = txt(Y.mergeUpdatesV1(B1))
-    t.compare(actual, expected)
+    let result = txt(B1)
+    t.compare(result, "mddpc")
 
-    // --- Bug 2: pending dropped ---
     const A = U('0101b5e7ece4090004010174017800')
     const B = U('0101b5e7ece4090184b5e7ece40900017900')
     const C = U('0101b5e7ece4090284b5e7ece40901017a00')
-    const expected2 = 'xyz'
-    const actual2 = txt(Y.applyUpdatesV1(false, [Y.applyUpdatesV1(false, [B, C]), A]))
-    t.compare(actual2, expected2)
+    result = txt([B, C, A])
+    t.compare(result, "xyz")
 }

--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -2,7 +2,6 @@ import {exchangeUpdates} from './testHelper.js' // eslint-disable-line
 
 import * as Y from 'ywasm'
 import * as t from 'lib0/testing'
-import * as yjs from 'yjs'
 
 /**
  * @param {t.TestCase} tc

--- a/tests-wasm/y-doc.tests.js
+++ b/tests-wasm/y-doc.tests.js
@@ -2,6 +2,7 @@ import {exchangeUpdates} from './testHelper.js' // eslint-disable-line
 
 import * as Y from 'ywasm'
 import * as t from 'lib0/testing'
+import * as yjs from 'yjs'
 
 /**
  * @param {t.TestCase} tc
@@ -462,4 +463,41 @@ export const testMergeUpdatesV2 = tc => {
     // Test merging empty array
     const emptyMerge = Y.mergeUpdatesV2([])
     t.assert(emptyMerge.length === 0, 'merging empty array should return empty update')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testApplyUpdates = tc => {
+
+    const U = h => new Uint8Array(Buffer.from(h, 'hex'))
+    const txt = u => {
+        const d = new yjs.Doc();
+        yjs.applyUpdate(d, u);
+        const s = d.getText('t').toString();
+        d.destroy();
+        return s
+    }
+
+    // --- Bug 1: panic ---
+    const B1 = [
+        '0101b690c589040004010174016d00',
+        '010198b0ea9c0e038498b0ea9c0e00016300',
+        '000198b0ea9c0e010201',
+        '010198b0ea9c0e0004010174017000',
+        '010198b0ea9c0e014498b0ea9c0e00016400',
+        '010198b0ea9c0e02c498b0ea9c0e0198b0ea9c0e00016e00',
+        '0101b690c589040184b690c5890400016400'
+    ].map(U)
+    const expected = 'mddpc'
+    const actual = txt(Y.mergeUpdatesV1(B1))
+    t.compare(actual, expected)
+
+    // --- Bug 2: pending dropped ---
+    const A = U('0101b5e7ece4090004010174017800')
+    const B = U('0101b5e7ece4090184b5e7ece40900017900')
+    const C = U('0101b5e7ece4090284b5e7ece40901017a00')
+    const expected2 = 'xyz'
+    const actual2 = txt(Y.applyUpdatesV1(false, [Y.applyUpdatesV1(false, [B, C]), A]))
+    t.compare(actual2, expected2)
 }

--- a/yrs/Cargo.toml
+++ b/yrs/Cargo.toml
@@ -30,7 +30,7 @@ dashmap = "6.0"
 
 [dev-dependencies]
 criterion = "0.5"
-flate2 = { version = "1", features = ["zlib-ng-compat"], default-features = false }
+flate2 = "1"
 ropey = "1.6.0"
 proptest = "1.2"
 proptest-derive = "0.4.0"

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -315,7 +315,7 @@ impl BlockStore {
                         let mut index = list.find_index(clock_start).unwrap();
                         let skip = unsafe { &mut *list.inner[index].get() };
                         let diff_start = clock_start - skip.clock_start();
-                        let diff_end = block.next_clock() - skip.next_clock();
+                        let diff_end = skip.next_clock() - block.next_clock();
                         if diff_start > 0 {
                             *skip = Block::Skip(BlockRange::new(skip.id(), diff_start));
                             index += 1;

--- a/yrs/src/block_store.rs
+++ b/yrs/src/block_store.rs
@@ -313,11 +313,11 @@ impl BlockStore {
                         // this replaces an integrated skip
                         let clock_start = block.clock_start();
                         let mut index = list.find_index(clock_start).unwrap();
-                        let skip = unsafe { &mut *list.inner[index].get() };
+                        let skip = unsafe { &*list.inner[index].get() };
                         let diff_start = clock_start - skip.clock_start();
                         let diff_end = skip.next_clock() - block.next_clock();
                         if diff_start > 0 {
-                            *skip = Block::Skip(BlockRange::new(skip.id(), diff_start));
+                            list.insert(index, Block::Skip(BlockRange::new(skip.id(), diff_start)));
                             index += 1;
                         }
                         if diff_end > 0 {

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -919,14 +919,18 @@ impl<'a> BlockPicker<'a> {
                 self.missing.set_min(*missing, missing_clock(missing));
                 for item in self.stack.drain(..) {
                     let client = *item.client();
-                    let unapplicable_blocks = match self.store.clients.remove(&client) {
-                        Some(mut blocks) => {
-                            blocks.push_front(item);
-                            blocks
-                        }
-                        // item was the last item on clientsStructRefs and the field was already cleared. Add item to restStructs and continue
-                        None => VecDeque::from([item]),
+                    let mut unapplicable_blocks = match self.store.clients.remove(&client) {
+                        Some(blocks) => blocks,
+                        None => match &mut self.latest {
+                            Some((latest_client, blocks)) if *latest_client == client => {
+                                std::mem::take(blocks)
+                            }
+                            // item was the last item on clientsStructRefs and the field was
+                            // already cleared. Add item to restStructs and continue
+                            _ => VecDeque::new(),
+                        },
                     };
+                    unapplicable_blocks.push_front(item);
                     self.unapplicable
                         .clients
                         .insert(client, unapplicable_blocks);

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1349,6 +1349,43 @@ mod test {
     }
 
     #[test]
+    fn apply_update_filling_partial_skip() {
+        // ref: https://github.com/y-crdt/yn/issues/3
+
+        // Sequence of updates that, when applied in order, leaves a client with an integrated
+        // Skip spanning two clocks and then delivers a single-clock block landing inside it.
+        let updates = [
+            vec![1, 1, 182, 144, 197, 137, 4, 0, 4, 1, 1, 116, 1, 109, 0],
+            vec![
+                1, 1, 152, 176, 234, 156, 14, 3, 132, 152, 176, 234, 156, 14, 0, 1, 99, 0,
+            ],
+            vec![0, 1, 152, 176, 234, 156, 14, 1, 2, 1],
+            vec![1, 1, 152, 176, 234, 156, 14, 0, 4, 1, 1, 116, 1, 112, 0],
+            vec![
+                1, 1, 152, 176, 234, 156, 14, 1, 68, 152, 176, 234, 156, 14, 0, 1, 100, 0,
+            ],
+            vec![
+                1, 1, 152, 176, 234, 156, 14, 2, 196, 152, 176, 234, 156, 14, 1, 152, 176, 234,
+                156, 14, 0, 1, 110, 0,
+            ],
+            vec![
+                1, 1, 182, 144, 197, 137, 4, 1, 132, 182, 144, 197, 137, 4, 0, 1, 100, 0,
+            ],
+        ];
+
+        let doc = Doc::new();
+        {
+            let mut txn = doc.transact_mut();
+            for u in &updates {
+                txn.apply_update(Update::decode_v1(u).unwrap()).unwrap();
+            }
+        }
+
+        let txt = doc.get_or_insert_text("t");
+        assert_eq!(txt.get_string(&doc.transact()), "mddpc");
+    }
+
+    #[test]
     fn update_state_vector_with_skips() {
         let mut update = Update::new();
         // skip followed by item => not included in state vector as it's not continuous from 0

--- a/yrs/src/update.rs
+++ b/yrs/src/update.rs
@@ -1386,6 +1386,74 @@ mod test {
     }
 
     #[test]
+    fn apply_update_filling_middle_of_skip() {
+        // Anchor client D builds "PQ".
+        let d = Doc::with_client_id(100);
+        {
+            let txt = d.get_or_insert_text("t");
+            let mut txn = d.transact_mut();
+            txt.insert(&mut txn, 0, "P");
+            txt.insert(&mut txn, 1, "Q");
+        }
+        let d_state = d
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+
+        // Client C syncs from D, then performs 4 single-block inserts. The anchoring is chosen so
+        // that:
+        //   - C:3 anchors only to remote blocks (left D:1, right none) => it can integrate while
+        //     C:1/C:2 are missing, creating a Skip over clocks [1,3).
+        //   - C:2 anchors to present blocks outside the Skip (left D:0, right C:0) => when it
+        //     arrives after C:3 it lands in the MIDDLE of the Skip (diff_start > 0).
+        let c = Doc::with_client_id(1);
+        c.transact_mut()
+            .apply_update(Update::decode_v1(&d_state).unwrap())
+            .unwrap();
+        let updates = Arc::new(Mutex::new(vec![]));
+        let sub = {
+            let updates = updates.clone();
+            c.observe_update_v1(move |_, e| updates.lock().unwrap().push(e.update.clone()))
+                .unwrap()
+        };
+        let txt = c.get_or_insert_text("t");
+        txt.insert(&mut c.transact_mut(), 1, "a"); // C:0  "PaQ"    left D:0, right D:1
+        txt.insert(&mut c.transact_mut(), 2, "b"); // C:1  "PabQ"   left C:0, right D:1
+        txt.insert(&mut c.transact_mut(), 1, "c"); // C:2  "PcabQ"  left D:0, right C:0
+        txt.insert(&mut c.transact_mut(), 5, "d"); // C:3  "PcabQd" left D:1, right none
+        drop(sub);
+
+        let mut msgs = vec![d_state];
+        msgs.extend(updates.lock().unwrap().iter().cloned());
+        // msgs: [D state, C:0, C:1, C:2, C:3]
+
+        let apply = |order: &[usize]| -> String {
+            let doc = Doc::new();
+            {
+                let mut txn = doc.transact_mut();
+                for &i in order {
+                    txn.apply_update(Update::decode_v1(&msgs[i]).unwrap())
+                        .unwrap();
+                }
+            }
+            let txt = doc.get_or_insert_text("t");
+            let s = txt.get_string(&doc.transact());
+            s
+        };
+
+        // ground truth: full causal delivery order
+        let causal = apply(&[0, 1, 2, 3, 4]);
+        assert_eq!(causal, "PcabQd");
+
+        // skip-inducing order: D, C:0, then C:3 (creates Skip[1,3)), then C:2 (fills the middle),
+        // then C:1. Must converge to the same document state.
+        let skipped = apply(&[0, 1, 4, 3, 2]);
+        assert_eq!(
+            skipped, causal,
+            "filling the middle of a Skip dropped a block"
+        );
+    }
+
+    #[test]
     fn update_state_vector_with_skips() {
         let mut update = Update::new();
         // skip followed by item => not included in state vector as it's not continuous from 0

--- a/ywasm/src/lib.rs
+++ b/ywasm/src/lib.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder};
-use yrs::{Assoc, ReadTxn, StickyIndex, Transact, TransactionMut, Update};
+use yrs::{Assoc, ReadTxn, StateVector, StickyIndex, Transact, TransactionMut, Update};
 
 mod array;
 mod awareness;
@@ -106,6 +106,74 @@ pub fn debug_update_v2(update: js_sys::Uint8Array) -> Result<String> {
         Ok(update) => Ok(format!("{:#?}", update)),
         Err(e) => Err(JsValue::from(e.to_string())),
     }
+}
+
+/// Similar to `mergeUpdatesV1` but instead of just merging the updates, it creates a temporary
+/// document, applies them and then performs garbage collection (if requested). Good for
+/// constructing document's state snapshot.
+#[wasm_bindgen(js_name = applyUpdatesV1)]
+pub fn apply_updates_v1(gc: bool, updates: Vec<Uint8Array>) -> Result<Uint8Array> {
+    let len = updates.len();
+    let mut decoded: Vec<Update> = Vec::with_capacity(len);
+    for bytes in updates {
+        let update =
+            Update::decode_v1(&bytes.to_vec()).map_err(|e| JsValue::from(e.to_string()))?;
+        decoded.push(update);
+    }
+
+    let opts = yrs::Options {
+        skip_gc: !gc,
+        ..Default::default()
+    };
+    let doc = yrs::Doc::with_options(opts);
+    {
+        let mut txn = doc.transact_mut();
+        for update in decoded {
+            if let Err(e) = txn.apply_update(update) {
+                return Err(JsValue::from(e.to_string()));
+            }
+        }
+    }
+
+    let bytes = doc
+        .transact()
+        .encode_state_as_update_v1(&StateVector::default());
+
+    Ok(Uint8Array::from(bytes.as_slice()))
+}
+
+/// Similar to `mergeUpdatesV2` but instead of just merging the updates, it creates a temporary
+/// document, applies them and then performs garbage collection (if requested). Good for
+/// constructing document's state snapshot.
+#[wasm_bindgen(js_name = applyUpdatesV2)]
+pub fn apply_updates_v2(gc: bool, updates: Vec<Uint8Array>) -> Result<Uint8Array> {
+    let len = updates.len();
+    let mut decoded: Vec<Update> = Vec::with_capacity(len);
+    for bytes in updates {
+        let update =
+            Update::decode_v2(&bytes.to_vec()).map_err(|e| JsValue::from(e.to_string()))?;
+        decoded.push(update);
+    }
+
+    let opts = yrs::Options {
+        skip_gc: !gc,
+        ..Default::default()
+    };
+    let doc = yrs::Doc::with_options(opts);
+    {
+        let mut txn = doc.transact_mut();
+        for update in decoded {
+            if let Err(e) = txn.apply_update(update) {
+                return Err(JsValue::from(e.to_string()));
+            }
+        }
+    }
+
+    let bytes = doc
+        .transact()
+        .encode_state_as_update_v2(&StateVector::default());
+
+    Ok(Uint8Array::from(bytes.as_slice()))
 }
 
 /// Merges a sequence of updates (encoded using lib0 v1 encoding) together, producing another


### PR DESCRIPTION
Related: https://github.com/y-crdt/yn/issues/3

1. When we integrated Skip block, then integrate Item that was partially overlapping with that Skip, the Skip block was sliced incorrectly.
2. In some conditions unapplicable blocks were not correctly extending existing pending list, but were replacing it instead causing missing updates.