### PR TITLE
Harden decoders against length-prefix allocation bombs

### DIFF
--- a/yrs/src/any.rs
+++ b/yrs/src/any.rs
@@ -60,7 +60,10 @@ impl Any {
             // CASE 118: Map<string,Any>
             118 => {
                 let len: usize = decoder.read_var()?;
-                let mut map = HashMap::with_capacity(len);
+                // `len` is attacker-controlled; a fallible reservation avoids an allocation bomb
+                // (see `Update::decode`'s `try_reserve`).
+                let mut map = HashMap::new();
+                map.try_reserve(len)?;
                 for _ in 0..len {
                     let key = decoder.read_string()?;
                     map.insert(key.to_owned(), Any::decode(decoder)?);
@@ -70,7 +73,10 @@ impl Any {
             // CASE 117: Array<Any>
             117 => {
                 let len: usize = decoder.read_var()?;
-                let mut arr = Vec::with_capacity(len);
+                // `len` is attacker-controlled; a fallible reservation avoids an allocation bomb
+                // (see `Update::decode`'s `try_reserve`).
+                let mut arr = Vec::new();
+                arr.try_reserve(len)?;
                 for _ in 0..len {
                     arr.push(Any::decode(decoder)?);
                 }
@@ -848,4 +854,35 @@ macro_rules! any_unexpected {
 #[doc(hidden)]
 macro_rules! any_expect_expr_comma {
     ($e:expr , $($tt:tt)*) => {};
+}
+
+#[cfg(test)]
+mod test {
+    use crate::any::Any;
+    use crate::encoding::read::Cursor;
+
+    #[test]
+    fn decode_map_rejects_length_amplification() {
+        // Regression: an `Any::Map` whose length prefix declares a huge entry count (a few bytes)
+        // must not trigger an eager multi-hundred-MB allocation. `try_reserve` turns it into a
+        // recoverable decode error instead of an abort under a hard memory limit.
+        // Bytes: tag 118 (Map) + var-int len ~250M (0xFF 0xFF 0xFF 0x7A) + no data.
+        let adversarial = [118u8, 0xFF, 0xFF, 0xFF, 0x7A];
+        let mut cursor = Cursor::new(&adversarial);
+        assert!(
+            Any::decode(&mut cursor).is_err(),
+            "an oversized Any::Map length must be rejected, not eagerly allocated"
+        );
+    }
+
+    #[test]
+    fn decode_array_rejects_length_amplification() {
+        // As above, for `Any::Array`. Bytes: tag 117 (Array) + var-int len ~250M + no data.
+        let adversarial = [117u8, 0xFF, 0xFF, 0xFF, 0x7A];
+        let mut cursor = Cursor::new(&adversarial);
+        assert!(
+            Any::decode(&mut cursor).is_err(),
+            "an oversized Any::Array length must be rejected, not eagerly allocated"
+        );
+    }
 }

--- a/yrs/src/id_set.rs
+++ b/yrs/src/id_set.rs
@@ -88,7 +88,15 @@ impl Encode for IdRanges<()> {
 impl Decode for IdRanges<()> {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
         let len: u32 = decoder.read_var()?;
-        let mut ranges = SmallVec::with_capacity(len as usize);
+        // Do NOT pre-allocate `len` entries up front: `len` is attacker-controlled (a few bytes
+        // can declare a huge count), so `SmallVec::with_capacity(len)` is an allocation bomb that
+        // aborts under a hard memory limit. `SmallVec::try_reserve` returns smallvec's own
+        // `CollectionAllocErr` (not `std::collections::TryReserveError`), so it can't feed the
+        // existing `Error::NotEnoughMemory` variant without widening the public error enum.
+        // Instead let the `SmallVec` grow on push — each range consumes real bytes from the
+        // decoder, so growth is bounded by the actual input length and it keeps its inline buffer
+        // for the common small case. (State vector / block decoding use `try_reserve` directly.)
+        let mut ranges = SmallVec::new();
         for _ in 0..len {
             ranges.push((Range::decode(decoder)?, ()));
         }
@@ -628,6 +636,22 @@ pub(crate) mod test {
     }
 
     use std::ops::Range;
+
+    #[test]
+    fn decode_rejects_range_length_amplification() {
+        // Regression: an id set (used for delete sets carried by updates) must not let a few
+        // bytes declare a huge range count and trigger an eager multi-hundred-MB allocation
+        // (allocation bomb / DoS). Growing the `SmallVec` on push instead of pre-allocating
+        // `len` entries bounds the allocation by the actual input length, so an oversized count
+        // fails with a clean decode error instead of aborting under a hard memory limit.
+        // Bytes: client_len = 1, client = 1, range_count = ~250M (0xFF 0xFF 0xFF 0x7A), no data.
+        let adversarial = [0x01u8, 0x01, 0xFF, 0xFF, 0xFF, 0x7A];
+        let result = IdSet::decode_v1(&adversarial);
+        assert!(
+            result.is_err(),
+            "an oversized id range length must be rejected, not eagerly allocated"
+        );
+    }
 
     #[test]
     fn id_range_merge_continous() {

--- a/yrs/src/state_vector.rs
+++ b/yrs/src/state_vector.rs
@@ -117,7 +117,12 @@ impl FromIterator<(ClientID, u32)> for StateVector {
 impl Decode for StateVector {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, Error> {
         let len = decoder.read_var::<u32>()? as usize;
-        let mut sv = HashMap::with_capacity_and_hasher(len, BuildHasherDefault::default());
+        // Attempt to pre-allocate memory for the state vector. `len` is attacker-controlled
+        // (a few bytes can declare a huge count), so a fallible reservation turns an
+        // allocation bomb into a recoverable decode error instead of an abort. Mirrors the
+        // `try_reserve` pattern already used for blocks in `Update::decode`.
+        let mut sv = HashMap::with_hasher(BuildHasherDefault::default());
+        sv.try_reserve(len)?;
         let mut i = 0;
         while i < len {
             let client: u64 = decoder.read_var()?;
@@ -209,9 +214,25 @@ impl Decode for Snapshot {
 #[cfg(test)]
 mod test {
     use crate::block::ClientID;
+    use crate::updates::decoder::Decode;
     use crate::{Doc, ReadTxn, StateVector, Text, Transact, WriteTxn};
     use std::cmp::Ordering;
     use std::iter::FromIterator;
+
+    #[test]
+    fn decode_rejects_length_amplification() {
+        // Regression: a handful of bytes must not be able to declare a huge entry count and
+        // trigger an eager multi-hundred-MB allocation (allocation bomb / DoS). `try_reserve`
+        // turns the oversized reservation into a recoverable decode error instead of aborting
+        // the process under a hard memory limit. `[255, 255, 255, 122]` decodes as a var-int
+        // length of ~250M entries with no backing data.
+        let adversarial = [255u8, 255, 255, 122];
+        let result = StateVector::decode_v1(&adversarial);
+        assert!(
+            result.is_err(),
+            "an oversized state vector length must be rejected, not eagerly allocated"
+        );
+    }
 
     #[test]
     fn ordering() {

--- a/yrs/src/sync/awareness.rs
+++ b/yrs/src/sync/awareness.rs
@@ -557,7 +557,10 @@ impl Encode for AwarenessUpdate {
 impl Decode for AwarenessUpdate {
     fn decode<D: Decoder>(decoder: &mut D) -> Result<Self, crate::encoding::read::Error> {
         let len: usize = decoder.read_var()?;
-        let mut clients = HashMap::with_capacity(len);
+        // `len` is attacker-controlled (awareness updates arrive over the network); a fallible
+        // reservation avoids an allocation bomb (see `Update::decode`'s `try_reserve`).
+        let mut clients = HashMap::new();
+        clients.try_reserve(len)?;
         for _ in 0..len {
             let client_id = ClientID::new(decoder.read_var::<u64>()?);
             let clock: u32 = decoder.read_var()?;
@@ -665,9 +668,23 @@ mod test {
     use std::sync::Arc;
 
     use crate::block::ClientID;
-    use crate::sync::awareness::{AwarenessUpdateSummary, Event};
+    use crate::sync::awareness::{AwarenessUpdate, AwarenessUpdateSummary, Event};
     use crate::sync::Awareness;
+    use crate::updates::decoder::Decode;
     use crate::Doc;
+
+    #[test]
+    fn decode_rejects_length_amplification() {
+        // Regression: an awareness update arrives over the network; a length prefix declaring a
+        // huge client count (a few bytes) must not trigger an eager multi-hundred-MB allocation.
+        // `try_reserve` turns it into a recoverable decode error instead of an abort under a hard
+        // memory limit. Bytes: var-int len ~250M (0xFF 0xFF 0xFF 0x7A) + no data.
+        let adversarial = [0xFFu8, 0xFF, 0xFF, 0x7A];
+        assert!(
+            AwarenessUpdate::decode_v1(&adversarial).is_err(),
+            "an oversized awareness client count must be rejected, not eagerly allocated"
+        );
+    }
 
     #[test]
     fn awareness() {


### PR DESCRIPTION
## Problem

Several `Decode` implementations pre-allocate capacity straight from an **attacker-controlled length prefix** via `with_capacity(len)`:

```rust
let len = decoder.read_var()?;              // untrusted
let mut coll = Collection::with_capacity(len);
```

A handful of bytes can declare a huge count — e.g. `[255, 255, 255, 122]` decodes as a var-int length of ~250M entries — so a malformed **state vector**, **update** (updates carry a delete set), **`Any` value** (map/array content), or **awareness message** triggers an eager multi-hundred-MB reservation with no backing data. Under overcommit (glibc) this is a large virtual reservation that then fails decoding cleanly; **under a hard memory limit (cgroup/container) or an eager allocator it aborts the process** (`handle_alloc_error`) — an allocation-bomb DoS.

`Update::decode` already fixed this class for block/client collections by switching to `try_reserve` in b234ef4e (*"switch from with_capacity to try_reserve in collections"*). These are the remaining length-prefixed decode sites that still use the unbounded `with_capacity`. This PR finishes that migration.

## Change

Four sites feed the existing `Error::NotEnoughMemory(#[from] TryReserveError)` variant via `try_reserve`, exactly mirroring `Update::decode`:

| Site | Decode path | Reachable via |
|---|---|---|
| `state_vector.rs` | `StateVector::decode` | `SyncStep1` / `StateVector::decode_v1` |
| `any.rs` (Map) | `Any::decode` → `Any::Map` | any untrusted `Any` content |
| `any.rs` (Array) | `Any::decode` → `Any::Array` | any untrusted `Any` content |
| `sync/awareness.rs` | `AwarenessUpdate::decode` | awareness/presence network messages |

The fifth site, `id_set.rs` (`IdRanges::decode`, used for the delete sets carried by every update), uses a `SmallVec`, whose `try_reserve` returns smallvec's own `CollectionAllocErr` rather than `std::collections::TryReserveError`; routing it through `?` would require adding a new public variant to the `Error` enum (a breaking change). It grows on push instead — each range consumes real bytes from the decoder, so the allocation is bounded by the actual input length — which keeps the inline buffer for the common small case without widening the error enum. **Happy to instead add a `From<CollectionAllocErr>` conversion and use `try_reserve` here too if you'd prefer symmetry.**

No behavior change for valid input; only the failure mode for malformed length prefixes changes (recoverable decode error instead of an unbounded reservation / abort).

## Tests

A regression test on each path feeds the adversarial length prefix and asserts a decode `Err` rather than an eager allocation:

- `state_vector::test::decode_rejects_length_amplification`
- `id_set::test::decode_rejects_range_length_amplification`
- `any::test::decode_map_rejects_length_amplification`
- `any::test::decode_array_rejects_length_amplification`
- `sync::awareness::test::decode_rejects_length_amplification`

Full `cargo test -p yrs` is green locally (all existing tests + the 5 new ones, 0 failures).

---

*Prepared with AI assistance; reviewed, tested, and verified by the submitter, who takes responsibility for this contribution.*
