### PR TITLE
introduced Number enum to lib0 Any type

### DIFF
--- a/tests-ffi/main.cpp
+++ b/tests-ffi/main.cpp
@@ -2291,11 +2291,11 @@ TEST_CASE("YMap JSON input") {
             REQUIRE_EQ(e->value->tag, Y_JSON_ARR);
             REQUIRE_EQ(e->value->len, 3);
             YOutput *array = youtput_read_json_array(e->value);
-            //NOTE: keep in mind that yrs deserializes numbers to float64 by default. This includes values with
-            //  no fractional numbers up to 53-bit. This is required for Yjs/JavaScript compatibility.
-            REQUIRE_EQ(*youtput_read_float(&array[0]), 1);
-            REQUIRE_EQ(*youtput_read_float(&array[1]), 2);
-            REQUIRE_EQ(*youtput_read_float(&array[2]), 3);
+            //NOTE: keep in mind that yrs deserializes numbers with no fractional part to integers,
+            //  just like it does when decoding them from an update.
+            REQUIRE_EQ(*youtput_read_long(&array[0]), 1);
+            REQUIRE_EQ(*youtput_read_long(&array[1]), 2);
+            REQUIRE_EQ(*youtput_read_long(&array[2]), 3);
         } else if (strcmp(e->key, "map") == 0) {
             REQUIRE_EQ(e->value->tag, Y_JSON_MAP);
             YMapEntry *map = youtput_read_json_map(e->value);
@@ -2341,11 +2341,11 @@ TEST_CASE("YArray JSON input") {
             REQUIRE_EQ(e->value->tag, Y_JSON_ARR);
             REQUIRE_EQ(e->value->len, 3);
             YOutput *array = youtput_read_json_array(e->value);
-            //NOTE: keep in mind that yrs deserializes numbers to float64 by default. This includes values with
-            //  no fractional numbers up to 53-bit. This is required for Yjs/JavaScript compatibility.
-            REQUIRE_EQ(*youtput_read_float(&array[0]), 1);
-            REQUIRE_EQ(*youtput_read_float(&array[1]), 2);
-            REQUIRE_EQ(*youtput_read_float(&array[2]), 3);
+            //NOTE: keep in mind that yrs deserializes numbers with no fractional part to integers,
+            //  just like it does when decoding them from an update.
+            REQUIRE_EQ(*youtput_read_long(&array[0]), 1);
+            REQUIRE_EQ(*youtput_read_long(&array[1]), 2);
+            REQUIRE_EQ(*youtput_read_long(&array[2]), 3);
         } else if (strcmp(e->key, "map") == 0) {
             REQUIRE_EQ(e->value->tag, Y_JSON_MAP);
             YMapEntry *map = youtput_read_json_map(e->value);

--- a/tests-wasm/package-lock.json
+++ b/tests-wasm/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../ywasm/pkg": {
       "name": "ywasm",
-      "version": "0.27.2",
+      "version": "0.27.3",
       "license": "MIT"
     },
     "node_modules/isomorphic.js": {

--- a/yffi/src/lib.rs
+++ b/yffi/src/lib.rs
@@ -25,7 +25,8 @@ use yrs::updates::decoder::{Decode, DecoderV1};
 use yrs::updates::encoder::{Encode, Encoder, EncoderV1, EncoderV2};
 use yrs::{
     uuid_v4, Any, Array, ArrayRef, Assoc, BranchID, GetString, IdSet, JsonPath, JsonPathEval, Map,
-    MapRef, Observable, OffsetKind, Options, Origin, Out, Quotable, ReadTxn, Snapshot, StateVector,
+    MapRef, Number, Observable, OffsetKind, Options, Origin, Out, Quotable, ReadTxn, Snapshot,
+    StateVector,
     StickyIndex, Store, SubdocsEvent, SubdocsEventIter, Text, TextRef, Transact,
     TransactionCleanupEvent, Update, Xml, XmlElementPrelim, XmlElementRef, XmlFragmentRef,
     XmlTextPrelim, XmlTextRef, ID,
@@ -2728,8 +2729,8 @@ impl YInput {
                 }
                 Y_JSON_NULL => Any::Null,
                 Y_JSON_UNDEF => Any::Undefined,
-                Y_JSON_INT => Any::BigInt(self.value.integer),
-                Y_JSON_NUM => Any::Number(self.value.num),
+                Y_JSON_INT => Any::Number(Number::Int(self.value.integer)),
+                Y_JSON_NUM => Any::Number(Number::Float(self.value.num)),
                 Y_JSON_BOOL => Any::Bool(if self.value.flag == 0 { false } else { true }),
                 Y_JSON_BUF => Any::from(std::slice::from_raw_parts(
                     self.value.buf as *mut u8,
@@ -3070,6 +3071,16 @@ impl From<f64> for YOutput {
     }
 }
 
+impl From<Number> for YOutput {
+    #[inline]
+    fn from(value: Number) -> Self {
+        match value {
+            Number::Int(value) => YOutput::from(value),
+            Number::Float(value) => YOutput::from(value),
+        }
+    }
+}
+
 impl From<i64> for YOutput {
     #[inline]
     fn from(value: i64) -> Self {
@@ -3150,7 +3161,6 @@ impl<'a> From<&'a Any> for YOutput {
                 Any::Undefined => YOutput::undefined(),
                 Any::Bool(v) => YOutput::from(*v),
                 Any::Number(v) => YOutput::from(*v),
-                Any::BigInt(v) => YOutput::from(*v),
                 Any::String(v) => YOutput::from(v.as_ref()),
                 Any::Buffer(v) => YOutput::from(v.as_ref()),
                 Any::Array(v) => YOutput::from(v.as_ref()),
@@ -3168,7 +3178,6 @@ impl From<Any> for YOutput {
                 Any::Undefined => YOutput::undefined(),
                 Any::Bool(v) => YOutput::from(v),
                 Any::Number(v) => YOutput::from(v),
-                Any::BigInt(v) => YOutput::from(v),
                 Any::String(v) => YOutput::from(v.as_ref()),
                 Any::Buffer(v) => YOutput::from(v.as_ref()),
                 Any::Array(v) => YOutput::from(v.as_ref()),

--- a/yrs/src/any.rs
+++ b/yrs/src/any.rs
@@ -143,37 +143,36 @@ impl Any {
             }
             Any::Number(num) => {
                 match *num {
-                    Number::Int(n)
-                        if n >= Number::I64_MIN_SAFE_INTEGER
-                            && n <= Number::I64_MAX_SAFE_INTEGER =>
-                    {
-                        // TYPE 125: INTEGER
-                        encoder.write_u8(125);
-                        encoder.write_var(n)
-                    }
                     Number::Int(n) => {
-                        // TYPE 122: BigInt
-                        encoder.write_u8(122);
-                        encoder.write_i64(n)
-                    }
-                    Number::Float(n)
-                        if n.trunc() == n
-                            && n >= Number::F64_MIN_SAFE_INTEGER
-                            && n <= Number::F64_MAX_SAFE_INTEGER =>
-                    {
-                        // TYPE 125: INTEGER
-                        encoder.write_u8(125);
-                        encoder.write_var(n as i64)
-                    }
-                    Number::Float(n) if (n as f32) as f64 == n => {
-                        // TYPE 124: FLOAT32
-                        encoder.write_u8(124);
-                        encoder.write_f32(n as f32)
+                        // ensure max compatibility with yjs lib0 number encoding
+                        if n >= -0x7FFFFFFF && n <= 0x7FFFFFFF {
+                            // TYPE 125: INTEGER
+                            encoder.write_u8(125);
+                            encoder.write_var(n)
+                        } else if (n as f32) as i64 == n {
+                            // TYPE 124: FLOAT32
+                            encoder.write_u8(124);
+                            encoder.write_f32(n as f32)
+                        } else if (n as f64) as i64 == n {
+                            // TYPE 123: FLOAT64
+                            encoder.write_u8(123);
+                            encoder.write_f64(n as f64)
+                        } else {
+                            // TYPE 122: BigInt
+                            encoder.write_u8(122);
+                            encoder.write_i64(n)
+                        }
                     }
                     Number::Float(n) => {
-                        // TYPE 123: FLOAT64
-                        encoder.write_u8(123);
-                        encoder.write_f64(n)
+                        if (n as f32) as f64 == n {
+                            // TYPE 124: FLOAT32
+                            encoder.write_u8(124);
+                            encoder.write_f32(n as f32)
+                        } else {
+                            // TYPE 123: FLOAT64
+                            encoder.write_u8(123);
+                            encoder.write_f64(n)
+                        }
                     }
                 }
             }
@@ -395,6 +394,16 @@ impl<'de> Deserialize<'de> for Number {
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 write!(formatter, "number")
+            }
+
+            fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v > (i64::MAX as u64) {
+                    return Err(E::custom("integer outside of bounds of i64"));
+                }
+                Ok(Number::Int(v as i64))
             }
 
             fn visit_i64<E>(self, value: i64) -> Result<Number, E> {
@@ -1019,6 +1028,7 @@ macro_rules! any_expect_expr_comma {
 mod test {
     use crate::any::Any;
     use crate::encoding::read::Cursor;
+    use crate::Number;
 
     #[test]
     fn decode_map_rejects_length_amplification() {
@@ -1043,5 +1053,32 @@ mod test {
             Any::decode(&mut cursor).is_err(),
             "an oversized Any::Array length must be rejected, not eagerly allocated"
         );
+    }
+
+    fn hex(n: Number) -> String {
+        let mut buf = Vec::new();
+        Any::Number(n).encode(&mut buf);
+        buf.iter().map(|b| format!("{:02x}", b)).collect()
+    }
+
+    #[test]
+    fn number_encoding_yjs_compat() {
+        assert_eq!(hex(Number::Int(0)), "7d00");
+        assert_eq!(hex(Number::Int(42)), "7d2a");
+        assert_eq!(hex(Number::Int(-42)), "7d6a");
+        assert_eq!(hex(Number::Int(2147483647)), "7dbfffffff0f");
+        // above 2^31 lib0 stops using the var int tag, even for whole numbers
+        assert_eq!(hex(Number::Int(2147483648)), "7c4f000000");
+        assert_eq!(hex(Number::Int(-2147483648)), "7ccf000000");
+        assert_eq!(hex(Number::Int(4294967295)), "7b41efffffffe00000");
+        assert_eq!(hex(Number::Int(9007199254740991)), "7b433fffffffffffff");
+        assert_eq!(hex(Number::Float(1.5)), "7c3fc00000");
+        assert_eq!(hex(Number::Float(1.1)), "7b3ff199999999999a");
+        assert_eq!(hex(Number::Float(2147483648.0)), "7c4f000000");
+        assert_eq!(hex(Number::Float(5e9)), "7c4f9502f9");
+        assert_eq!(hex(Number::Float(1e30)), "7b46293e5939a08cea");
+        assert_eq!(hex(Number::Float(f64::NAN)), "7b7ff8000000000000");
+        assert_eq!(hex(Number::Float(f64::INFINITY)), "7c7f800000");
+        assert_eq!(hex(Number::Float(f64::NEG_INFINITY)), "7cff800000");
     }
 }

--- a/yrs/src/any.rs
+++ b/yrs/src/any.rs
@@ -1,8 +1,11 @@
 use crate::encoding::read::{Error, Read};
 use crate::encoding::write::Write;
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::PartialEq;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::Formatter;
 use std::sync::Arc;
 
 pub const F64_MAX_SAFE_INTEGER: f64 = (i64::pow(2, 53) - 1) as f64;
@@ -15,8 +18,7 @@ pub enum Any {
     Null,
     Undefined,
     Bool(bool),
-    Number(f64),
-    BigInt(i64),
+    Number(Number),
     String(Arc<str>),
     Buffer(Arc<[u8]>),
     Array(Arc<[Any]>),
@@ -41,13 +43,13 @@ impl Any {
             // CASE 126: null
             126 => Any::Null,
             // CASE 125: integer
-            125 => Any::Number(decoder.read_var::<i64>()? as f64),
+            125 => Any::Number(Number::Int(decoder.read_var::<i64>()?)),
             // CASE 124: float32
-            124 => Any::Number(decoder.read_f32()? as f64),
+            124 => Any::Number(Number::Float(decoder.read_f32()? as f64)),
             // CASE 123: float64
-            123 => Any::Number(decoder.read_f64()?),
+            123 => Any::Number(Number::Float(decoder.read_f64()?)),
             // CASE 122: bigint
-            122 => Any::BigInt(decoder.read_i64()?),
+            122 => Any::Number(Number::Int(decoder.read_i64()?)),
             // CASE 121: boolean (false)
             121 => Any::Bool(false),
             // CASE 120: boolean (true)
@@ -140,28 +142,40 @@ impl Any {
                 encoder.write_string(&str)
             }
             Any::Number(num) => {
-                let num_truncated = num.trunc();
-                if num_truncated == *num
-                    && num_truncated <= F64_MAX_SAFE_INTEGER
-                    && num_truncated >= F64_MIN_SAFE_INTEGER
-                {
-                    // TYPE 125: INTEGER
-                    encoder.write_u8(125);
-                    encoder.write_var(num_truncated as i64)
-                } else if ((*num as f32) as f64) == *num {
-                    // TYPE 124: FLOAT32
-                    encoder.write_u8(124);
-                    encoder.write_f32(*num as f32)
-                } else {
-                    // TYPE 123: FLOAT64
-                    encoder.write_u8(123);
-                    encoder.write_f64(*num)
+                match *num {
+                    Number::Int(n)
+                        if n >= Number::I64_MIN_SAFE_INTEGER
+                            && n <= Number::I64_MAX_SAFE_INTEGER =>
+                    {
+                        // TYPE 125: INTEGER
+                        encoder.write_u8(125);
+                        encoder.write_var(n)
+                    }
+                    Number::Int(n) => {
+                        // TYPE 122: BigInt
+                        encoder.write_u8(122);
+                        encoder.write_i64(n)
+                    }
+                    Number::Float(n)
+                        if n.trunc() == n
+                            && n >= Number::F64_MIN_SAFE_INTEGER
+                            && n <= Number::F64_MAX_SAFE_INTEGER =>
+                    {
+                        // TYPE 125: INTEGER
+                        encoder.write_u8(125);
+                        encoder.write_var(n as i64)
+                    }
+                    Number::Float(n) if (n as f32) as f64 == n => {
+                        // TYPE 124: FLOAT32
+                        encoder.write_u8(124);
+                        encoder.write_f32(n as f32)
+                    }
+                    Number::Float(n) => {
+                        // TYPE 123: FLOAT64
+                        encoder.write_u8(123);
+                        encoder.write_f64(n)
+                    }
                 }
-            }
-            Any::BigInt(num) => {
-                // TYPE 122: BigInt
-                encoder.write_u8(122);
-                encoder.write_i64(*num)
             }
             Any::Array(arr) => {
                 // TYPE 117: Array
@@ -228,7 +242,6 @@ impl std::fmt::Display for Any {
             Any::Undefined => f.write_str("undefined"),
             Any::Bool(value) => write!(f, "{}", value),
             Any::Number(value) => write!(f, "{}", value),
-            Any::BigInt(value) => write!(f, "{}", value),
             Any::String(value) => f.write_str(value.as_ref()),
             Any::Array(values) => {
                 write!(f, "[")?;
@@ -260,6 +273,155 @@ impl std::fmt::Display for Any {
                 }
                 Ok(())
             }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Number {
+    Int(i64),
+    Float(f64),
+}
+
+impl Number {
+    pub const I64_MAX_SAFE_INTEGER: i64 = i64::pow(2, 53) - 1;
+    pub const I64_MIN_SAFE_INTEGER: i64 = -Self::I64_MAX_SAFE_INTEGER;
+    pub const F64_MAX_SAFE_INTEGER: f64 = Self::I64_MAX_SAFE_INTEGER as f64;
+    pub const F64_MIN_SAFE_INTEGER: f64 = -Self::F64_MAX_SAFE_INTEGER;
+
+    pub fn from_safe(value: f64) -> Self {
+        if value >= Self::F64_MIN_SAFE_INTEGER && value <= Self::F64_MAX_SAFE_INTEGER {
+            Number::Int(value as i64)
+        } else {
+            Number::Float(value)
+        }
+    }
+
+    pub fn as_i64(self) -> Option<i64> {
+        match self {
+            Number::Int(value) => Some(value),
+            Number::Float(value) => {
+                // check if conversion is lossless
+                let converted = value as i64;
+                if converted as f64 == value {
+                    Some(converted)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    pub fn as_f64(self) -> Option<f64> {
+        match self {
+            Number::Int(value) => {
+                if (Self::I64_MIN_SAFE_INTEGER..=Self::I64_MAX_SAFE_INTEGER).contains(&value) {
+                    Some(value as f64)
+                } else {
+                    None
+                }
+            }
+            Number::Float(value) => Some(value),
+        }
+    }
+}
+
+impl PartialEq for Number {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Number::Int(a), Number::Int(b)) => a == b,
+            (Number::Float(a), Number::Float(b)) => a == b,
+            _ => match (self.as_f64(), other.as_f64()) {
+                (Some(a), Some(b)) => a == b,
+                _ => false,
+            },
+        }
+    }
+}
+
+impl From<f64> for Number {
+    #[inline]
+    fn from(value: f64) -> Self {
+        Number::Float(value)
+    }
+}
+
+impl From<i64> for Number {
+    #[inline]
+    fn from(value: i64) -> Self {
+        Number::Int(value)
+    }
+}
+
+impl TryFrom<u64> for Number {
+    type Error = u64;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if value <= i64::MAX as u64 {
+            Ok(Number::Int(value as i64))
+        } else {
+            Err(value)
+        }
+    }
+}
+
+impl Serialize for Number {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::Error;
+        match self.as_f64() {
+            Some(v) => serializer.serialize_f64(v),
+            None => match self.as_i64() {
+                Some(v) => serializer.serialize_i64(v),
+                None => Err(S::Error::custom("cannot serialize number")),
+            },
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Number {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NumberVisitor;
+        impl<'de> Visitor<'de> for NumberVisitor {
+            type Value = Number;
+
+            fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                write!(formatter, "number")
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Number, E> {
+                Ok(Number::Int(value))
+            }
+
+            fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if v <= Number::F64_MAX_SAFE_INTEGER
+                    && v > Number::F64_MIN_SAFE_INTEGER
+                    && v.trunc() == v
+                {
+                    Ok(Number::Int(v as i64))
+                } else {
+                    Ok(Number::Float(v))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(NumberVisitor)
+    }
+}
+
+impl std::fmt::Display for Number {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Number::Int(value) => write!(f, "{}", value),
+            Number::Float(value) => write!(f, "{}", value),
         }
     }
 }
@@ -347,12 +509,12 @@ impl Iterator for AnyIntoIter {
     }
 }
 
-macro_rules! impl_from_num {
+macro_rules! impl_from_float {
     ($t:ty) => {
         impl From<$t> for Any {
             #[inline]
             fn from(v: $t) -> Self {
-                Self::Number(v as f64)
+                Self::Number(Number::Float(v as f64))
             }
         }
 
@@ -361,24 +523,21 @@ macro_rules! impl_from_num {
 
             fn try_from(v: Any) -> Result<Self, Self::Error> {
                 match v {
-                    Any::Number(num) => Ok(num as Self),
-                    Any::BigInt(num) => Ok(num as Self),
+                    Any::Number(num) => match num.as_f64() {
+                        Some(n) => Ok(n as Self),
+                        None => Err(v),
+                    },
                     other => Err(other),
                 }
             }
         }
     };
 }
-macro_rules! impl_from_bigint {
+macro_rules! impl_from_int {
     ($t:ty) => {
         impl From<$t> for Any {
             fn from(value: $t) -> Self {
-                let v = value as f64;
-                if v <= F64_MAX_SAFE_INTEGER && v >= F64_MIN_SAFE_INTEGER {
-                    Self::Number(v)
-                } else {
-                    Self::BigInt(value as i64)
-                }
+                Any::Number(Number::from(value as i64))
             }
         }
 
@@ -387,8 +546,10 @@ macro_rules! impl_from_bigint {
 
             fn try_from(v: Any) -> Result<Self, Self::Error> {
                 match v {
-                    Any::Number(num) => Ok(num as Self),
-                    Any::BigInt(num) => Ok(num as Self),
+                    Any::Number(num) => match num.as_i64() {
+                        Some(n) => Ok(n as Self),
+                        None => Err(v),
+                    },
                     other => Err(other),
                 }
             }
@@ -396,29 +557,20 @@ macro_rules! impl_from_bigint {
     };
 }
 
-impl_from_num!(f32);
-impl_from_num!(f64);
-impl_from_num!(i16);
-impl_from_num!(i32);
-impl_from_num!(u16);
-impl_from_num!(u32);
-impl_from_bigint!(i64);
-impl_from_bigint!(isize);
+impl_from_float!(f32);
+impl_from_float!(f64);
+impl_from_int!(i16);
+impl_from_int!(i32);
+impl_from_int!(u16);
+impl_from_int!(u32);
+impl_from_int!(i64);
+impl_from_int!(isize);
 
 impl TryFrom<u64> for Any {
     type Error = u64;
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        if value > i64::MAX.abs() as u64 {
-            Err(value)
-        } else {
-            let v = value as f64;
-            if v <= F64_MAX_SAFE_INTEGER && v >= F64_MIN_SAFE_INTEGER {
-                Ok(Any::Number(v))
-            } else {
-                Ok(Any::BigInt(v as i64))
-            }
-        }
+        Ok(Any::Number(Number::try_from(value)?))
     }
 }
 
@@ -427,8 +579,10 @@ impl TryFrom<Any> for u64 {
 
     fn try_from(v: Any) -> Result<Self, Self::Error> {
         match v {
-            Any::Number(num) => Ok(num as Self),
-            Any::BigInt(num) => Ok(num as Self),
+            Any::Number(num) => match num.as_i64() {
+                Some(n) if n >= 0 => Ok(n as u64),
+                _ => Err(Any::Number(num)),
+            },
             other => Err(other),
         }
     }
@@ -442,7 +596,7 @@ impl TryFrom<usize> for Any {
         // for 32-bit architectures we know that usize will always fit,
         // so there's no need to check for length, but we stick to TryInto
         // trait to keep API compatibility
-        Ok(Any::Number(value as f64))
+        Ok(Any::Number(Number::Int(value as i64)))
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -461,8 +615,10 @@ impl TryFrom<Any> for usize {
 
     fn try_from(v: Any) -> Result<Self, Self::Error> {
         match v {
-            Any::Number(num) => Ok(num as Self),
-            Any::BigInt(num) => Ok(num as Self),
+            Any::Number(num) => match num.as_i64() {
+                Some(n) if n >= 0 => Ok(n as usize),
+                _ => Err(v),
+            },
             other => Err(other),
         }
     }

--- a/yrs/src/any.rs
+++ b/yrs/src/any.rs
@@ -317,8 +317,9 @@ impl Number {
     pub fn as_f64(self) -> Option<f64> {
         match self {
             Number::Int(value) => {
-                if (Self::I64_MIN_SAFE_INTEGER..=Self::I64_MAX_SAFE_INTEGER).contains(&value) {
-                    Some(value as f64)
+                let n = value as f64;
+                if n as i64 == value {
+                    Some(n)
                 } else {
                     None
                 }

--- a/yrs/src/any.rs
+++ b/yrs/src/any.rs
@@ -289,8 +289,11 @@ impl Number {
     pub const F64_MAX_SAFE_INTEGER: f64 = Self::I64_MAX_SAFE_INTEGER as f64;
     pub const F64_MIN_SAFE_INTEGER: f64 = -Self::F64_MAX_SAFE_INTEGER;
 
-    pub fn from_safe(value: f64) -> Self {
-        if value >= Self::F64_MIN_SAFE_INTEGER && value <= Self::F64_MAX_SAFE_INTEGER {
+    pub fn try_i64(value: f64) -> Self {
+        if value.trunc() == value
+            && value >= Self::F64_MIN_SAFE_INTEGER
+            && value <= Self::F64_MAX_SAFE_INTEGER
+        {
             Number::Int(value as i64)
         } else {
             Number::Float(value)

--- a/yrs/src/doc.rs
+++ b/yrs/src/doc.rs
@@ -9,7 +9,7 @@ use crate::updates::decoder::{Decode, Decoder};
 use crate::updates::encoder::{Encode, Encoder};
 use crate::utils::OptionExt;
 use crate::{
-    uuid_v4, uuid_v4_from, ArrayRef, BranchID, MapRef, Out, ReadTxn, TextRef, Transact,
+    uuid_v4, uuid_v4_from, ArrayRef, BranchID, MapRef, Number, Out, ReadTxn, TextRef, Transact,
     TransactionAcqError, Uuid, WriteTxn, XmlFragmentRef,
 };
 use crate::{Any, Subscription};
@@ -588,7 +588,7 @@ impl Options {
             OffsetKind::Bytes => 1,
             OffsetKind::Utf16 => 0, // 0 for compatibility with Yjs, which doesn't have this option
         };
-        m.insert("encoding".to_owned(), Any::BigInt(encoding));
+        m.insert("encoding".to_owned(), Any::from(encoding));
         m.insert("autoLoad".to_owned(), self.auto_load.into());
         m.insert("shouldLoad".to_owned(), self.should_load.into());
         Any::from(m)
@@ -625,7 +625,9 @@ impl Decode for Options {
                     ("gc", Any::Bool(gc)) => options.skip_gc = !*gc,
                     ("autoLoad", Any::Bool(auto_load)) => options.auto_load = *auto_load,
                     ("collectionId", Any::String(cid)) => options.collection_id = Some(cid.clone()),
-                    ("encoding", Any::BigInt(1)) => options.offset_kind = OffsetKind::Bytes,
+                    ("encoding", Any::Number(Number::Int(1))) => {
+                        options.offset_kind = OffsetKind::Bytes
+                    }
                     ("encoding", _) => options.offset_kind = OffsetKind::Utf16,
                     _ => { /* do nothing */ }
                 }

--- a/yrs/src/encoding/serde/de.rs
+++ b/yrs/src/encoding/serde/de.rs
@@ -1,4 +1,4 @@
-use crate::any::Any;
+use crate::any::{Any, Number};
 use crate::encoding::read::Error;
 use serde::de::value::{MapAccessDeserializer, MapDeserializer, SeqDeserializer};
 use serde::de::{IntoDeserializer, MapAccess, SeqAccess, Visitor};
@@ -38,7 +38,7 @@ impl<'de> Deserialize<'de> for Any {
             where
                 E: serde::de::Error,
             {
-                Ok(Any::Number(v as f64))
+                Ok(Any::Number(Number::Int(v as i64)))
             }
 
             fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
@@ -66,7 +66,7 @@ impl<'de> Deserialize<'de> for Any {
             where
                 E: serde::de::Error,
             {
-                Ok(Any::Number(v as f64))
+                Ok(Any::Number(Number::Int(v as i64)))
             }
 
             fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
@@ -242,8 +242,8 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
             Any::Null => self.deserialize_unit(visitor),
             Any::Undefined => self.deserialize_unit(visitor),
             Any::Bool(_) => self.deserialize_bool(visitor),
-            Any::Number(_) => self.deserialize_f64(visitor),
-            Any::BigInt(_) => self.deserialize_i64(visitor),
+            Any::Number(Number::Float(_)) => self.deserialize_f64(visitor),
+            Any::Number(Number::Int(_)) => self.deserialize_i64(visitor),
             Any::String(_) => self.deserialize_string(visitor),
             Any::Buffer(_) => self.deserialize_byte_buf(visitor),
             Any::Array(_) => self.deserialize_seq(visitor),
@@ -266,14 +266,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<i8>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<i8>()),
+            },
             _ => return Err(Error::type_mismatch::<i8>()),
         }
         .try_into()
@@ -286,14 +282,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<i16>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<i16>()),
+            },
             _ => return Err(Error::type_mismatch::<i16>()),
         }
         .try_into()
@@ -306,14 +298,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<i32>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<i32>()),
+            },
             _ => return Err(Error::type_mismatch::<i32>()),
         }
         .try_into()
@@ -326,14 +314,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<i64>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<i64>()),
+            },
             _ => return Err(Error::type_mismatch::<i64>()),
         };
         visitor.visit_i64(value)
@@ -344,14 +328,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<u8>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<u8>()),
+            },
             _ => return Err(Error::type_mismatch::<u8>()),
         }
         .try_into()
@@ -364,14 +344,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<u16>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<u16>()),
+            },
             _ => return Err(Error::type_mismatch::<u16>()),
         }
         .try_into()
@@ -384,14 +360,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<u32>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<u32>()),
+            },
             _ => return Err(Error::type_mismatch::<u32>()),
         }
         .try_into()
@@ -404,14 +376,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         let value = match self.value {
-            Any::Number(i) => {
-                if i.fract() == 0.0 {
-                    *i as i64
-                } else {
-                    return Err(Error::type_mismatch::<u64>());
-                }
-            }
-            Any::BigInt(i) => *i,
+            Any::Number(i) => match i.as_i64() {
+                Some(i) => i,
+                None => return Err(Error::type_mismatch::<u64>()),
+            },
             _ => return Err(Error::type_mismatch::<u64>()),
         }
         .try_into()
@@ -424,8 +392,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         match self.value {
-            Any::Number(f) => visitor.visit_f32(*f as f32),
-            Any::BigInt(f) => visitor.visit_f32(*f as f32),
+            Any::Number(f) => match f.as_f64() {
+                Some(f) => visitor.visit_f32(f as f32),
+                None => Err(Error::type_mismatch::<f32>()),
+            },
             _ => Err(Error::type_mismatch::<f32>()),
         }
     }
@@ -435,8 +405,10 @@ impl<'de> Deserializer<'de> for AnyDeserializer<'de> {
         V: Visitor<'de>,
     {
         match self.value {
-            Any::Number(f) => visitor.visit_f64(*f),
-            Any::BigInt(f) => visitor.visit_f64(*f as f64),
+            Any::Number(f) => match f.as_f64() {
+                Some(f) => visitor.visit_f64(f),
+                None => Err(Error::type_mismatch::<f64>()),
+            },
             _ => Err(Error::type_mismatch::<f64>()),
         }
     }
@@ -881,7 +853,7 @@ mod test {
             test: i8,
         }
 
-        let any: Any = HashMap::from([("test".to_string(), Any::BigInt(1000))]).into();
+        let any: Any = HashMap::from([("test".to_string(), Any::Number(Number::Int(1000)))]).into();
 
         assert!(matches!(
             from_any::<Test>(&any).unwrap_err(),
@@ -896,7 +868,7 @@ mod test {
             test: i8,
         }
 
-        let any: Any = HashMap::from([("test".to_string(), Any::Number(1000.1f64))]).into();
+        let any: Any = HashMap::from([("test".to_string(), Any::Number(Number::Float(1000.1)))]).into();
 
         let error = from_any::<Test>(&any).unwrap_err();
         match error {

--- a/yrs/src/encoding/serde/mod.rs
+++ b/yrs/src/encoding/serde/mod.rs
@@ -8,7 +8,7 @@ pub use ser::to_any;
 mod test {
     use super::*;
     use crate::any;
-    use crate::any::Any;
+    use crate::any::{Any, Number};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
     use std::collections::HashMap;
@@ -40,7 +40,7 @@ mod test {
     #[test]
     fn json_any_number() {
         for v in [1.8, -1.5, 0.2, 0.25, 2349464814556456.4] {
-            let expected = Any::Number(v);
+            let expected = Any::from(v);
             let actual = roundtrip(&expected);
             assert_eq!(actual, expected);
         }
@@ -58,7 +58,7 @@ mod test {
     #[test]
     fn json_any_array() {
         let expected = Any::from(vec![
-            Any::Number(-10.0),
+            Any::Number(Number::Int(-10)),
             Any::String("hello \\world".into()),
             Any::Null,
             Any::Bool(true),
@@ -70,14 +70,14 @@ mod test {
     #[test]
     fn json_any_map() {
         let expected = Any::from(HashMap::from([
-            ("a".to_string(), Any::Number(-10.2)),
+            ("a".to_string(), Any::from(-10.2)),
             ("b".to_string(), Any::String("hello world".into())),
             ("c".to_string(), Any::Null),
             ("d".to_string(), Any::Bool(true)),
             ("e".to_string(), Any::from(vec![Any::String("abc".into())])),
             (
                 "f".to_string(),
-                Any::from(HashMap::from([("fa".to_string(), Any::Number(1.5))])),
+                Any::from(HashMap::from([("fa".to_string(), Any::from(1.5))])),
             ),
         ]));
         let actual = roundtrip(&expected);

--- a/yrs/src/encoding/serde/ser.rs
+++ b/yrs/src/encoding/serde/ser.rs
@@ -1,4 +1,4 @@
-use crate::any::Any;
+use crate::any::{Any, Number};
 use serde::ser::{
     SerializeMap, SerializeSeq, SerializeStruct, SerializeStructVariant, SerializeTuple,
     SerializeTupleStruct, SerializeTupleVariant,
@@ -23,16 +23,16 @@ impl Serialize for Any {
             Any::Undefined => serializer.serialize_none(),
             Any::Bool(value) => serializer.serialize_bool(*value),
             Any::Number(value) => {
-                let value = *value;
                 // since JS doesn't clearly recognise difference between integers and floats,
                 // we check if it's possible to perform lossless conversion to i64
-                if value as i64 as f64 == value {
-                    serializer.serialize_i64(value as i64)
-                } else {
-                    serializer.serialize_f64(value)
+                match value.as_i64() {
+                    Some(n) => serializer.serialize_i64(n),
+                    None => match value.as_f64() {
+                        Some(n) => serializer.serialize_f64(n),
+                        None => Err(serde::ser::Error::custom("cannot serialize number")),
+                    },
                 }
             }
-            Any::BigInt(value) => serializer.serialize_i64(*value),
             Any::String(value) => serializer.serialize_str(value.as_ref()),
             Any::Array(values) => {
                 let mut seq = serializer.serialize_seq(Some(values.len()))?;
@@ -141,7 +141,7 @@ impl Serializer for AnySerializer {
 
     #[inline]
     fn serialize_f64(self, v: f64) -> Result<Self::Ok, Self::Error> {
-        Ok(Any::Number(v))
+        Ok(Any::Number(Number::Float(v)))
     }
 
     #[inline]
@@ -478,14 +478,14 @@ mod test {
     #[test]
     fn test_serialize_any_to_float() {
         assert_eq!(
-            serde_json::to_string(&Any::Number(-1298.283f64)).unwrap(),
+            serde_json::to_string(&Any::from(-1298.283)).unwrap(),
             "-1298.283"
         );
     }
 
     #[test]
     fn test_serialize_any_to_int() {
-        assert_eq!(serde_json::to_string(&Any::BigInt(-1298)).unwrap(), "-1298");
+        assert_eq!(serde_json::to_string(&Any::from(-1298)).unwrap(), "-1298");
     }
 
     #[test]
@@ -672,7 +672,7 @@ mod test {
 
         assert_eq!(
             to_any(&Test(i64::MAX as u64)).unwrap(),
-            Any::BigInt(i64::MAX)
+            Any::Number(Number::Int(i64::MAX))
         )
     }
 

--- a/yrs/src/lib.rs
+++ b/yrs/src/lib.rs
@@ -654,7 +654,7 @@ pub use crate::alt::{
     diff_updates_v1, diff_updates_v2, encode_state_vector_from_update_v1,
     encode_state_vector_from_update_v2, merge_updates_v1, merge_updates_v2,
 };
-pub use crate::any::Any;
+pub use crate::any::{Any, Number};
 pub use crate::block::ClientID;
 pub use crate::block::ID;
 pub use crate::branch::BranchID;

--- a/yrs/src/types/array.rs
+++ b/yrs/src/types/array.rs
@@ -981,7 +981,7 @@ mod test {
             delta.swap(None),
             Some(
                 vec![Change::Added(vec![
-                    Any::Number(4.0).into(),
+                    Any::from(4).into(),
                     Any::String("dtrn".into()).into()
                 ])]
                 .into()
@@ -1013,7 +1013,7 @@ mod test {
             Some(
                 vec![
                     Change::Retain(1),
-                    Change::Added(vec![Any::Number(0.5).into()])
+                    Change::Added(vec![Any::from(0.5).into()])
                 ]
                 .into()
             )
@@ -1049,7 +1049,7 @@ mod test {
             Some(
                 vec![Change::Added(vec![
                     Any::String("dtrn".into()).into(),
-                    Any::Number(0.5).into(),
+                    Any::from(0.5).into(),
                 ])]
                 .into()
             )
@@ -1106,7 +1106,7 @@ mod test {
             let len = rng.between(1, 4);
             let content: Vec<_> = (0..len)
                 .into_iter()
-                .map(|_| Any::BigInt(unique_number))
+                .map(|_| Any::from(unique_number))
                 .collect();
             let mut pos = rng.between(0, yarray.len(&txn)) as usize;
             if let Any::Array(expected) = yarray.to_json(&txn) {
@@ -1129,7 +1129,7 @@ mod test {
             let mut txn = doc.transact_mut();
             let pos = rng.between(0, yarray.len(&txn));
             let array2 = yarray.insert(&mut txn, pos, ArrayPrelim::from([1, 2, 3, 4]));
-            let expected: Arc<[Any]> = (1..=4).map(|i| Any::Number(i as f64)).collect();
+            let expected: Arc<[Any]> = (1..=4).map(Any::from).collect();
             assert_eq!(array2.to_json(&txn), Any::Array(expected));
         }
 

--- a/yrs/src/types/map.rs
+++ b/yrs/src/types/map.rs
@@ -999,7 +999,7 @@ mod test {
             entries.swap(None),
             Some(Arc::new(HashMap::from([(
                 "a".into(),
-                EntryChange::Inserted(Any::Number(1.0).into())
+                EntryChange::Inserted(Any::from(1).into())
             )])))
         );
 
@@ -1012,7 +1012,7 @@ mod test {
             entries.swap(None),
             Some(Arc::new(HashMap::from([(
                 "a".into(),
-                EntryChange::Updated(Any::Number(1.0).into(), Any::Number(2.0).into())
+                EntryChange::Updated(Any::from(1).into(), Any::from(2).into())
             )])))
         );
 
@@ -1026,7 +1026,7 @@ mod test {
             entries.swap(None),
             Some(Arc::new(HashMap::from([(
                 "a".into(),
-                EntryChange::Updated(Any::Number(2.0).into(), Any::Number(4.0).into())
+                EntryChange::Updated(Any::from(2).into(), Any::from(4).into())
             )])))
         );
 
@@ -1039,7 +1039,7 @@ mod test {
             entries.swap(None),
             Some(Arc::new(HashMap::from([(
                 "a".into(),
-                EntryChange::Removed(Any::Number(4.0).into())
+                EntryChange::Removed(Any::from(4).into())
             )])))
         );
 
@@ -1053,7 +1053,7 @@ mod test {
             entries.swap(None),
             Some(Arc::new(HashMap::from([(
                 "b".into(),
-                EntryChange::Inserted(Any::Number(2.0).into())
+                EntryChange::Inserted(Any::from(2).into())
             )])))
         );
 
@@ -1090,7 +1090,7 @@ mod test {
             entries.swap(None),
             Some(Arc::new(HashMap::from([(
                 "b".into(),
-                EntryChange::Inserted(Any::Number(2.0).into())
+                EntryChange::Inserted(Any::from(2).into())
             )])))
         );
     }

--- a/yrs/src/types/text.rs
+++ b/yrs/src/types/text.rs
@@ -2215,7 +2215,7 @@ mod test {
             let mut txn = d1.transact_mut();
             txt1.insert_with_attributes(&mut txn, 0, "ab", a1.clone());
 
-            let a2: Attrs = HashMap::from([("width".into(), Any::Number(100.0))]);
+            let a2: Attrs = HashMap::from([("width".into(), Any::from(100))]);
 
             txt1.insert_embed_with_attributes(&mut txn, 1, embed.clone(), a2.clone());
             drop(txn);
@@ -2244,10 +2244,7 @@ mod test {
         };
 
         let a1 = Some(Box::new(a1));
-        let a2 = Some(Box::new(HashMap::from([(
-            "width".into(),
-            Any::Number(100.0),
-        )])));
+        let a2 = Some(Box::new(HashMap::from([("width".into(), Any::from(100))])));
 
         let expected = vec![
             Diff::new("a".into(), a1.clone()),

--- a/yrs/src/types/xml.rs
+++ b/yrs/src/types/xml.rs
@@ -1611,13 +1611,13 @@ mod test {
         let f = doc.get_or_insert_xml_fragment("test");
         let mut txn = doc.transact_mut();
         let txt = f.push_back(&mut txn, XmlTextPrelim::new(""));
-        txt.insert_attribute(&mut txn, "test", Any::BigInt(42));
+        txt.insert_attribute(&mut txn, "test", Any::from(42));
         txt.insert_attribute(&mut txn, "test_true", true);
         txt.insert_attribute(&mut txn, "test_null", Any::Null);
 
         assert_eq!(
             txt.get_attribute(&txn, "test"),
-            Some(Out::Any(Any::BigInt(42)))
+            Some(Out::Any(Any::from(42)))
         );
         assert_eq!(
             txt.get_attribute(&txn, "test_true"),

--- a/yrs/src/undo.rs
+++ b/yrs/src/undo.rs
@@ -2135,8 +2135,8 @@ mod test {
     #[test]
     fn multi_doc_undo() {
         let mut um = UndoManager::new();
-        let d1 = Doc::new();
-        let d2 = Doc::new();
+        let d1 = Doc::with_client_id(1);
+        let d2 = Doc::with_client_id(2);
         let txt1 = d1.get_or_insert_text("text");
         let txt2 = d2.get_or_insert_text("text");
 

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -33,8 +33,8 @@ use yrs::types::{
     TYPE_REFS_XML_ELEMENT, TYPE_REFS_XML_FRAGMENT, TYPE_REFS_XML_TEXT,
 };
 use yrs::{
-    Any, ArrayRef, BranchID, Doc, Map, MapRef, Origin, Out, Text, TextRef, TransactionMut, WeakRef,
-    Xml, XmlElementRef, XmlFragment, XmlFragmentRef, XmlOut, XmlTextRef,
+    Any, ArrayRef, BranchID, Doc, Map, MapRef, Number, Origin, Out, Text, TextRef, TransactionMut,
+    WeakRef, Xml, XmlElementRef, XmlFragment, XmlFragmentRef, XmlOut, XmlTextRef,
 };
 
 #[repr(transparent)]
@@ -72,8 +72,13 @@ impl Js {
             Any::Null => Js(JsValue::NULL),
             Any::Undefined => Js(JsValue::UNDEFINED),
             Any::Bool(value) => Js(JsValue::from_bool(*value)),
-            Any::Number(value) => Js(JsValue::from_f64(*value)),
-            Any::BigInt(value) => Js(js_sys::BigInt::from(*value).into()),
+            Any::Number(value) => match value.as_f64() {
+                Some(value) => Js(JsValue::from_f64(value)),
+                None => match value.as_i64() {
+                    Some(value) => Js(js_sys::BigInt::from(value).into()),
+                    None => Js(JsValue::UNDEFINED),
+                },
+            },
             Any::String(str) => Js(JsValue::from_str(&*str)),
             Any::Buffer(binary) => Js(Uint8Array::from(binary.as_ref()).into()),
             Any::Array(array) => {
@@ -135,12 +140,12 @@ impl Js {
         } else if self.0.is_undefined() {
             Ok(ValueRef::Any(Any::Undefined))
         } else if let Some(f) = self.0.as_f64() {
-            Ok(ValueRef::Any(Any::Number(f)))
+            Ok(ValueRef::Any(Any::Number(Number::from_safe(f))))
         } else if let Some(b) = self.0.as_bool() {
             Ok(ValueRef::Any(Any::Bool(b)))
         } else if self.0.is_bigint() {
             let i = js_sys::BigInt::from(self.0.clone()).as_f64().unwrap();
-            Ok(ValueRef::Any(Any::BigInt(i as i64)))
+            Ok(ValueRef::Any(Any::Number(Number::Int(i as i64))))
         } else if js_sys::Array::is_array(&self.0) {
             let array = js_sys::Array::from(&self.0);
             let mut result = Vec::with_capacity(array.length() as usize);

--- a/ywasm/src/js.rs
+++ b/ywasm/src/js.rs
@@ -140,7 +140,7 @@ impl Js {
         } else if self.0.is_undefined() {
             Ok(ValueRef::Any(Any::Undefined))
         } else if let Some(f) = self.0.as_f64() {
-            Ok(ValueRef::Any(Any::Number(Number::from_safe(f))))
+            Ok(ValueRef::Any(Any::Number(Number::try_i64(f))))
         } else if let Some(b) = self.0.as_bool() {
             Ok(ValueRef::Any(Any::Bool(b)))
         } else if self.0.is_bigint() {


### PR DESCRIPTION
This PR introduces a new `Number` enum that's used to consolidate `Any::Number` and `Any::BigInt`. The reason is that, in lib0 JavaScript (Yjs) numbers have basically 2 interpretations: floating points and BigInt. This however becomes problematic when we go down to typed languages that have significant integers. It already proved in the past that it can cause issues when it comes to proper encoding/decoding of numbers serialized as `f64` and deserialised as `i64`, which was valid in JavaScript, but problematic in Rust.

For this reason the `Number` primitive is a simplification (similar to number in serde_json), that expects users to explicitly state what type they expect via `Number::as_i64`/`Number::as_f64`. It will handle underlying int<->float conversions for you if they are safe and lossless.