### PR TITLE
fix: missing right neighbor when inserting at index 0

### DIFF
--- a/yrs/src/branch.rs
+++ b/yrs/src/branch.rs
@@ -475,7 +475,7 @@ impl Branch {
             }
         };
         let (left, right) = if index == 0 {
-            (None, None)
+            (None, self.start)
         } else {
             Branch::index_to_ptr(txn, start, index)
         };

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -1991,4 +1991,35 @@ mod test {
             assert_eq!(actual, "<p><b></b></p>");
         }
     }
+
+    #[test]
+    fn yrs_issue_636() {
+        // Doc A (client 1) builds <first/> inside a shared XML fragment.
+        let doc_a = Doc::with_client_id(1);
+        let frag_a = doc_a.get_or_insert_xml_fragment("frag");
+        frag_a.insert(
+            &mut doc_a.transact_mut(),
+            0,
+            XmlElementPrelim::empty("first"),
+        );
+        let update = doc_a
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+
+        // Doc B (client 2, larger id) applies it, then prepends <zero/> at index 0.
+        let doc_b = Doc::with_client_id(2);
+        let frag_b = doc_b.get_or_insert_xml_fragment("frag");
+        doc_b
+            .transact_mut()
+            .apply_update(Update::decode_v1(&update).unwrap())
+            .unwrap();
+        frag_b.insert(
+            &mut doc_b.transact_mut(),
+            0,
+            XmlElementPrelim::empty("zero"),
+        );
+
+        let xml = frag_b.get_string(&doc_b.transact());
+        assert_eq!(xml, "<zero></zero><first></first>"); // fails: "<first></first><zero></zero>"
+    }
 }


### PR DESCRIPTION
related issue: https://github.com/y-crdt/y-crdt/issues/636

Attribution to [QR-Madness](https://github.com/QR-Madness)